### PR TITLE
feat: migrate all deps from schouhy/full-bedrock-integration to lssa main

### DIFF
--- a/nssa-framework-cli/Cargo.toml
+++ b/nssa-framework-cli/Cargo.toml
@@ -10,9 +10,9 @@ path = "src/bin/main.rs"
 
 [dependencies]
 nssa-framework-core = { path = "../nssa-framework-core" }
-nssa_core = { git = "https://github.com/logos-blockchain/lssa.git", branch = "schouhy/full-bedrock-integration" }
-nssa = { git = "https://github.com/logos-blockchain/lssa.git", branch = "schouhy/full-bedrock-integration" }
-wallet = { git = "https://github.com/logos-blockchain/lssa.git", branch = "schouhy/full-bedrock-integration" }
+nssa_core = { git = "https://github.com/logos-blockchain/lssa.git", branch = "main" }
+nssa = { git = "https://github.com/logos-blockchain/lssa.git", branch = "main" }
+wallet = { git = "https://github.com/logos-blockchain/lssa.git", branch = "main" }
 risc0-zkvm = { version = "3.0.3", features = ["std"] }
 base58 = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/nssa-framework-cli/src/init.rs
+++ b/nssa-framework-cli/src/init.rs
@@ -275,7 +275,7 @@ path = "src/bin/{snake_name}.rs"
 [dependencies]
 nssa-framework = {{ git = "https://github.com/jimmy-claw/nssa-framework.git" }}
 nssa-framework-core = {{ git = "https://github.com/jimmy-claw/nssa-framework.git" }}
-nssa_core = {{ git = "https://github.com/logos-blockchain/lssa.git", branch = "schouhy/full-bedrock-integration" }}
+nssa_core = {{ git = "https://github.com/logos-blockchain/lssa.git", branch = "main" }}
 risc0-zkvm = {{ version = "3.0.3", default-features = false }}
 {snake_name}_core = {{ path = "../../{snake_name}_core" }}
 serde = {{ version = "1.0", features = ["derive"] }}

--- a/nssa-framework-cli/src/tx.rs
+++ b/nssa-framework-cli/src/tx.rs
@@ -227,7 +227,7 @@ pub async fn execute_instruction(
     };
 
     let signing_keys: Vec<_> = signer_accounts.iter().map(|id| {
-        wallet_core.storage().user_data.get_pub_account_signing_key(id).unwrap_or_else(|| {
+        wallet_core.storage().user_data.get_pub_account_signing_key(*id).unwrap_or_else(|| {
             eprintln!("❌ Signing key not found for account {}", id);
             process::exit(1);
         })

--- a/nssa-framework-core/Cargo.toml
+++ b/nssa-framework-core/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Core types for the NSSA/LEZ program framework"
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/lssa.git", branch = "schouhy/full-bedrock-integration", features = ["host"] }
+nssa_core = { git = "https://github.com/logos-blockchain/lssa.git", branch = "main", features = ["host"] }
 borsh = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/nssa-framework/Cargo.toml
+++ b/nssa-framework/Cargo.toml
@@ -7,5 +7,5 @@ description = "Developer framework for building NSSA/LEZ programs (like Anchor f
 [dependencies]
 nssa-framework-core = { path = "../nssa-framework-core" }
 nssa-framework-macros = { path = "../nssa-framework-macros" }
-nssa_core = { git = "https://github.com/logos-blockchain/lssa.git", branch = "schouhy/full-bedrock-integration", features = ["host"] }
+nssa_core = { git = "https://github.com/logos-blockchain/lssa.git", branch = "main", features = ["host"] }
 borsh = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
Migrates all LSSA dependencies from `schouhy/full-bedrock-integration` to `main` branch.

### Changes
- All `Cargo.toml` git deps: `branch = "main"`
- Scaffolded project template (`init.rs`): same
- Fix `tx.rs`: `get_pub_account_signing_key` now takes `AccountId` by value (API change on main)

### Why
- Aligns with lez-multisig which already migrated
- Enables `sequencer_runner` for smoke test deploy/submit steps
- Tracks latest stable LSSA

### Verified
- ✅ `nssa-framework`, `nssa-framework-core`, `nssa-framework-macros` build
- ✅ All tests pass
- ✅ `nssa-framework-cli` builds (with type fix)