### PR TITLE
feat: extend IDL with lssa-lang compatible fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,20 @@ lez_framework::generate_idl!("../methods/guest/src/bin/my_program.rs");
 
 It reads the `#[lez_program]` annotations at compile time and generates a complete JSON IDL describing instructions, arguments, accounts, and PDA seeds.
 
+#### LSSA-lang compatible fields
+
+The generated IDL is a superset of the lssa-lang IDL spec. In addition to our core fields, each instruction includes:
+
+- **discriminator** -- SHA256 of global:name, first 8 bytes, matching lssa-lang convention
+- **execution** -- public/private_owned flags (default: public execution)
+- **variant** -- PascalCase variant name
+
+Each account field includes:
+
+- **visibility** -- list of visibility tags (default: public)
+
+These fields are optional and backward-compatible -- existing IDL consumers that do not know about them will simply ignore them.
+
 ## CLI Usage
 
 ```bash

--- a/lez-framework-core/Cargo.toml
+++ b/lez-framework-core/Cargo.toml
@@ -10,3 +10,4 @@ borsh = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+sha2 = "0.10"

--- a/lez-framework-core/src/idl.rs
+++ b/lez-framework-core/src/idl.rs
@@ -3,6 +3,13 @@
 //! The proc-macro generates an IDL JSON file at compile time that
 //! describes the program's interface. This module defines the
 //! serializable IDL format.
+//!
+//! ## LSSA-lang compatibility
+//!
+//! This IDL format is a superset of the lssa-lang IDL spec. Fields like
+//! `discriminator`, `execution`, and `visibility` are included for
+//! compatibility with lssa-lang tooling. All new fields are optional
+//! and backward-compatible with existing LEZ programs.
 
 use serde::{Deserialize, Serialize};
 
@@ -18,6 +25,30 @@ pub struct LezIdl {
     pub types: Vec<IdlTypeDef>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub errors: Vec<IdlError>,
+    /// IDL spec identifier (lssa-lang compat).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spec: Option<String>,
+    /// Program metadata (lssa-lang compat).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<IdlMetadata>,
+}
+
+/// Program metadata (lssa-lang compat).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IdlMetadata {
+    pub name: String,
+    pub version: String,
+}
+
+/// Execution mode for an instruction (lssa-lang compat).
+///
+/// Maps to lssa-lang's `Execution` type which has `public` and `private_owned` flags.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct IdlExecution {
+    #[serde(default)]
+    pub public: bool,
+    #[serde(default)]
+    pub private_owned: bool,
 }
 
 /// An instruction in the IDL.
@@ -26,6 +57,15 @@ pub struct IdlInstruction {
     pub name: String,
     pub accounts: Vec<IdlAccountItem>,
     pub args: Vec<IdlArg>,
+    /// SHA256("global:{name}")[..8] discriminator (lssa-lang compat).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub discriminator: Option<Vec<u8>>,
+    /// Execution mode (lssa-lang compat). Defaults to public.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub execution: Option<IdlExecution>,
+    /// Variant name in PascalCase (lssa-lang compat).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub variant: Option<String>,
 }
 
 /// An account expected by an instruction.
@@ -45,6 +85,9 @@ pub struct IdlAccountItem {
     /// If true, this account represents a variable-length trailing list.
     #[serde(default, skip_serializing_if = "is_false")]
     pub rest: bool,
+    /// Visibility tags (lssa-lang compat). e.g. ["public"].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub visibility: Vec<String>,
 }
 
 fn is_false(v: &bool) -> bool { !v }
@@ -129,6 +172,17 @@ pub struct IdlError {
     pub msg: Option<String>,
 }
 
+/// Compute the lssa-lang discriminator for an instruction name.
+///
+/// This is SHA256("global:{name}")[..8], matching lssa-lang's convention.
+pub fn compute_discriminator(name: &str) -> Vec<u8> {
+    use sha2::{Sha256, Digest};
+    let mut hasher = Sha256::new();
+    hasher.update(format!("global:{}", name).as_bytes());
+    let result = hasher.finalize();
+    result[..8].to_vec()
+}
+
 impl LezIdl {
     /// Create a new IDL with the given program name.
     pub fn new(name: impl Into<String>) -> Self {
@@ -139,6 +193,8 @@ impl LezIdl {
             accounts: vec![],
             types: vec![],
             errors: vec![],
+            spec: None,
+            metadata: None,
         }
     }
 

--- a/lez-framework-core/tests/variable_accounts.rs
+++ b/lez-framework-core/tests/variable_accounts.rs
@@ -13,6 +13,7 @@ fn test_rest_account_serializes() {
         owner: None,
         pda: None,
         rest: true,
+        visibility: vec!["public".to_string()],
     };
     let json = serde_json::to_string(&acc).unwrap();
     assert!(json.contains("\"rest\":true"), "JSON: {}", json);
@@ -28,6 +29,7 @@ fn test_non_rest_account_omits_rest() {
         owner: None,
         pda: None,
         rest: false,
+        visibility: vec![],
     };
     let json = serde_json::to_string(&acc).unwrap();
     assert!(!json.contains("rest"), "rest=false should be omitted, JSON: {}", json);

--- a/lez-framework-macros/Cargo.toml
+++ b/lez-framework-macros/Cargo.toml
@@ -11,3 +11,4 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full", "extra-traits"] }
+sha2 = "0.10"

--- a/lez-framework-macros/src/lib.rs
+++ b/lez-framework-macros/src/lib.rs
@@ -30,6 +30,7 @@
 //! ```
 
 use proc_macro::TokenStream;
+use sha2::{Sha256, Digest};
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{format_ident, quote};
 use syn::{
@@ -801,6 +802,14 @@ fn rust_type_to_idl_json(ty: &Type) -> String {
 
 // ─── IDL generation (code-based, for __program_idl()) ────────────────────
 
+/// Compute SHA256("global:{name}")[..8] discriminator at macro expansion time.
+fn compute_discriminator(name: &str) -> Vec<u8> {
+    let mut hasher = Sha256::new();
+    hasher.update(format!("global:{}", name).as_bytes());
+    let result = hasher.finalize();
+    result[..8].to_vec()
+}
+
 fn generate_idl_fn(mod_name: &Ident, instructions: &[InstructionInfo]) -> TokenStream2 {
     let program_name = mod_name.to_string();
 
@@ -855,6 +864,7 @@ fn generate_idl_fn(mod_name: &Ident, instructions: &[InstructionInfo]) -> TokenS
                             owner: None,
                             pda: #pda_expr,
                             rest: #is_rest,
+                            visibility: vec!["public".to_string()],
                         }
                     }
                 })
@@ -875,11 +885,34 @@ fn generate_idl_fn(mod_name: &Ident, instructions: &[InstructionInfo]) -> TokenS
                 })
                 .collect();
 
+            let discriminator_bytes = compute_discriminator(&ix_name);
+            let disc_bytes_lit: Vec<proc_macro2::TokenStream> = discriminator_bytes.iter()
+                .map(|b| { let val = proc_macro2::Literal::u8_unsuffixed(*b); quote! { #val } })
+                .collect();
+            let variant_name_str = {
+                let s = &ix_name;
+                s.split('_')
+                    .map(|w| {
+                        let mut c = w.chars();
+                        match c.next() {
+                            None => String::new(),
+                            Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
+                        }
+                    })
+                    .collect::<String>()
+            };
+
             quote! {
                 lez_framework::idl::IdlInstruction {
                     name: #ix_name.to_string(),
                     accounts: vec![#(#account_literals),*],
                     args: vec![#(#arg_literals),*],
+                    discriminator: Some(vec![#(#disc_bytes_lit),*]),
+                    execution: Some(lez_framework::idl::IdlExecution {
+                        public: true,
+                        private_owned: false,
+                    }),
+                    variant: Some(#variant_name_str.to_string()),
                 }
             }
         })
@@ -895,6 +928,11 @@ fn generate_idl_fn(mod_name: &Ident, instructions: &[InstructionInfo]) -> TokenS
                 accounts: vec![],
                 types: vec![],
                 errors: vec![],
+                spec: Some("0.1.0".to_string()),
+                metadata: Some(lez_framework::idl::IdlMetadata {
+                    name: #program_name.to_string(),
+                    version: "0.1.0".to_string(),
+                }),
             }
         }
     }


### PR DESCRIPTION
## Summary

Extends the LEZ IDL format with fields from the lssa-lang IDL spec, making our IDL a superset compatible with lssa-lang tooling.

## New fields

### IdlInstruction
- **discriminator**: SHA256(global:name)[..8]
- **execution**: { public, private_owned }
- **variant**: PascalCase name

### IdlAccountItem
- **visibility**: defaults to ["public"]

### LezIdl (top-level)
- **spec**, **metadata**

## Backward compatibility

All new fields are Optional/defaulted. cargo build ✅ cargo test ✅