### PR TITLE
fix: cfg-gate generated main() to enable inline unit tests

### DIFF
--- a/lez-framework-macros/src/lib.rs
+++ b/lez-framework-macros/src/lib.rs
@@ -285,7 +285,8 @@ fn expand_lez_program(input: ItemMod, config: ProgramConfig) -> syn::Result<Toke
         // IDL generation (available at host-side for tooling)
         #idl_fn
 
-        // The guest binary entry point
+        // The guest binary entry point (cfg-gated so cargo test works on host)
+        #[cfg(not(test))]
         #main_fn
     };
 


### PR DESCRIPTION
## Summary

- Wraps the `#[lez_program]` macro's generated `fn main()` in `#[cfg(not(test))]`
- This allows guest programs to have inline `#[cfg(test)] mod tests { ... }` that call handler and validation functions directly

## Problem

The generated `main()` calls `read_nssa_inputs()`, which invokes risc0 guest syscalls unavailable on the host. Running `cargo test` on any guest crate using `#[lez_program]` aborts with:

```
panicked at risc0-zkvm-platform/.../syscall.rs: not implemented
thread caused non-unwinding panic. aborting.
```

Without this fix, users must wrap the entire `#[lez_program]` module in `#[cfg(not(test))]`, extract domain logic into separate `_impl` functions, and test those instead — meaning the macro-generated signer/init validation is never exercised in tests.

## Change

One line in `lez-framework-macros/src/lib.rs` — adds `#[cfg(not(test))]` before the generated `#main_fn` in the expanded output.

## Context

Discovered while porting the [LEZ HTLC program](https://github.com/logos-co/eth-lez-atomic-swaps/tree/feat/lez-framework-port/programs/lez-htlc) to lez-framework.

Closes #21