### PR TITLE
fix: recognize AccountId as a known IDL type

### DIFF
--- a/lez-framework-macros/src/lib.rs
+++ b/lez-framework-macros/src/lib.rs
@@ -743,6 +743,7 @@ fn rust_type_to_idl_string(ty: &Type) -> String {
                     }
                 }
                 "ProgramId" => "program_id".to_string(),
+                "AccountId" => "account_id".to_string(),
                 other => other.to_string(),
             }
         }
@@ -783,6 +784,7 @@ fn rust_type_to_idl_json(ty: &Type) -> String {
                     }
                 }
                 "ProgramId" => "\"program_id\"".to_string(),
+                "AccountId" => "\"account_id\"".to_string(),
                 other => format!("{{\"defined\":\"{}\"}}", other),
             }
         }


### PR DESCRIPTION
Superseded by #28, which includes an additional fix for `lez-client-gen/src/util.rs` consistency. Thanks @danisharora099!