### PR TITLE
fix: replace PDA XOR with SHA-256 concat to match on-chain derivation

### DIFF
--- a/lez-cli/src/pda.rs
+++ b/lez-cli/src/pda.rs
@@ -81,20 +81,27 @@ fn resolve_seed(
     }
 }
 
-/// XOR two 32-byte arrays.
-fn xor_bytes(a: &[u8; 32], b: &[u8; 32]) -> [u8; 32] {
-    let mut result = [0u8; 32];
-    for i in 0..32 {
-        result[i] = a[i] ^ b[i];
+/// Hash multiple 32-byte seeds via SHA-256(seed1 || seed2 || ...).
+///
+/// Uses concatenation + SHA-256 (not XOR) to avoid commutativity and
+/// self-cancellation issues. Matches the on-chain nssa derivation pattern.
+fn hash_seeds(seeds: &[[u8; 32]]) -> [u8; 32] {
+    use risc0_zkvm::sha::{Impl, Sha256};
+    let mut bytes = Vec::with_capacity(seeds.len() * 32);
+    for seed in seeds {
+        bytes.extend_from_slice(seed);
     }
-    result
+    Impl::hash_bytes(&bytes)
+        .as_bytes()
+        .try_into()
+        .expect("SHA-256 output must be exactly 32 bytes")
 }
 
 /// Compute PDA AccountId from IDL seed definitions.
 ///
 /// Supports single and multi-seed PDAs:
 /// - Single seed: used directly as PDA seed
-/// - Multi-seed: XOR-combined into a single 32-byte seed
+/// - Multi-seed: SHA-256(seed1 || seed2 || ...) combined into a single 32-byte seed
 ///
 /// Supports all seed types: `const`, `account`, and `arg`.
 pub fn compute_pda_from_seeds(
@@ -113,11 +120,13 @@ pub fn compute_pda_from_seeds(
         .map(|s| resolve_seed(s, program_id, account_map, parsed_args))
         .collect::<Result<Vec<_>, _>>()?;
 
-    // Combine via XOR (matching lez-multisig pattern)
-    let combined = resolved
-        .iter()
-        .skip(1)
-        .fold(resolved[0], |acc, seed| xor_bytes(&acc, seed));
+    // Single seed: use directly. Multi-seed: SHA-256(seed1 || seed2 || ...)
+    // This avoids XOR commutativity and self-cancellation issues.
+    let combined = if resolved.len() == 1 {
+        resolved[0]
+    } else {
+        hash_seeds(&resolved)
+    };
 
     let pda_seed = PdaSeed::new(combined);
     Ok(AccountId::from((program_id, &pda_seed)))
@@ -171,34 +180,41 @@ mod tests {
     }
 
     #[test]
-    fn test_xor_combines_seeds() {
-        let a = [0xFFu8; 32];
-        let b = [0xFFu8; 32];
-        let result = xor_bytes(&a, &b);
-        assert_eq!(result, [0u8; 32]); // FF XOR FF = 00
+    fn test_hash_seeds_not_commutative() {
+        use risc0_zkvm::sha::{Impl, Sha256};
+        // SHA-256(A || B) != SHA-256(B || A) for A != B
+        let a = [0x01u8; 32];
+        let b = [0x02u8; 32];
+        let ab = hash_seeds(&[a, b]);
+        let ba = hash_seeds(&[b, a]);
+        assert_ne!(ab, ba, "seed order must matter (non-commutative)");
     }
 
     #[test]
-    fn test_multi_seed_xor() {
-        let seeds = vec![
+    fn test_hash_seeds_no_self_cancellation() {
+        // SHA-256(A || A) != zero
+        let a = [0xFFu8; 32];
+        let result = hash_seeds(&[a, a]);
+        assert_ne!(result, [0u8; 32], "identical seeds must not cancel out");
+    }
+
+    #[test]
+    fn test_multi_seed_differs_from_single() {
+        let seeds_multi = vec![
             IdlSeed::Const { value: "test".to_string() },
             IdlSeed::Arg { path: "key".to_string() },
+        ];
+        let seeds_single = vec![
+            IdlSeed::Const { value: "test".to_string() },
         ];
         let program_id: ProgramId = [1u32; 8];
         let mut args = HashMap::new();
         args.insert("key".to_string(), ParsedValue::ByteArray(vec![0u8; 32]));
 
-        // XOR with zeros should give us the const seed padded
-        let result = compute_pda_from_seeds(&seeds, &program_id, &HashMap::new(), &args).unwrap();
+        let multi = compute_pda_from_seeds(&seeds_multi, &program_id, &HashMap::new(), &args).unwrap();
+        let single = compute_pda_from_seeds(&seeds_single, &program_id, &HashMap::new(), &HashMap::new()).unwrap();
 
-        // Same as single const seed
-        let single = compute_pda_from_seeds(
-            &[IdlSeed::Const { value: "test".to_string() }],
-            &program_id,
-            &HashMap::new(),
-            &HashMap::new(),
-        ).unwrap();
-
-        assert_eq!(result, single);
+        // Multi-seed SHA-256 must differ from single seed (no zero-cancellation)
+        assert_ne!(multi, single);
     }
 }

--- a/lez-client-gen/src/codegen.rs
+++ b/lez-client-gen/src/codegen.rs
@@ -24,19 +24,20 @@ pub fn generate_client(idl: &LezIdl) -> Result<String, String> {
     writeln!(out, "use wallet::WalletCore;").unwrap();
     writeln!(out).unwrap();
 
-    // PDA helper
-    writeln!(out, "/// Compute a PDA by XOR-ing seed bytes (padded/truncated to 32 bytes).").unwrap();
+    // PDA helper — SHA-256(seed1 || seed2 || ...) matching on-chain derivation
+    writeln!(out, "/// Compute a PDA by SHA-256 hashing concatenated seeds.").unwrap();
+    writeln!(out, "/// Matches the on-chain nssa PDA derivation (not XOR).").unwrap();
     writeln!(out, "fn compute_pda(seeds: &[&[u8]]) -> AccountId {{").unwrap();
-    writeln!(out, "    let mut result = [0u8; 32];").unwrap();
+    writeln!(out, "    use sha2::{{Sha256, Digest}};").unwrap();
+    writeln!(out, "    let mut hasher = Sha256::new();").unwrap();
     writeln!(out, "    for seed in seeds {{").unwrap();
     writeln!(out, "        let mut padded = [0u8; 32];").unwrap();
     writeln!(out, "        let len = seed.len().min(32);").unwrap();
     writeln!(out, "        padded[..len].copy_from_slice(&seed[..len]);").unwrap();
-    writeln!(out, "        for (i, b) in padded.iter().enumerate() {{").unwrap();
-    writeln!(out, "            result[i] ^= b;").unwrap();
-    writeln!(out, "        }}").unwrap();
+    writeln!(out, "        hasher.update(&padded);").unwrap();
     writeln!(out, "    }}").unwrap();
-    writeln!(out, "    AccountId::from(result)").unwrap();
+    writeln!(out, "    let hash: [u8; 32] = hasher.finalize().into();").unwrap();
+    writeln!(out, "    AccountId::from(hash)").unwrap();
     writeln!(out, "}}").unwrap();
     writeln!(out).unwrap();
 

--- a/lez-client-gen/src/ffi_codegen.rs
+++ b/lez-client-gen/src/ffi_codegen.rs
@@ -74,16 +74,18 @@ pub fn generate_ffi(idl: &LezIdl) -> Result<String, String> {
     writeln!(out, "}}").unwrap();
     writeln!(out).unwrap();
 
-    // PDA computation
+    // PDA computation — SHA-256(seed1 || seed2 || ...) matching on-chain derivation
     writeln!(out, "fn compute_pda(seeds: &[&[u8]]) -> nssa::AccountId {{").unwrap();
-    writeln!(out, "    let mut result = [0u8; 32];").unwrap();
+    writeln!(out, "    use sha2::{{Sha256, Digest}};").unwrap();
+    writeln!(out, "    let mut hasher = Sha256::new();").unwrap();
     writeln!(out, "    for seed in seeds {{").unwrap();
     writeln!(out, "        let mut padded = [0u8; 32];").unwrap();
     writeln!(out, "        let len = seed.len().min(32);").unwrap();
     writeln!(out, "        padded[..len].copy_from_slice(&seed[..len]);").unwrap();
-    writeln!(out, "        for (i, b) in padded.iter().enumerate() {{ result[i] ^= b; }}").unwrap();
+    writeln!(out, "        hasher.update(&padded);").unwrap();
     writeln!(out, "    }}").unwrap();
-    writeln!(out, "    nssa::AccountId::from(result)").unwrap();
+    writeln!(out, "    let hash: [u8; 32] = hasher.finalize().into();").unwrap();
+    writeln!(out, "    nssa::AccountId::from(hash)").unwrap();
     writeln!(out, "}}").unwrap();
     writeln!(out).unwrap();
 


### PR DESCRIPTION
Fixes #22\n\n- lez-cli: use risc0_zkvm::sha::Impl::hash_bytes() for multi-seed PDAs\n- lez-client-gen: use sha2::Sha256 in generated code\n- Add tests verifying non-commutativity and no self-cancellation