### PR TITLE
fix: pin lssa deps to dee3f7fa (matches logos-scaffold template)

### DIFF
--- a/lez-cli/Cargo.toml
+++ b/lez-cli/Cargo.toml
@@ -10,9 +10,9 @@ path = "src/bin/main.rs"
 
 [dependencies]
 lez-framework-core = { path = "../lez-framework-core" }
-nssa_core = { git = "https://github.com/logos-blockchain/lssa.git", rev = "dee3f7fa6f2bf63abef00828f246ddacade9cdaf" }
-nssa = { git = "https://github.com/logos-blockchain/lssa.git", rev = "dee3f7fa6f2bf63abef00828f246ddacade9cdaf" }
-wallet = { git = "https://github.com/logos-blockchain/lssa.git", rev = "dee3f7fa6f2bf63abef00828f246ddacade9cdaf" }
+nssa_core = { git = "https://github.com/logos-blockchain/lssa.git", rev = "767b5afd388c7981bcdf6f5b5c80159607e07e5b" }
+nssa = { git = "https://github.com/logos-blockchain/lssa.git", rev = "767b5afd388c7981bcdf6f5b5c80159607e07e5b" }
+wallet = { git = "https://github.com/logos-blockchain/lssa.git", rev = "767b5afd388c7981bcdf6f5b5c80159607e07e5b" }
 risc0-zkvm = { version = "3.0.3", features = ["std"] }
 base58 = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/lez-framework-core/Cargo.toml
+++ b/lez-framework-core/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "Core types for the LEZ program framework"
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/lssa.git", rev = "dee3f7fa6f2bf63abef00828f246ddacade9cdaf", features = ["host"] }
+nssa_core = { git = "https://github.com/logos-blockchain/lssa.git", rev = "767b5afd388c7981bcdf6f5b5c80159607e07e5b", features = ["host"] }
 borsh = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/lez-framework/Cargo.toml
+++ b/lez-framework/Cargo.toml
@@ -7,7 +7,7 @@ description = "Developer framework for building LEZ programs (like Anchor for So
 [dependencies]
 lez-framework-core = { path = "../lez-framework-core" }
 lez-framework-macros = { path = "../lez-framework-macros" }
-nssa_core = { git = "https://github.com/logos-blockchain/lssa.git", rev = "dee3f7fa6f2bf63abef00828f246ddacade9cdaf", features = ["host"] }
+nssa_core = { git = "https://github.com/logos-blockchain/lssa.git", rev = "767b5afd388c7981bcdf6f5b5c80159607e07e5b", features = ["host"] }
 borsh = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Switch from `branch="main"` to pinned rev `dee3f7fa` in lez-framework, lez-framework-core, and lez-cli.

This ensures reproducible builds and aligns with the `lssa_pin` default used in the logos-scaffold lez-framework template, preventing version mismatches that cause build failures.

**Tested:** `cargo build --workspace` passes.