### PR TITLE
feat: lez-client-gen generates PDA compute helpers from IDL

### DIFF
--- a/lez-client-gen/src/ffi_codegen.rs
+++ b/lez-client-gen/src/ffi_codegen.rs
@@ -273,7 +273,128 @@ pub fn generate_ffi(idl: &LezIdl) -> Result<String, String> {
     writeln!(out, "    to_cstring(\"{}\".to_string())", idl.version).unwrap();
     writeln!(out, "}}").unwrap();
 
+    // PDA compute helpers
+    out.push_str(&generate_pda_helpers(idl));
     Ok(out)
+}
+
+/// Generate standalone PDA compute helper functions from an IDL.
+///
+/// Emits one `pub fn compute_{account}_pda(...)` per unique account that has
+/// a `pda` field in the IDL. The generated functions use SHA-256 to combine
+/// multiple seeds (matching `lez-cli/src/pda.rs` behaviour) and return an
+/// `AccountId` derived from the program ID and the combined seed.
+pub fn generate_pda_helpers(idl: &LezIdl) -> String {
+    use std::collections::HashSet;
+    let mut out = String::new();
+    let mut seen: HashSet<String> = HashSet::new();
+
+    for ix in &idl.instructions {
+        for acc in &ix.accounts {
+            let acc_name = snake_case(&acc.name);
+            if let Some(pda) = &acc.pda {
+                if !seen.insert(acc_name.clone()) {
+                    continue; // already generated for this account name
+                }
+
+                // Collect function parameters from arg seeds.
+                // Const seeds are inlined; account seeds get a TODO comment.
+                let mut params: Vec<(String, String)> = Vec::new();
+                for seed in &pda.seeds {
+                    match seed {
+                        IdlSeed::Arg { path } => {
+                            let ty = ix.args.iter().find(|a| a.name == *path)
+                                .map(|a| idl_type_to_rust(&a.type_))
+                                .unwrap_or_else(|| "[u8; 32]".to_string());
+                            // Normalise aliases to raw array types for cleaner FFI signatures
+                            let param_ty = match ty.as_str() {
+                                "AccountId" => "[u8; 32]".to_string(),
+                                "ProgramId" => "[u32; 8]".to_string(),
+                                other => other.to_string(),
+                            };
+                            params.push((rust_ident(path), param_ty));
+                        }
+                        IdlSeed::Account { .. } => {
+                            // account seeds: less common, skipped (see TODO inside generated fn)
+                        }
+                        IdlSeed::Const { .. } => {}
+                    }
+                }
+
+                // Doc comment
+                writeln!(out).unwrap();
+                let seed_desc: Vec<String> = pda.seeds.iter().map(|s| match s {
+                    IdlSeed::Const { value } => format!("const(\"{}\")", value),
+                    IdlSeed::Arg { path } => format!("arg({})", path),
+                    IdlSeed::Account { path } => format!("account({})", path),
+                }).collect();
+                writeln!(out, "/// Compute PDA for `{}` account.", acc.name).unwrap();
+                writeln!(out, "/// Seeds: [{}]", seed_desc.join(", ")).unwrap();
+
+                // Function signature
+                write!(out, "pub fn compute_{}_pda(", acc_name).unwrap();
+                write!(out, "program_id: &ProgramId").unwrap();
+                for (name, ty) in &params {
+                    write!(out, ", {}: &{}", name, ty).unwrap();
+                }
+                writeln!(out, ") -> AccountId {{").unwrap();
+
+                let n_seeds = pda.seeds.len();
+                if n_seeds == 1 {
+                    // Single seed: use directly as PdaSeed bytes
+                    match &pda.seeds[0] {
+                        IdlSeed::Const { value } => {
+                            writeln!(out, "    let mut seed_bytes = [0u8; 32];").unwrap();
+                            writeln!(out, "    let src = b\"{}\";", value).unwrap();
+                            writeln!(out, "    seed_bytes[..src.len()].copy_from_slice(src);").unwrap();
+                        }
+                        IdlSeed::Arg { path } => {
+                            let pname = rust_ident(path);
+                            writeln!(out, "    let seed_bytes: [u8; 32] = *{};", pname).unwrap();
+                        }
+                        IdlSeed::Account { path } => {
+                            let pname = rust_ident(path);
+                            writeln!(out, "    // TODO: account seed '{}' — pass the raw AccountId bytes here", path).unwrap();
+                            writeln!(out, "    let seed_bytes: [u8; 32] = *{};", pname).unwrap();
+                        }
+                    }
+                    writeln!(out, "    let pda_seed = nssa_core::program::PdaSeed::new(seed_bytes);").unwrap();
+                    writeln!(out, "    AccountId::from((program_id, &pda_seed))").unwrap();
+                } else {
+                    // Multi-seed: SHA-256(seed1 || seed2 || ...) — matches lez-cli/src/pda.rs
+                    writeln!(out, "    use sha2::{{Sha256, Digest}};").unwrap();
+                    writeln!(out, "    let mut hasher = Sha256::new();").unwrap();
+                    for seed in &pda.seeds {
+                        match seed {
+                            IdlSeed::Const { value } => {
+                                writeln!(out, "    {{").unwrap();
+                                writeln!(out, "        let mut padded = [0u8; 32];").unwrap();
+                                writeln!(out, "        let src = b\"{}\";", value).unwrap();
+                                writeln!(out, "        padded[..src.len()].copy_from_slice(src);").unwrap();
+                                writeln!(out, "        hasher.update(&padded);").unwrap();
+                                writeln!(out, "    }}").unwrap();
+                            }
+                            IdlSeed::Arg { path } => {
+                                let pname = rust_ident(path);
+                                writeln!(out, "    hasher.update({} as &[u8]);", pname).unwrap();
+                            }
+                            IdlSeed::Account { path } => {
+                                let pname = rust_ident(path);
+                                writeln!(out, "    // TODO: account seed '{}' — use account bytes", path).unwrap();
+                                writeln!(out, "    hasher.update({} as &[u8]);", pname).unwrap();
+                            }
+                        }
+                    }
+                    writeln!(out, "    let combined: [u8; 32] = hasher.finalize().into();").unwrap();
+                    writeln!(out, "    let pda_seed = nssa_core::program::PdaSeed::new(combined);").unwrap();
+                    writeln!(out, "    AccountId::from((program_id, &pda_seed))").unwrap();
+                }
+                writeln!(out, "}}").unwrap();
+            }
+        }
+    }
+
+    out
 }
 
 /// Generate a C header file from an IDL.

--- a/lez-client-gen/src/tests.rs
+++ b/lez-client-gen/src/tests.rs
@@ -199,3 +199,184 @@ fn test_rest_accounts() {
     // FFI should handle rest accounts as optional array, defaulting to empty
     assert!(output.ffi_code.contains("signers"));
 }
+
+#[test]
+fn test_pda_helpers_single_arg_seed() {
+    use lez_framework_core::idl::*;
+    use crate::ffi_codegen::generate_pda_helpers;
+
+    let idl = LezIdl {
+        version: "0.1.0".to_string(),
+        name: "test_program".to_string(),
+        instructions: vec![IdlInstruction {
+            name: "create".to_string(),
+            accounts: vec![IdlAccountItem {
+                name: "multisig_state".to_string(),
+                writable: true,
+                signer: false,
+                init: true,
+                owner: None,
+                pda: Some(IdlPda {
+                    seeds: vec![IdlSeed::Arg { path: "create_key".to_string() }],
+                }),
+                rest: false,
+                visibility: vec![],
+            }],
+            args: vec![IdlArg {
+                name: "create_key".to_string(),
+                type_: IdlType::Primitive("[u8; 32]".to_string()),
+
+            }],
+            discriminator: None,
+            execution: None,
+            variant: None,
+        }],
+        accounts: vec![],
+        types: vec![],
+        errors: vec![],
+        spec: None,
+        metadata: None,
+        instruction_type: None,
+    };
+
+    let output = generate_pda_helpers(&idl);
+
+    // Function signature
+    assert!(output.contains("pub fn compute_multisig_state_pda("), "missing fn signature: {}", output);
+    assert!(output.contains("program_id: &ProgramId"), "missing program_id param: {}", output);
+    assert!(output.contains("create_key: &[u8; 32]"), "missing create_key param: {}", output);
+    assert!(output.contains("-> AccountId"), "missing return type: {}", output);
+
+    // Single-seed: use directly (no SHA256)
+    assert!(output.contains("PdaSeed::new(seed_bytes)"), "missing PdaSeed::new: {}", output);
+    assert!(output.contains("AccountId::from((program_id, &pda_seed))"), "missing AccountId::from: {}", output);
+
+    // Single seed means no SHA256 hasher
+    assert!(!output.contains("Sha256"), "single-seed should not use SHA256: {}", output);
+}
+
+#[test]
+fn test_pda_helpers_multi_seed() {
+    use lez_framework_core::idl::*;
+    use crate::ffi_codegen::generate_pda_helpers;
+
+    let idl = LezIdl {
+        version: "0.1.0".to_string(),
+        name: "test_program".to_string(),
+        instructions: vec![IdlInstruction {
+            name: "create".to_string(),
+            accounts: vec![IdlAccountItem {
+                name: "multisig_state".to_string(),
+                writable: true,
+                signer: false,
+                init: true,
+                owner: None,
+                pda: Some(IdlPda {
+                    seeds: vec![
+                        IdlSeed::Const { value: "multisig_state__".to_string() },
+                        IdlSeed::Arg { path: "create_key".to_string() },
+                    ],
+                }),
+                rest: false,
+                visibility: vec![],
+            }],
+            args: vec![IdlArg {
+                name: "create_key".to_string(),
+                type_: IdlType::Primitive("[u8; 32]".to_string()),
+
+            }],
+            discriminator: None,
+            execution: None,
+            variant: None,
+        }],
+        accounts: vec![],
+        types: vec![],
+        errors: vec![],
+        spec: None,
+        metadata: None,
+        instruction_type: None,
+    };
+
+    let output = generate_pda_helpers(&idl);
+
+    // Function signature
+    assert!(output.contains("pub fn compute_multisig_state_pda("), "missing fn signature: {}", output);
+    assert!(output.contains("create_key: &[u8; 32]"), "missing create_key param: {}", output);
+
+    // Multi-seed: must use SHA256
+    assert!(output.contains("Sha256"), "multi-seed must use SHA256: {}", output);
+    assert!(output.contains("hasher.update"), "must call hasher.update: {}", output);
+    assert!(output.contains("multisig_state__"), "must inline const seed: {}", output);
+
+    // Doc comment seeds annotation
+    assert!(output.contains("Seeds: ["), "missing Seeds doc comment: {}", output);
+    assert!(output.contains("arg(create_key)"), "missing arg seed in doc: {}", output);
+}
+
+#[test]
+fn test_pda_helpers_deduplication() {
+    use lez_framework_core::idl::*;
+    use crate::ffi_codegen::generate_pda_helpers;
+
+    // Same account name appears in two instructions — should only generate one helper
+    let make_ix = |name: &str| IdlInstruction {
+        name: name.to_string(),
+        accounts: vec![IdlAccountItem {
+            name: "shared_state".to_string(),
+            writable: true,
+            signer: false,
+            init: false,
+            owner: None,
+            pda: Some(IdlPda {
+                seeds: vec![IdlSeed::Arg { path: "my_key".to_string() }],
+            }),
+            rest: false,
+            visibility: vec![],
+        }],
+        args: vec![IdlArg {
+            name: "my_key".to_string(),
+            type_: IdlType::Primitive("[u8; 32]".to_string()),
+        }],
+        discriminator: None,
+        execution: None,
+        variant: None,
+    };
+
+    let idl = LezIdl {
+        version: "0.1.0".to_string(),
+        name: "test_program".to_string(),
+        instructions: vec![make_ix("create"), make_ix("update")],
+        accounts: vec![],
+        types: vec![],
+        errors: vec![],
+        spec: None,
+        metadata: None,
+        instruction_type: None,
+    };
+
+    let output = generate_pda_helpers(&idl);
+
+    // Should appear exactly once
+    let count = output.matches("pub fn compute_shared_state_pda(").count();
+    assert_eq!(count, 1, "account PDA helper should be generated exactly once, got {}", count);
+}
+
+#[test]
+fn test_pda_helpers_in_ffi_output() {
+    // Verify generate_ffi includes PDA helpers in its output
+    let output = generate_from_idl_json(SAMPLE_IDL).expect("codegen should succeed");
+
+    // The SAMPLE_IDL has multisig_state with a 2-seed PDA (const + arg)
+    assert!(
+        output.ffi_code.contains("pub fn compute_multisig_state_pda("),
+        "FFI output must include PDA helper function"
+    );
+    assert!(
+        output.ffi_code.contains("create_key: &[u8; 32]"),
+        "FFI PDA helper must have create_key param"
+    );
+    assert!(
+        output.ffi_code.contains("Sha256"),
+        "FFI PDA helper for multi-seed must use SHA256"
+    );
+}


### PR DESCRIPTION
## Summary

Extends `lez-client-gen` to generate PDA compute helper functions from IDL annotations, eliminating the need for hand-written PDA helpers in downstream crates.

## Changes

- Added `pub fn generate_pda_helpers(idl: &LezIdl) -> String` in `ffi_codegen.rs`
- Integrated into `generate_ffi()` — PDA helpers are appended to the generated FFI output
- Seed kinds supported: `const` (UTF-8 padded to 32 bytes), `arg` (typed param), `account` (TODO)
- Single seed → direct `PdaSeed::new()`, multi-seed → SHA-256(seed1 || seed2 || ...) matching `lez-cli`
- Account names deduplicated across instructions
- 4 new tests covering single-seed, multi-seed, deduplication, and integration into `generate_ffi`

## Example output

For an IDL with:
- `create_multisig` instruction → `multisig_state` account with `pda = [arg(create_key)]`
- `propose` instruction → `proposal` account with `pda = [const("proposal"), arg(create_key)]`

The generated code is:

```rust
/// Compute PDA for `multisig_state` account.
/// Seeds: [arg(create_key)]
pub fn compute_multisig_state_pda(program_id: &ProgramId, create_key: &[u8; 32]) -> AccountId {
    let seed_bytes: [u8; 32] = *create_key;
    let pda_seed = nssa_core::program::PdaSeed::new(seed_bytes);
    AccountId::from((program_id, &pda_seed))
}

/// Compute PDA for `proposal` account.
/// Seeds: [const("proposal"), arg(create_key)]
pub fn compute_proposal_pda(program_id: &ProgramId, create_key: &[u8; 32]) -> AccountId {
    use sha2::{Sha256, Digest};
    let mut hasher = Sha256::new();
    {
        let mut padded = [0u8; 32];
        let src = b"proposal";
        padded[..src.len()].copy_from_slice(src);
        hasher.update(&padded);
    }
    hasher.update(create_key as &[u8]);
    let combined: [u8; 32] = hasher.finalize().into();
    let pda_seed = nssa_core::program::PdaSeed::new(combined);
    AccountId::from((program_id, &pda_seed))
}
```

## Motivation

Closes part of [lez-framework#39](https://github.com/jimmy-claw/lez-framework/issues/39). Once merged, `lez-multisig-framework` can replace its hand-rolled `multisig_core` PDA helpers with generated ones.