### PR TITLE
fix: parse and serialize Vec<u8> and Vec<u32> properly

### DIFF
--- a/lez-cli/src/parse.rs
+++ b/lez-cli/src/parse.rs
@@ -184,6 +184,26 @@ fn parse_vec(raw: &str, elem_type: &IdlType) -> Result<ParsedValue, String> {
             }
             _ => Ok(ParsedValue::Raw(raw.to_string())),
         },
+        // Vec<u8> — comma-separated decimal values
+        IdlType::Primitive(p) if p == "u8" => {
+            let bytes: Result<Vec<u8>, _> = raw.split(',')
+                .map(|s| s.trim().parse::<u8>())
+                .collect();
+            match bytes {
+                Ok(b) => Ok(ParsedValue::ByteArray(b)),
+                Err(_) => Ok(ParsedValue::Raw(raw.to_string())),
+            }
+        }
+        // Vec<u32> — comma-separated decimal values
+        IdlType::Primitive(p) if p == "u32" => {
+            let vals: Result<Vec<u32>, _> = raw.split(',')
+                .map(|s| s.trim().parse::<u32>())
+                .collect();
+            match vals {
+                Ok(v) => Ok(ParsedValue::U32Array(v)),
+                Err(_) => Ok(ParsedValue::Raw(raw.to_string())),
+            }
+        }
         _ => Ok(ParsedValue::Raw(raw.to_string())),
     }
 }

--- a/lez-cli/src/serialize.rs
+++ b/lez-cli/src/serialize.rs
@@ -98,6 +98,13 @@ fn serialize_vec_risc0(out: &mut Vec<u32>, elem_type: &IdlType, val: &ParsedValu
                 out.push(*v);
             }
         }
+        // Vec<u8> — byte array (already parsed)
+        (IdlType::Primitive(p), ParsedValue::ByteArray(bytes)) if p == "u8" => {
+            out.push(bytes.len() as u32);
+            for b in bytes {
+                out.push(*b as u32);
+            }
+        }
         // Vec<u32> — passed as Raw CSV string (e.g. "0,200,0,0,0")
         (IdlType::Primitive(p), ParsedValue::Raw(s)) if p == "u32" => {
             let vals: Vec<u32> = s.split(',')


### PR DESCRIPTION
parse_vec fell through to Raw for Vec<u8> and Vec<u32>. Now parses them as ByteArray and U32Array. serialize_vec_risc0 now handles ByteArray (Vec<u8>) correctly.