### PR TITLE
fix: correct program-id endianness in hex parsing and PDA derivation

### DIFF
--- a/lez-cli/Cargo.toml
+++ b/lez-cli/Cargo.toml
@@ -18,4 +18,5 @@ base58 = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 borsh = "1.5"
+bytemuck = { version = "1", features = ["derive"] }
 tokio = { version = "1.28.2", features = ["net", "rt-multi-thread", "sync", "macros"] }

--- a/lez-cli/src/lib.rs
+++ b/lez-cli/src/lib.rs
@@ -318,10 +318,10 @@ fn compute_pda_raw(args: &[String]) {
         eprintln!("❌ Invalid --program-id '{}': {}", pid_hex, e);
         std::process::exit(1);
     });
+    let program_id_slice: &[u32] = bytemuck::try_cast_slice(&pid_bytes)
+        .expect("ProgramId bytes should be castable to &[u32]");
     let mut program_id: ProgramId = [0u32; 8];
-    for (i, chunk) in pid_bytes.chunks(4).enumerate() {
-        program_id[i] = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
-    }
+    program_id.copy_from_slice(program_id_slice);
 
     // Collect seed args (everything that's not --program-id or its value)
     let mut seeds: Vec<[u8; 32]> = Vec::new();

--- a/lez-cli/src/parse.rs
+++ b/lez-cli/src/parse.rs
@@ -107,7 +107,7 @@ fn parse_program_id(raw: &str) -> Result<ParsedValue, String> {
         let bytes = hex_decode(raw)?;
         let mut vals = Vec::with_capacity(8);
         for chunk in bytes.chunks(4) {
-            vals.push(u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
+            vals.push(u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
         }
         Ok(ParsedValue::U32Array(vals))
     } else {


### PR DESCRIPTION
## Summary
- **#54**: `parse_program_id` in `lez-cli/src/parse.rs` now uses `u32::from_be_bytes` instead of `from_le_bytes` for 64-char hex input (hex is big-endian by convention)
- **#55**: `compute_pda_raw` in `lez-cli/src/lib.rs` now uses `bytemuck::try_cast_slice` for program_id byte conversion, matching `nssa_core`'s LE byte-order cast behavior

Closes #54, closes #55

## Test plan
- [x] All 33 existing tests pass (`cargo test`)
- [ ] Manual verification: parse a known program ID hex string and confirm correct u32 values

🤖 Generated with [Claude Code](https://claude.com/claude-code)