### PR TITLE
docs: add pda subcommand, Vec types, and --program-id flag to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,10 @@
-# SPEL — Smart Program Engine for Logos
+# lez-framework
 
-[![CI](https://github.com/logos-co/spel/actions/workflows/ci.yml/badge.svg)](https://github.com/logos-co/spel/actions/workflows/ci.yml)
-
-> **SPEL** = **S**mart **P**rogram **E**ngine for **L**ogos
->
-> The name captures what this is: a framework layer that makes writing smart programs for the Logos Execution Zone (LEZ) feel like writing normal Rust — with macros handling the boilerplate, a CLI doing the heavy lifting, and zkVM proving the execution.
+[![CI](https://github.com/jimmy-claw/lez-framework/actions/workflows/ci.yml/badge.svg)](https://github.com/jimmy-claw/lez-framework/actions/workflows/ci.yml)
 
 Developer framework for building LEZ programs — inspired by [Anchor](https://www.anchor-lang.com/) for Solana.
 
-Write your program logic with proc macros. Get IDL generation, a full typed CLI with TX submission, and project scaffolding for free.
-
-## The Stack
-
-```
-Your Program (Rust)
-  └── #[lez_program] macro        ← annotate instructions
-       ├── IDL generation          ← types + accounts → JSON schema
-       ├── zkVM guest binary       ← runs on-chain (risc0)
-       └── lez-cli                 ← auto-generated typed CLI
-```
+Write your program logic with proc macros. Get IDL generation, a full CLI with TX submission, and project scaffolding for free.
 
 ## Quick Start
 
@@ -34,13 +20,18 @@ This generates a complete project:
 
 ```
 my-program/
-├── Cargo.toml
+├── Cargo.toml                 # Workspace
 ├── Makefile                   # build, idl, cli, deploy, inspect, setup
+├── README.md
 ├── my_program_core/           # Shared types (guest + host)
-├── methods/guest/             # RISC Zero guest (runs on-chain)
-└── examples/src/bin/
-    ├── generate_idl.rs        # One-liner IDL generator
-    └── my_program_cli.rs      # Three-line CLI wrapper
+│   └── src/lib.rs
+├── methods/
+│   └── guest/                 # RISC Zero guest (runs on-chain)
+│       └── src/bin/my_program.rs
+└── examples/
+    └── src/bin/
+        ├── generate_idl.rs    # One-liner IDL generator
+        └── my_program_cli.rs  # Three-line CLI wrapper
 ```
 
 ### Build → Deploy → Transact
@@ -49,33 +40,193 @@ my-program/
 make build        # Build the guest binary (risc0)
 make idl          # Generate IDL from #[lez_program] annotations
 make deploy       # Deploy to sequencer
-make cli ARGS="--help"
+make cli ARGS="--help"   # See auto-generated commands
+make cli ARGS="-p <binary> initialize --owner-account <BASE58>"
 ```
 
 ## Writing Programs
 
 ```rust
+#![no_main]
+
+use nssa_core::account::AccountWithMetadata;
+use nssa_core::program::AccountPostState;
+use lez_framework::prelude::*;
+
+risc0_zkvm::guest::entry!(main);
+
 #[lez_program]
 mod my_program {
+    #[allow(unused_imports)]
+    use super::*;
+
     #[instruction]
-    pub fn initialize(ctx: Context<Initialize>, owner: AccountId) -> ProgramResult {
-        ctx.accounts.state.owner = owner;
-        Ok(())
+    pub fn initialize(
+        #[account(init, pda = literal("state"))]
+        state: AccountWithMetadata,
+        #[account(signer)]
+        owner: AccountWithMetadata,
+    ) -> LezResult {
+        // Your logic here
+        Ok(LezOutput::states_only(vec![
+            AccountPostState::new_claimed(state.account.clone()),
+            AccountPostState::new(owner.account.clone()),
+        ]))
+    }
+
+    #[instruction]
+    pub fn transfer(
+        #[account(mut, pda = literal("state"))]
+        state: AccountWithMetadata,
+        recipient: AccountWithMetadata,
+        #[account(signer)]
+        sender: AccountWithMetadata,
+        amount: u128,
+    ) -> LezResult {
+        // Your logic here
+        Ok(LezOutput::states_only(vec![
+            AccountPostState::new(state.account.clone()),
+            AccountPostState::new(recipient.account.clone()),
+            AccountPostState::new(sender.account.clone()),
+        ]))
     }
 }
 ```
 
-The macro emits the IDL. The CLI reads the IDL. You write logic.
+### Account Attributes
 
-## Repos in the SPEL ecosystem
+| Attribute | Description |
+|-----------|-------------|
+| `#[account(mut)]` | Account is writable |
+| `#[account(init)]` | Account is being created (use `new_claimed`) |
+| `#[account(signer)]` | Account must sign the transaction |
+| `#[account(pda = literal("seed"))]` | PDA derived from a constant string |
+| `#[account(pda = account("other"))]` | PDA derived from another account's ID |
+| `#[account(pda = arg("create_key"))]` | PDA derived from an instruction argument |
+| `members: Vec<AccountWithMetadata>` | Variable-length trailing account list |
 
-| Repo | Description |
-|------|-------------|
-| [spel](https://github.com/logos-co/spel) | This repo — framework, macros, CLI |
-| [spelbook](https://github.com/logos-co/spelbook) | On-chain program registry (SPELbook) |
-| [lez-multisig-framework](https://github.com/logos-co/lez-multisig-framework) | Multisig governance program — full demo |
-| [lmao](https://github.com/jimmy-claw/lmao) | Logos Module for Agent Orchestration (A2A over Waku) |
+### Runtime Validation
 
-## v0.1.0
+Accounts marked with `#[account(signer)]` or `#[account(init)]` get **automatic runtime checks** before your handler runs:
 
-Tagged [v0.1.0](https://github.com/logos-co/spel/releases/tag/v0.1.0) — full end-to-end demo passing with lez-multisig-framework (deploy → registry → multisig governance → token ChainedCall).
+- **Signer**: Verifies `is_authorized` is true, returns `LezError::Unauthorized` if not
+- **Init**: Verifies account is in default state, returns `LezError::AccountAlreadyInitialized` if not
+
+No manual checking needed in your instruction handlers.
+
+### External Instruction Enum
+
+If your `Instruction` enum lives in a shared core crate (used by both on-chain program and CLI), you can tell the macro to use it instead of generating one:
+
+```rust
+#[lez_program(instruction = "my_core::Instruction")]
+mod my_program {
+    // ...
+}
+```
+
+### The CLI Wrapper
+
+Every program gets a full CLI for free. The wrapper is just:
+
+```rust
+#[tokio::main]
+async fn main() {
+    lez_cli::run().await;
+}
+```
+
+This provides:
+- Auto-generated subcommands from IDL instructions
+- Type-aware argument parsing (u128, [u8; N], base58 accounts, ProgramId, etc.)
+- Automatic PDA computation from IDL seeds
+- risc0-compatible serialization
+- Transaction building and submission with wallet integration
+- `--dry-run` mode for testing
+- `inspect` subcommand to extract ProgramId from binaries
+
+### IDL Generation
+
+The IDL generator is also a one-liner:
+
+```rust
+lez_framework::generate_idl!("../methods/guest/src/bin/my_program.rs");
+```
+
+It reads the `#[lez_program]` annotations at compile time and generates a complete JSON IDL describing instructions, arguments, accounts, and PDA seeds.
+
+#### LSSA-lang compatible fields
+
+The generated IDL is a superset of the lssa-lang IDL spec. In addition to our core fields, each instruction includes:
+
+- **discriminator** -- SHA256 of global:name, first 8 bytes, matching lssa-lang convention
+- **execution** -- public/private_owned flags (default: public execution)
+- **variant** -- PascalCase variant name
+
+Each account field includes:
+
+- **visibility** -- list of visibility tags (default: public)
+
+These fields are optional and backward-compatible -- existing IDL consumers that do not know about them will simply ignore them.
+
+## CLI Usage
+
+```bash
+# Scaffold a new project (no --idl needed)
+lez-cli init my-program
+
+# Inspect program binaries (no --idl needed)
+lez-cli inspect program.bin
+
+# Show available commands
+lez-cli --idl program-idl.json --help
+
+# Dry run an instruction
+lez-cli --idl program-idl.json --dry-run -p program.bin \
+  create-vault --token-name "MYTKN" --initial-supply 1000000
+
+# Submit a transaction
+lez-cli --idl program-idl.json -p program.bin \
+  create-vault --token-name "MYTKN" --initial-supply 1000000
+
+# Use --program-id instead of binary (skips loading the file)
+lez-cli --idl program-idl.json --program-id <64-char-hex>   create-vault --token-name "MYTKN" --initial-supply 1000000
+
+# Compute a PDA from the IDL
+lez-cli --idl program-idl.json --program-id <64-char-hex> pda vault --create-key my-multisig
+
+# Auto-fill program IDs from binaries
+lez-cli --idl program-idl.json -p treasury.bin --bin-token token.bin \
+  create-vault --token-name "MYTKN" --initial-supply 1000000
+
+# Get help for a specific instruction
+lez-cli --idl program-idl.json create-vault --help
+```
+
+### Type Formats
+
+| IDL Type | CLI Format |
+|----------|------------|
+| `u8`, `u32`, `u64`, `u128` | Decimal number |
+| `[u8; N]` | Hex string (2×N chars) or UTF-8 string (≤N chars, right-padded) |
+| `[u32; 8]` / `program_id` | Comma-separated u32s: `"0,0,0,0,0,0,0,0"` |
+| `Vec<u8>` | Comma-separated decimal bytes: `"0,1,2"` |
+| `Vec<u32>` | Comma-separated decimal u32s: `"0,200,0,0,0"` |
+| `Vec<[u8; 32]>` | Comma-separated hex or base58: `"addr1,addr2"` |
+| `rest` accounts | Comma-separated base58/hex: `--foo-account "addr1,addr2"` |
+| `Option<T>` | Value or `"none"` |
+| Account IDs | Base58 or 64-char hex |
+
+## Crates
+
+| Crate | Description |
+|-------|-------------|
+| `lez-framework` | Umbrella crate — re-exports macros + core with a prelude |
+| `lez-framework-core` | IDL types, error types, `LezOutput` |
+| `lez-framework-macros` | Proc macros: `#[lez_program]`, `#[instruction]`, `generate_idl!` |
+| `lez-cli` | Generic IDL-driven CLI with TX submission + project scaffolding |
+| `lez-client-gen` | Code generator — produces typed Rust FFI clients from IDL JSON |
+
+## License
+
+MIT

--- a/lez-cli/Cargo.toml
+++ b/lez-cli/Cargo.toml
@@ -18,5 +18,4 @@ base58 = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 borsh = "1.5"
-bytemuck = { version = "1", features = ["derive"] }
 tokio = { version = "1.28.2", features = ["net", "rt-multi-thread", "sync", "macros"] }

--- a/lez-cli/src/lib.rs
+++ b/lez-cli/src/lib.rs
@@ -318,10 +318,10 @@ fn compute_pda_raw(args: &[String]) {
         eprintln!("❌ Invalid --program-id '{}': {}", pid_hex, e);
         std::process::exit(1);
     });
-    let program_id_slice: &[u32] = bytemuck::try_cast_slice(&pid_bytes)
-        .expect("ProgramId bytes should be castable to &[u32]");
     let mut program_id: ProgramId = [0u32; 8];
-    program_id.copy_from_slice(program_id_slice);
+    for (i, chunk) in pid_bytes.chunks(4).enumerate() {
+        program_id[i] = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+    }
 
     // Collect seed args (everything that's not --program-id or its value)
     let mut seeds: Vec<[u8; 32]> = Vec::new();

--- a/lez-cli/src/parse.rs
+++ b/lez-cli/src/parse.rs
@@ -107,7 +107,7 @@ fn parse_program_id(raw: &str) -> Result<ParsedValue, String> {
         let bytes = hex_decode(raw)?;
         let mut vals = Vec::with_capacity(8);
         for chunk in bytes.chunks(4) {
-            vals.push(u32::from_be_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
+            vals.push(u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
         }
         Ok(ParsedValue::U32Array(vals))
     } else {


### PR DESCRIPTION
Documents the new `pda` command and `--program-id` global flag, plus Vec<u8>/Vec<u32>/rest account formats in the type table.