### PR TITLE
chore(bump): update LEZ to 98e98c62

### DIFF
--- a/spel-cli/Cargo.toml
+++ b/spel-cli/Cargo.toml
@@ -10,11 +10,11 @@ path = "src/bin/main.rs"
 
 [dependencies]
 spel-framework-core = { path = "../spel-framework-core", features = ["idl-gen"] }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b" }
-nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b" }
-common = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b" }
-sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b", features = ["client"] }
-wallet = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "98e98c6214afb6e0b60db3627ccfeae8293fe361" }
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "98e98c6214afb6e0b60db3627ccfeae8293fe361" }
+common = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "98e98c6214afb6e0b60db3627ccfeae8293fe361" }
+sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "98e98c6214afb6e0b60db3627ccfeae8293fe361", features = ["client"] }
+wallet = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "98e98c6214afb6e0b60db3627ccfeae8293fe361" }
 risc0-zkvm = { version = "3.0.3", features = ["std"] }
 base58 = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/spel-framework-core/Cargo.toml
+++ b/spel-framework-core/Cargo.toml
@@ -9,7 +9,7 @@ default = []
 idl-gen = ["dep:syn"]
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b", features = ["host"] }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "98e98c6214afb6e0b60db3627ccfeae8293fe361", features = ["host"] }
 borsh = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/spel-framework/Cargo.toml
+++ b/spel-framework/Cargo.toml
@@ -7,7 +7,7 @@ description = "Developer framework for building SPEL programs (like Anchor for S
 [dependencies]
 spel-framework-core = { path = "../spel-framework-core" }
 spel-framework-macros = { path = "../spel-framework-macros" }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b", features = ["host"] }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "98e98c6214afb6e0b60db3627ccfeae8293fe361", features = ["host"] }
 borsh = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/tests/e2e/fixture_program/Cargo.toml
+++ b/tests/e2e/fixture_program/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 
 [dependencies]
 spel-framework = { path = "../../../spel-framework" }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b", features = ["host"] }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "98e98c6214afb6e0b60db3627ccfeae8293fe361", features = ["host"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
Bumps LEZ to `98e98c6214afb6e0b60db3627ccfeae8293fe361`.

All cargo checks pass:
- ✅ spel-framework-core
- ✅ spel-framework  
- ✅ spel-cli