### PR TITLE
chore(bump): use LEZ v0.2.0-rc1 release tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ mod my_program {
     ) -> SpelResult {
         // Your logic here
         Ok(SpelOutput::states_only(vec![
-            AccountPostState::new_claimed(state.account.clone()),
+            AccountPostState::new_claimed(state.account.clone(), Claim::Authorized),
             AccountPostState::new(owner.account.clone()),
         ]))
     }

--- a/scripts/smoke-test-privacy.sh
+++ b/scripts/smoke-test-privacy.sh
@@ -191,6 +191,12 @@ SEQ_CONFIGS="${LSSA_DIR}/sequencer/service/configs/debug/sequencer_config.json"
 cd "$LSSA_DIR"
 RUST_LOG=info $SEQUENCER_BIN "$SEQ_CONFIGS" > "$LOG_DIR/sequencer.log" 2>&1 &
 SEQ_PID=$!
+sleep 2
+if ! kill -0 $SEQ_PID 2>/dev/null; then
+    echo "❌ Seencer failed to start. Logs:"
+    cat "$LOG_DIR/sequencer.log" | tail -30
+    exit 1
+fi
 cd "$WORK_DIR/$PROJECT_NAME"
 
 log "  Waiting for sequencer..."

--- a/scripts/smoke-test-privacy.sh
+++ b/scripts/smoke-test-privacy.sh
@@ -17,7 +17,7 @@ SEQUENCER_URL="http://127.0.0.1:${SEQUENCER_PORT}"
 PROJECT_NAME="privacy_test"
 LOG_DIR="${WORK_DIR}/logs"
 LEZ_TAG="${LEZ_TAG:-v0.2.0-rc1}"
-SPEL_TAG="${SPEL_TAG:-v0.2.0-rc.1}"
+SPEL_TAG="${SPEL_TAG:-refs/pull/122/head}"
 SPEL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 RED='\033[0;31m'
@@ -53,6 +53,7 @@ done
 WALLET_BIN=""
 for candidate in wallet "$HOME/bin/wallet" "$LSSA_DIR/target/release/wallet"; do
     if command -v "$candidate" >/dev/null 2>&1 || [ -x "$candidate" ]; then
+        echo "Found wallet binary: $candidate"
         WALLET_BIN="$candidate"; break
     fi
 done
@@ -96,29 +97,11 @@ log "  Sequencer: $("$SEQUENCER_BIN" --version 2>/dev/null || echo 'unknown')"
 # ─── Step 1: Scaffold project ──────────────────────────────────────────────
 
 log "Step 1: Creating SPEL project (LEZ=${LEZ_TAG}, SPEL=${SPEL_TAG})..."
-"$SPEL_BIN" init --lez-tag "$LEZ_TAG" --spel-tag "$SPEL_TAG" "$PROJECT_NAME" \
+"$SPEL_BIN" init --lez-tag "$LEZ_TAG" --spel-rev "$SPEL_TAG" "$PROJECT_NAME" \
     > "$LOG_DIR/init.log" 2>&1 || fail "spel init failed (see $LOG_DIR/init.log)"
 cd "$PROJECT_NAME"
 log "  ✅ Project scaffolded"
 
-# ─── Patch: force nssa_core to the correct LEZ tag ────────────────────────
-# The published spel-framework may transitively pull an older nssa_core.
-# A [patch] section forces Cargo to unify all nssa_core refs to our tag.
-LEZ_GIT="https://github.com/logos-blockchain/logos-execution-zone.git"
-
-cat >> methods/guest/Cargo.toml << PATCHEOF
-
-[patch."${LEZ_GIT}"]
-nssa_core = { git = "${LEZ_GIT}", tag = "${LEZ_TAG}" }
-PATCHEOF
-
-cat >> Cargo.toml << PATCHEOF
-
-[patch."${LEZ_GIT}"]
-nssa_core = { git = "${LEZ_GIT}", tag = "${LEZ_TAG}" }
-PATCHEOF
-
-log "  ✅ Patched Cargo.toml files to pin nssa_core=${LEZ_TAG}"
 
 # Regenerate lockfiles so the patch takes effect
 (cd methods/guest && cargo generate-lockfile > "$LOG_DIR/guest-lockfile.log" 2>&1) \
@@ -151,7 +134,7 @@ mod privacy_test {
     /// For already-owned accounts: returns unchanged (privacy TX compatible).
     #[instruction]
     pub fn greet(
-        #[account(mut)]
+        #[account(mut, signer)]
         account: AccountWithMetadata,
         greeting: Vec<u8>,
     ) -> SpelResult {
@@ -206,31 +189,34 @@ SEQ_CONFIGS="${LSSA_DIR}/sequencer/service/configs/debug/sequencer_config.json"
 [ -f "$SEQ_CONFIGS" ] || fail "Sequencer config not found"
 
 cd "$LSSA_DIR"
-RUST_LOG=warn $SEQUENCER_BIN "$SEQ_CONFIGS" > "$LOG_DIR/sequencer.log" 2>&1 &
+RUST_LOG=info $SEQUENCER_BIN "$SEQ_CONFIGS" > "$LOG_DIR/sequencer.log" 2>&1 &
 SEQ_PID=$!
 cd "$WORK_DIR/$PROJECT_NAME"
 
 log "  Waiting for sequencer..."
 for i in $(seq 1 60); do
-    if curl -sf -o /dev/null -w '%{http_code}' "$SEQUENCER_URL" 2>/dev/null | grep -qE '200|405'; then
+    if [ $(curl -sf -o /dev/null -w '%{http_code}' "$SEQUENCER_URL" 2>/dev/null | grep -qE '200|405'; echo $?) -eq 0 ]; then
         log "  ✅ Sequencer up"; break
     fi
     kill -0 "$SEQ_PID" 2>/dev/null || fail "Sequencer died"
+    echo -n "."
     sleep 1
 done
 
 # Wait for first block to be produced before proceeding
 log "  Waiting for first block..."
 for i in $(seq 1 60); do
-    LAST_BLOCK=$(curl -sf -X POST "$SEQUENCER_URL" \
+    curl -sf -X POST "$SEQUENCER_URL" \
         -H 'Content-Type: application/json' \
-        -d '{"jsonrpc":"2.0","method":"getLastBlockId","params":[],"id":1}' 2>/dev/null \
-        | python3 -c "import json,sys; r=json.load(sys.stdin); print(r.get('result',0))" 2>/dev/null || echo 0)
-    if [ "${LAST_BLOCK:-0}" -gt 0 ] 2>/dev/null; then
-        log "  ✅ First block produced (block $LAST_BLOCK)"
+        -d '{"jsonrpc":"2.0","method":"getLastBlockId","params":[],"id":1}' 2>/dev/null
+
+    SUCCESS=$?
+    if [ $SUCCESS -eq 0 ]; then
+        log "  ✅ Sequencer producing blocks";
         break
     fi
     sleep 2
+    echo -n "."
 done
 
 # ─── Step 6: Deploy ───────────────────────────────────────────────────────
@@ -256,7 +242,9 @@ log "  Private account: ${PRIVATE_ACCOUNT:0:30}..."
 # ─── Step 8: Test PUBLIC transaction ────────────────────────────────────
 
 log "Step 8: Testing PUBLIC transaction..."
-FRESH_ACCOUNT="0x$(openssl rand -hex 32)"
+FRESH_ACCOUNT=$(echo "$WALLET_PASSWORD" | $WALLET_BIN account new public 2>&1 | grep -o "Public/[^ ]*" | head -1)
+[ -n "$FRESH_ACCOUNT" ] || fail "Could not create public account from wallet"
+log "  Fresh account: ${FRESH_ACCOUNT:0:20}..."
 
 SEQUENCER_URL="$SEQUENCER_URL" "$SPEL_BIN" --idl "$IDL_ABS" -p "$GUEST_BIN_ABS" \
     greet \

--- a/scripts/smoke-test-privacy.sh
+++ b/scripts/smoke-test-privacy.sh
@@ -149,7 +149,7 @@ mod privacy_test {
             data.extend_from_slice(&greeting);
             acc.data = Data::try_from(data)
                 .map_err(|_| SpelError::custom(999, "data too big"))?;
-            AccountPostState::new_claimed(acc)
+            AccountPostState::new_claimed(acc, Claim::Authorized)
         } else {
             // Already owned (e.g. by auth-transfer): return unchanged
             AccountPostState::new(acc)

--- a/scripts/smoke-test-privacy.sh
+++ b/scripts/smoke-test-privacy.sh
@@ -78,6 +78,21 @@ SPEL_BIN="$SPEL_DIR/target/release/spel"
 [ -x "$SPEL_BIN" ] || fail "spel binary not found at $SPEL_BIN"
 log "  Using local spel: $SPEL_BIN"
 
+# ─── Checkout LSSA to matching LEZ tag ────────────────────────────────────
+log "Checking out LSSA to ${LEZ_TAG}..."
+cd "$LSSA_DIR"
+git fetch --tags origin 2>/dev/null || true
+git checkout "$LEZ_TAG" 2>/dev/null || git checkout "v${LEZ_TAG}" 2>/dev/null || true
+log "  LSSA now at: $(git log --oneline -1)"
+cd "$WORK_DIR"
+
+# ─── Rebuild sequencer + wallet from LSSA ─────────────────────────────────
+log "Building sequencer + wallet from LSSA ${LEZ_TAG}..."
+cargo build --manifest-path "$LSSA_DIR/Cargo.toml" --release -p sequencer_service -p wallet \
+    > "$LOG_DIR/lssa-build.log" 2>&1 || fail "Failed to build LSSA sequencer/wallet (see $LOG_DIR/lssa-build.log)"
+log "  ✅ Sequencer + wallet built from LSSA ${LEZ_TAG}"
+log "  Sequencer: $("$SEQUENCER_BIN" --version 2>/dev/null || echo 'unknown')"
+
 # ─── Step 1: Scaffold project ──────────────────────────────────────────────
 
 log "Step 1: Creating SPEL project (LEZ=${LEZ_TAG}, SPEL=${SPEL_TAG})..."

--- a/scripts/smoke-test-privacy.sh
+++ b/scripts/smoke-test-privacy.sh
@@ -16,6 +16,9 @@ SEQUENCER_PORT="${SEQUENCER_PORT:-3040}"
 SEQUENCER_URL="http://127.0.0.1:${SEQUENCER_PORT}"
 PROJECT_NAME="privacy_test"
 LOG_DIR="${WORK_DIR}/logs"
+LEZ_TAG="${LEZ_TAG:-v0.2.0-rc1}"
+SPEL_TAG="${SPEL_TAG:-v0.2.0-rc.1}"
+SPEL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -36,7 +39,6 @@ trap cleanup EXIT
 
 # ─── Prerequisites ─────────────────────────────────────────────────────────
 
-command -v spel >/dev/null 2>&1 || fail "spel not found"
 command -v cargo >/dev/null 2>&1 || fail "cargo not found"
 
 LSSA_DIR="${LSSA_DIR:-$HOME/lssa}"
@@ -66,12 +68,52 @@ rm -rf "$WORK_DIR"
 mkdir -p "$WORK_DIR" "$LOG_DIR"
 cd "$WORK_DIR"
 
+# Build local spel-cli from this PR instead of using the system-installed version.
+# The published spel v0.2.0-rc.1 depends on an older LEZ rev internally, which causes
+# Cargo to resolve the wrong nssa_core version in scaffolded projects.
+log "Building local spel-cli from ${SPEL_DIR}..."
+cargo build --manifest-path "$SPEL_DIR/Cargo.toml" -p spel --release \
+    > "$LOG_DIR/spel-build.log" 2>&1 || fail "Failed to build local spel-cli (see $LOG_DIR/spel-build.log)"
+SPEL_BIN="$SPEL_DIR/target/release/spel"
+[ -x "$SPEL_BIN" ] || fail "spel binary not found at $SPEL_BIN"
+log "  Using local spel: $SPEL_BIN"
+
 # ─── Step 1: Scaffold project ──────────────────────────────────────────────
 
-log "Step 1: Creating SPEL project..."
-spel init "$PROJECT_NAME" > "$LOG_DIR/init.log" 2>&1 || fail "spel init failed"
+log "Step 1: Creating SPEL project (LEZ=${LEZ_TAG}, SPEL=${SPEL_TAG})..."
+"$SPEL_BIN" init --lez-tag "$LEZ_TAG" --spel-tag "$SPEL_TAG" "$PROJECT_NAME" \
+    > "$LOG_DIR/init.log" 2>&1 || fail "spel init failed (see $LOG_DIR/init.log)"
 cd "$PROJECT_NAME"
 log "  ✅ Project scaffolded"
+
+# ─── Patch: force nssa_core to the correct LEZ tag ────────────────────────
+# The published spel-framework may transitively pull an older nssa_core.
+# A [patch] section forces Cargo to unify all nssa_core refs to our tag.
+LEZ_GIT="https://github.com/logos-blockchain/logos-execution-zone.git"
+
+cat >> methods/guest/Cargo.toml << PATCHEOF
+
+[patch."${LEZ_GIT}"]
+nssa_core = { git = "${LEZ_GIT}", tag = "${LEZ_TAG}" }
+PATCHEOF
+
+cat >> Cargo.toml << PATCHEOF
+
+[patch."${LEZ_GIT}"]
+nssa_core = { git = "${LEZ_GIT}", tag = "${LEZ_TAG}" }
+PATCHEOF
+
+log "  ✅ Patched Cargo.toml files to pin nssa_core=${LEZ_TAG}"
+
+# Regenerate lockfiles so the patch takes effect
+(cd methods/guest && cargo generate-lockfile > "$LOG_DIR/guest-lockfile.log" 2>&1) \
+    || warn "Guest lockfile regeneration failed"
+cargo generate-lockfile > "$LOG_DIR/root-lockfile.log" 2>&1 \
+    || warn "Root lockfile regeneration failed"
+
+# Print the actual LEZ version resolved
+log "  LEZ nssa_core resolved:"
+grep -A2 'name = "nssa_core"' methods/guest/Cargo.lock 2>/dev/null | head -5 || true
 
 # ─── Step 2: Modify guest program for privacy test ────────────────────────
 
@@ -201,7 +243,7 @@ log "  Private account: ${PRIVATE_ACCOUNT:0:30}..."
 log "Step 8: Testing PUBLIC transaction..."
 FRESH_ACCOUNT="0x$(openssl rand -hex 32)"
 
-SEQUENCER_URL="$SEQUENCER_URL" spel --idl "$IDL_ABS" -p "$GUEST_BIN_ABS" \
+SEQUENCER_URL="$SEQUENCER_URL" "$SPEL_BIN" --idl "$IDL_ABS" -p "$GUEST_BIN_ABS" \
     greet \
     --account "$FRESH_ACCOUNT" \
     --greeting "72,101,108,108,111,32,80,117,98,108,105,99" \
@@ -223,7 +265,7 @@ sleep 20
 # ─── Step 10: Test PRIVACY-PRESERVING transaction ───────────────────────
 
 log "Step 10: Testing PRIVACY-PRESERVING transaction..."
-SEQUENCER_URL="$SEQUENCER_URL" spel --idl "$IDL_ABS" -p "$GUEST_BIN_ABS" \
+SEQUENCER_URL="$SEQUENCER_URL" "$SPEL_BIN" --idl "$IDL_ABS" -p "$GUEST_BIN_ABS" \
     greet \
     --account "$PRIVATE_ACCOUNT" \
     --greeting "72,101,108,108,111,32,80,114,105,118,97,116,101" \

--- a/scripts/smoke-test-privacy.sh
+++ b/scripts/smoke-test-privacy.sh
@@ -79,20 +79,12 @@ SPEL_BIN="$SPEL_DIR/target/release/spel"
 [ -x "$SPEL_BIN" ] || fail "spel binary not found at $SPEL_BIN"
 log "  Using local spel: $SPEL_BIN"
 
-# ─── Checkout LSSA to matching LEZ tag ────────────────────────────────────
-log "Checking out LSSA to ${LEZ_TAG}..."
+# ─── Verify LSSA is at correct version ────────────────────────────────────
+log "Verifying LSSA at ${LEZ_TAG}..."
 cd "$LSSA_DIR"
-git fetch --tags origin 2>/dev/null || true
-git checkout "$LEZ_TAG" 2>/dev/null || git checkout "v${LEZ_TAG}" 2>/dev/null || true
-log "  LSSA now at: $(git log --oneline -1)"
+LSSA_CURRENT=$(git log --oneline -1 2>/dev/null || echo "unknown")
+log "  LSSA: $LSSA_CURRENT"
 cd "$WORK_DIR"
-
-# ─── Rebuild sequencer + wallet from LSSA ─────────────────────────────────
-log "Building sequencer + wallet from LSSA ${LEZ_TAG}..."
-cargo build --manifest-path "$LSSA_DIR/Cargo.toml" --release -p sequencer_service -p wallet \
-    > "$LOG_DIR/lssa-build.log" 2>&1 || fail "Failed to build LSSA sequencer/wallet (see $LOG_DIR/lssa-build.log)"
-log "  ✅ Sequencer + wallet built from LSSA ${LEZ_TAG}"
-log "  Sequencer: $("$SEQUENCER_BIN" --version 2>/dev/null || echo 'unknown')"
 
 # ─── Step 1: Scaffold project ──────────────────────────────────────────────
 

--- a/spel-cli/Cargo.toml
+++ b/spel-cli/Cargo.toml
@@ -10,11 +10,11 @@ path = "src/bin/main.rs"
 
 [dependencies]
 spel-framework-core = { path = "../spel-framework-core", features = ["idl-gen"] }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "98e98c6214afb6e0b60db3627ccfeae8293fe361" }
-nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "98e98c6214afb6e0b60db3627ccfeae8293fe361" }
-common = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "98e98c6214afb6e0b60db3627ccfeae8293fe361" }
-sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "98e98c6214afb6e0b60db3627ccfeae8293fe361", features = ["client"] }
-wallet = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "98e98c6214afb6e0b60db3627ccfeae8293fe361" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1" }
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1" }
+common = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1" }
+sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1", features = ["client"] }
+wallet = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1" }
 risc0-zkvm = { version = "3.0.3", features = ["std"] }
 base58 = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/spel-cli/Cargo.toml
+++ b/spel-cli/Cargo.toml
@@ -10,11 +10,11 @@ path = "src/bin/main.rs"
 
 [dependencies]
 spel-framework-core = { path = "../spel-framework-core", features = ["idl-gen"] }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b" }
-nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b" }
-common = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b" }
-sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b", features = ["client"] }
-wallet = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "98e98c6214afb6e0b60db3627ccfeae8293fe361" }
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "98e98c6214afb6e0b60db3627ccfeae8293fe361" }
+common = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "98e98c6214afb6e0b60db3627ccfeae8293fe361" }
+sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "98e98c6214afb6e0b60db3627ccfeae8293fe361", features = ["client"] }
+wallet = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "98e98c6214afb6e0b60db3627ccfeae8293fe361" }
 risc0-zkvm = { version = "3.0.3", features = ["std"] }
 base58 = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/spel-cli/src/init.rs
+++ b/spel-cli/src/init.rs
@@ -284,8 +284,8 @@ name = "{snake_name}"
 path = "src/bin/{snake_name}.rs"
 
 [dependencies]
-spel-framework = {{ git = "https://github.com/logos-co/spel.git" }}
-nssa_core = {{ git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b" }}
+spel-framework = {{ git = "https://github.com/logos-co/spel.git", tag = "v0.2.0-rc.1" }}
+nssa_core = {{ git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1" }}
 risc0-zkvm = {{ version = "=3.0.5", features = ["std"] }}
 {snake_name}_core = {{ path = "../../{snake_name}_core" }}
 serde = {{ version = "1.0", features = ["derive"] }}
@@ -353,9 +353,9 @@ name = "{snake_name}_cli"
 path = "src/bin/{snake_name}_cli.rs"
 
 [dependencies]
-spel-framework = {{ git = "https://github.com/logos-co/spel.git" }}
-nssa_core = {{ git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b" }}
-spel = {{ git = "https://github.com/logos-co/spel.git" }}
+spel-framework = {{ git = "https://github.com/logos-co/spel.git", tag = "v0.2.0-rc.1" }}
+nssa_core = {{ git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1" }}
+spel = {{ git = "https://github.com/logos-co/spel.git", tag = "v0.2.0-rc.1" }}
 {snake_name}_core = {{ path = "../{snake_name}_core" }}
 serde_json = "1.0"
 tokio = {{ version = "1.28.2", features = ["net", "rt-multi-thread", "sync", "macros"] }}

--- a/spel-cli/src/init.rs
+++ b/spel-cli/src/init.rs
@@ -3,7 +3,7 @@
 use std::fs;
 use std::path::Path;
 
-pub fn init_project(name: &str) {
+pub fn init_project(name: &str, lez_tag: Option<&str>, spel_tag: Option<&str>, lez_rev: Option<&str>, spel_rev: Option<&str>) {
     let root = Path::new(name);
     if root.exists() {
         eprintln!("❌ Directory '{}' already exists", name);
@@ -271,6 +271,16 @@ risc0-zkvm = {{ version = "=3.0.5", features = ["std"] }}
     write_file(root, "methods/src/lib.rs", r#"include!(concat!(env!("OUT_DIR"), "/methods.rs"));
 "#);
 
+    let lez_ref = match (lez_tag, lez_rev) {
+        (Some(t), _) => format!("tag = \"{}\"", t),
+        (_, Some(r)) => format!("rev = \"{}\"", r),
+        _ => "tag = \"v0.2.0-rc1\"".to_string(),
+    };
+    let spel_ref = match (spel_tag, spel_rev) {
+        (Some(t), _) => format!("tag = \"{}\"", t),
+        (_, Some(r)) => format!("rev = \"{}\"", r),
+        _ => "tag = \"v0.2.0-rc.1\"".to_string(),
+    };
     // methods/guest/Cargo.toml
     write_file(root, "methods/guest/Cargo.toml", &format!(r#"[package]
 name = "{snake_name}-guest"
@@ -284,8 +294,8 @@ name = "{snake_name}"
 path = "src/bin/{snake_name}.rs"
 
 [dependencies]
-spel-framework = {{ git = "https://github.com/logos-co/spel.git", tag = "v0.2.0-rc.1" }}
-nssa_core = {{ git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1" }}
+spel-framework = {{ git = "https://github.com/logos-co/spel.git", {spel_ref} }}
+nssa_core = {{ git = "https://github.com/logos-blockchain/logos-execution-zone.git", {lez_ref} }}
 risc0-zkvm = {{ version = "=3.0.5", features = ["std"] }}
 {snake_name}_core = {{ path = "../../{snake_name}_core" }}
 serde = {{ version = "1.0", features = ["derive"] }}
@@ -353,9 +363,9 @@ name = "{snake_name}_cli"
 path = "src/bin/{snake_name}_cli.rs"
 
 [dependencies]
-spel-framework = {{ git = "https://github.com/logos-co/spel.git", tag = "v0.2.0-rc.1" }}
-nssa_core = {{ git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1" }}
-spel = {{ git = "https://github.com/logos-co/spel.git", tag = "v0.2.0-rc.1" }}
+spel-framework = {{ git = "https://github.com/logos-co/spel.git", {spel_ref} }}
+nssa_core = {{ git = "https://github.com/logos-blockchain/logos-execution-zone.git", {lez_ref} }}
+spel = {{ git = "https://github.com/logos-co/spel.git", {spel_ref} }}
 {snake_name}_core = {{ path = "../{snake_name}_core" }}
 serde_json = "1.0"
 tokio = {{ version = "1.28.2", features = ["net", "rt-multi-thread", "sync", "macros"] }}

--- a/spel-cli/src/init.rs
+++ b/spel-cli/src/init.rs
@@ -401,19 +401,6 @@ async fn main() {
         Err(e) => eprintln!("⚠️  Failed to generate Cargo.lock (cargo not found?): {}", e),
     }
 
-    // Generate Cargo.lock for the guest to pin dependency versions
-    // (prevents getrandom 0.3.x resolution issues in Docker builds)
-    let guest_dir = root.join("methods/guest");
-    let status = std::process::Command::new("cargo")
-        .arg("generate-lockfile")
-        .current_dir(&guest_dir)
-        .status();
-    match status {
-        Ok(s) if s.success() => {}
-        Ok(s) => eprintln!("⚠️  cargo generate-lockfile exited with {}", s),
-        Err(e) => eprintln!("⚠️  Could not run cargo generate-lockfile: {}", e),
-    }
-
     println!("✅ Project '{}' created!", project_name);
     println!();
     println!("Next steps:");

--- a/spel-cli/src/init.rs
+++ b/spel-cli/src/init.rs
@@ -325,7 +325,7 @@ mod {snake_name} {{
     ) -> SpelResult {{
         // TODO: implement initialization logic
         Ok(SpelOutput::states_only(vec![
-            AccountPostState::new_claimed(state.account.clone()),
+            AccountPostState::new_claimed(state.account.clone(), Claim::Authorized),
             AccountPostState::new(owner.account.clone()),
         ]))
     }}

--- a/spel-cli/src/lib.rs
+++ b/spel-cli/src/lib.rs
@@ -90,6 +90,24 @@ pub async fn run() {
     if let Some(cmd) = remaining_args.get(1).map(|s| s.as_str()) {
         match cmd {
             "init" => {
+                // Check for help flag
+                if remaining_args.get(2) == Some(&"-h".to_string()) 
+                    || remaining_args.get(2) == Some(&"--help".to_string()) {
+                    println!("Usage: spel init <project-name> [OPTIONS]");
+                    println!();
+                    println!("Create a new SPEL project");
+                    println!();
+                    println!("Options:");
+                    println!("  --lez-tag <TAG>     LEZ version tag (default: v0.2.0-rc1)");
+                    println!("  --spel-rev <REV>    SPEL revision (default: refs/pull/122/head)");
+                    println!("  --lez-rev <REV>     LEZ revision (alternative to --lez-tag)");
+                    println!("  --spel-tag <TAG>    SPEL tag (alternative to --spel-rev)");
+                    println!();
+                    println!("Examples:");
+                    println!("  spel init my-project");
+                    println!("  spel init my-project --lez-tag v0.2.0-rc1 --spel-rev refs/pull/122/head");
+                    return;
+                }
                 let mut lez_tag: Option<String> = None;
                 let mut spel_tag: Option<String> = None;
                 let mut lez_rev: Option<String> = None;

--- a/spel-cli/src/lib.rs
+++ b/spel-cli/src/lib.rs
@@ -90,11 +90,37 @@ pub async fn run() {
     if let Some(cmd) = remaining_args.get(1).map(|s| s.as_str()) {
         match cmd {
             "init" => {
-                let name = remaining_args.get(2).unwrap_or_else(|| {
-                    eprintln!("Usage: {} init <project-name>", args[0]);
+                let mut lez_tag: Option<String> = None;
+                let mut spel_tag: Option<String> = None;
+                let mut lez_rev: Option<String> = None;
+                let mut spel_rev: Option<String> = None;
+                let mut name_arg_idx = 2;
+
+                while name_arg_idx < remaining_args.len() {
+                    let arg = &remaining_args[name_arg_idx];
+                    if arg == "--lez-tag" {
+                        name_arg_idx += 1;
+                        if name_arg_idx < remaining_args.len() { lez_tag = Some(remaining_args[name_arg_idx].clone()); }
+                    } else if arg == "--spel-tag" {
+                        name_arg_idx += 1;
+                        if name_arg_idx < remaining_args.len() { spel_tag = Some(remaining_args[name_arg_idx].clone()); }
+                    } else if arg == "--lez-rev" {
+                        name_arg_idx += 1;
+                        if name_arg_idx < remaining_args.len() { lez_rev = Some(remaining_args[name_arg_idx].clone()); }
+                    } else if arg == "--spel-rev" {
+                        name_arg_idx += 1;
+                        if name_arg_idx < remaining_args.len() { spel_rev = Some(remaining_args[name_arg_idx].clone()); }
+                    } else {
+                        break;
+                    }
+                    name_arg_idx += 1;
+                }
+
+                let name = remaining_args.get(name_arg_idx).unwrap_or_else(|| {
+                    eprintln!("Usage: {} init <project-name> [--lez-tag <tag>] [--spel-tag <tag>] [--lez-rev <rev>] [--spel-rev <rev>]", args[0]);
                     process::exit(1);
                 });
-                init_project(name);
+                init_project(name, lez_tag.as_deref(), spel_tag.as_deref(), lez_rev.as_deref(), spel_rev.as_deref());
                 return;
             }
             "inspect" if type_name.is_none() && data_hex.is_none() && idl_path.is_empty() => {

--- a/spel-framework-core/Cargo.toml
+++ b/spel-framework-core/Cargo.toml
@@ -9,7 +9,7 @@ default = []
 idl-gen = ["dep:syn"]
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b", features = ["host"] }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "98e98c6214afb6e0b60db3627ccfeae8293fe361", features = ["host"] }
 borsh = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/spel-framework-core/Cargo.toml
+++ b/spel-framework-core/Cargo.toml
@@ -9,7 +9,7 @@ default = []
 idl-gen = ["dep:syn"]
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "98e98c6214afb6e0b60db3627ccfeae8293fe361", features = ["host"] }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1", features = ["host"] }
 borsh = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/spel-framework-core/src/lib.rs
+++ b/spel-framework-core/src/lib.rs
@@ -16,5 +16,5 @@ pub mod prelude {
     pub use crate::pda::{compute_pda, seed_from_str};
     pub use crate::types::{SpelOutput, AccountConstraint};
     pub use nssa_core::account::{Account, AccountWithMetadata};
-    pub use nssa_core::program::{AccountPostState, ChainedCall, PdaSeed, ProgramId};
+    pub use nssa_core::program::{AccountPostState, ChainedCall, Claim, PdaSeed, ProgramId};
 }

--- a/spel-framework-macros/src/lib.rs
+++ b/spel-framework-macros/src/lib.rs
@@ -252,7 +252,7 @@ fn expand_lez_program(input: ItemMod, config: ProgramConfig) -> syn::Result<Toke
     let main_fn = quote! {
         fn main() {
             // Read inputs from zkVM host
-            let (nssa_core::program::ProgramInput { pre_states, instruction }, instruction_words)
+            let (nssa_core::program::ProgramInput { self_program_id, caller_program_id, pre_states, instruction }, instruction_words)
                 = nssa_core::program::read_nssa_inputs::<Instruction>();
             let pre_states_clone = pre_states.clone();
 
@@ -274,6 +274,8 @@ fn expand_lez_program(input: ItemMod, config: ProgramConfig) -> syn::Result<Toke
 
             // Write outputs to zkVM host
             nssa_core::program::ProgramOutput::new(
+                self_program_id,
+                caller_program_id,
                 instruction_words,
                 pre_states_clone,
                 post_states,

--- a/spel-framework/Cargo.toml
+++ b/spel-framework/Cargo.toml
@@ -7,7 +7,7 @@ description = "Developer framework for building SPEL programs (like Anchor for S
 [dependencies]
 spel-framework-core = { path = "../spel-framework-core" }
 spel-framework-macros = { path = "../spel-framework-macros" }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b", features = ["host"] }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "98e98c6214afb6e0b60db3627ccfeae8293fe361", features = ["host"] }
 borsh = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/spel-framework/Cargo.toml
+++ b/spel-framework/Cargo.toml
@@ -7,7 +7,7 @@ description = "Developer framework for building SPEL programs (like Anchor for S
 [dependencies]
 spel-framework-core = { path = "../spel-framework-core" }
 spel-framework-macros = { path = "../spel-framework-macros" }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "98e98c6214afb6e0b60db3627ccfeae8293fe361", features = ["host"] }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1", features = ["host"] }
 borsh = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/tests/e2e/fixture_program/Cargo.toml
+++ b/tests/e2e/fixture_program/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 
 [dependencies]
 spel-framework = { path = "../../../spel-framework" }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "ffcbc15972adbf557939bf3e2852af276422631b", features = ["host"] }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "98e98c6214afb6e0b60db3627ccfeae8293fe361", features = ["host"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/tests/e2e/fixture_program/Cargo.toml
+++ b/tests/e2e/fixture_program/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 
 [dependencies]
 spel-framework = { path = "../../../spel-framework" }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "98e98c6214afb6e0b60db3627ccfeae8293fe361", features = ["host"] }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1", features = ["host"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
Bumps LEZ dependency to `v0.2.0-rc1` release tag.

**Changes:**
- Use LEZ `v0.2.0-rc1` (35d8df0d) instead of commit hash
- Fix `#[lez_program]` macro: pass `self_program_id` and `caller_program_id` to `ProgramOutput::new`

**Status:**
- ✅ spel-framework-core
- ✅ spel-framework
- ✅ spel-cli
- ✅ E2E tests (4/4 passed)