### PR TITLE
fix(cli): parse PDA seed args through IDL type system

### DIFF
--- a/spel-cli/src/lib.rs
+++ b/spel-cli/src/lib.rs
@@ -340,14 +340,16 @@ fn compute_pda_command(idl: &SpelIdl, program_path: &str, program_id_hex: Option
         }
     };
 
-    // Find account definition with PDA seeds
-    let pda_def = idl.instructions.iter()
-        .flat_map(|ix| &ix.accounts)
-        .find(|acc| acc.name == account_name || snake_to_kebab(&acc.name) == account_name)
-        .and_then(|acc| acc.pda.as_ref());
+    // Find account definition with PDA seeds and its owning instruction
+    let found = idl.instructions.iter()
+        .find_map(|ix| {
+            ix.accounts.iter()
+                .find(|acc| acc.name == account_name || snake_to_kebab(&acc.name) == account_name)
+                .and_then(|acc| acc.pda.as_ref().map(|pda| (ix, pda)))
+        });
 
-    let pda_def = match pda_def {
-        Some(p) => p,
+    let (owning_ix, pda_def) = match found {
+        Some(pair) => pair,
         None => {
             eprintln!("❌ No PDA account named '{}' found in IDL", account_name);
             eprintln!("   Available PDAs:");
@@ -362,19 +364,30 @@ fn compute_pda_command(idl: &SpelIdl, program_path: &str, program_id_hex: Option
         }
     };
 
-    // Parse --key value pairs from remaining args
+    // Build a map from arg name to IDL type using the owning instruction's args
+    let arg_types: HashMap<&str, &spel_framework_core::idl::IdlType> = owning_ix
+        .args
+        .iter()
+        .map(|a| (a.name.as_str(), &a.type_))
+        .collect();
+
+    // Parse --key value pairs from remaining args, using IDL types when available
     let mut seed_args: HashMap<String, ParsedValue> = HashMap::new();
     let mut i = 1;
     while i < args.len() {
         if let Some(key) = args[i].strip_prefix("--") {
             if i + 1 < args.len() {
                 let raw = &args[i + 1];
-                // Try to parse as string (covers bytes32, u64, etc via parse_value)
-                // Use Raw as fallback — seed resolution handles Str type
-                seed_args.insert(
-                    key.replace('-', "_").to_string(),
-                    ParsedValue::Str(raw.clone()),
-                );
+                let arg_name = key.replace('-', "_");
+                let parsed = if let Some(ty) = arg_types.get(arg_name.as_str()) {
+                    parse::parse_value(raw, ty).unwrap_or_else(|e| {
+                        eprintln!("⚠️  Failed to parse --{} as {}: {}", key, format!("{:?}", ty), e);
+                        ParsedValue::Str(raw.clone())
+                    })
+                } else {
+                    ParsedValue::Str(raw.clone())
+                };
+                seed_args.insert(arg_name, parsed);
                 i += 2;
             } else {
                 eprintln!("❌ Missing value for --{}", key);

--- a/spel-cli/src/parse.rs
+++ b/spel-cli/src/parse.rs
@@ -207,3 +207,51 @@ fn parse_vec(raw: &str, elem_type: &IdlType) -> Result<ParsedValue, String> {
         _ => Ok(ParsedValue::Raw(raw.to_string())),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spel_framework_core::idl::IdlType;
+
+    #[test]
+    fn pda_seed_from_bytes32_arg() {
+        // Simulate what happens when IDL has a [u8; 32] arg used as a PDA seed:
+        // 1. IDL declares arg type as Array { array: (Primitive("u8"), 32) }
+        // 2. User passes hex string on CLI
+        // 3. parse_value should produce ParsedValue::ByteArray(...)
+        // 4. PDA resolver should extract the 32 bytes as seed material
+
+        let idl_type = IdlType::Array {
+            array: (Box::new(IdlType::Primitive("u8".to_string())), 32),
+        };
+
+        let hex_input = "4343434343434343434343434343434343434343434343434343434343434343";
+        let parsed = parse_value(hex_input, &idl_type).expect("should parse [u8; 32] from hex");
+
+        // Must be ByteArray, not Raw — Raw causes PDA computation to fail
+        match &parsed {
+            ParsedValue::ByteArray(bytes) => {
+                assert_eq!(bytes.len(), 32);
+                assert_eq!(bytes[0], 0x43);
+            }
+            other => panic!("expected ByteArray, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn primitive_bytes32_string_does_not_parse_as_byte_array() {
+        // This is the bug: the macro emits Primitive("[u8; 32]") which
+        // falls through to Raw instead of being parsed as a byte array.
+        // This test documents the broken behavior that the macro fix addresses.
+        let buggy_type = IdlType::Primitive("[u8; 32]".to_string());
+
+        let hex_input = "4343434343434343434343434343434343434343434343434343434343434343";
+        let parsed = parse_value(hex_input, &buggy_type).expect("should not error");
+
+        // With Primitive("[u8; 32]"), parse_primitive doesn't recognize it → Raw
+        assert!(
+            matches!(&parsed, ParsedValue::Raw(_)),
+            "Primitive('[u8; 32]') should fall through to Raw, got {:?}", parsed
+        );
+    }
+}

--- a/spel-cli/src/serialize.rs
+++ b/spel-cli/src/serialize.rs
@@ -147,3 +147,165 @@ fn serialize_bytes_padded(out: &mut Vec<u32>, bytes: &[u8]) {
         i += 4;
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spel_framework_core::idl::IdlType;
+    use crate::parse::parse_value;
+    use risc0_zkvm::serde::Deserializer;
+    use serde::Deserialize;
+
+    #[test]
+    fn serialize_bytes32_one_word_per_byte() {
+        // risc0 serde format: each u8 is its own u32 word (zero-extended).
+        // A [u8; 32] produces 32 u32 words, NOT 8 packed words.
+        let idl_type = IdlType::Array {
+            array: (Box::new(IdlType::Primitive("u8".to_string())), 32),
+        };
+
+        let parsed = parse_value(
+            "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+            &idl_type,
+        ).unwrap();
+
+        let words = serialize_to_risc0(0, &[(&idl_type, &parsed)]);
+
+        // words[0] = variant index, words[1..33] = 32 individual u8-as-u32 words
+        let payload = &words[1..];
+        assert_eq!(payload.len(), 32, "expected 32 u32 words for [u8; 32]");
+        assert_eq!(payload[0], 0x01);
+        assert_eq!(payload[1], 0x02);
+        assert_eq!(payload[31], 0x20);
+    }
+
+    #[test]
+    fn serialize_vec_u8_one_word_per_byte() {
+        // Vec<u8> in risc0 serde: length prefix + one u32 word per byte.
+        let elem_type = IdlType::Primitive("u8".to_string());
+        let idl_type = IdlType::Vec { vec: Box::new(elem_type) };
+
+        let bytes = ParsedValue::ByteArray(vec![0x3b, 0x50, 0x9c, 0x40]);
+
+        let words = serialize_to_risc0(0, &[(&idl_type, &bytes)]);
+
+        // words[0] = variant index, words[1] = length (4), words[2..6] = bytes as u32
+        let payload = &words[1..];
+        assert_eq!(payload[0], 4, "length prefix");
+        assert_eq!(payload.len(), 5, "1 length + 4 bytes");
+        assert_eq!(payload[1], 0x3b);
+        assert_eq!(payload[2], 0x50);
+    }
+
+    #[test]
+    fn serialize_vec_byte_array_one_word_per_byte() {
+        // Vec<[u8; 4]>: vec length prefix, then each element's bytes as individual words.
+        let inner = IdlType::Array {
+            array: (Box::new(IdlType::Primitive("u8".to_string())), 4),
+        };
+        let idl_type = IdlType::Vec { vec: Box::new(inner) };
+
+        let bytes = ParsedValue::ByteArrayVec(vec![
+            vec![0x3b, 0x50, 0x9c, 0x40],
+            vec![0x61, 0x13, 0x01, 0xf7],
+        ]);
+
+        let words = serialize_to_risc0(0, &[(&idl_type, &bytes)]);
+
+        // words[0] = variant, words[1] = vec len (2), words[2..6] = elem0, words[6..10] = elem1
+        let payload = &words[1..];
+        assert_eq!(payload[0], 2, "vec length");
+        assert_eq!(payload.len(), 9, "1 length + 2*4 bytes");
+        assert_eq!(payload[1], 0x3b);
+        assert_eq!(payload[5], 0x61);
+    }
+
+    /// Verify risc0's own serializer as the reference for [u8; 32] format.
+    #[test]
+    fn risc0_reference_bytes32_format() {
+        let seed: [u8; 32] = [
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+            0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+            0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+            0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+        ];
+
+        #[derive(serde::Serialize)]
+        enum TestInstruction {
+            CommitRun { seed: [u8; 32], class: u8, strength: u32 },
+        }
+
+        let reference = risc0_zkvm::serde::to_vec(
+            &TestInstruction::CommitRun { seed, class: 2, strength: 42 }
+        ).unwrap();
+
+        // Each u8 is its own u32 word (not packed)
+        // word[0] = variant index (0)
+        // word[1..33] = 32 u8 values, each as u32
+        // word[33] = class (2)
+        // word[34] = strength (42)
+        assert_eq!(reference.len(), 35, "expected 35 words: 1 variant + 32 seed + 1 class + 1 strength");
+        assert_eq!(reference[0], 0, "variant index");
+        assert_eq!(reference[1], 0x01, "seed[0]");
+        assert_eq!(reference[2], 0x02, "seed[1]");
+        assert_eq!(reference[33], 2, "class");
+        assert_eq!(reference[34], 42, "strength");
+    }
+
+    /// Verifies spel CLI's serialization is compatible with the guest-side
+    /// Deserializer from risc0_zkvm (used by nssa_core::program::read_nssa_inputs).
+    /// This is the contract between the CLI (transaction sender) and the
+    /// on-chain program (transaction executor) at LEZ v0.2.0-rc1.
+    #[test]
+    fn serialize_deserialize_roundtrip_with_bytes32() {
+        #[derive(Deserialize, Debug, PartialEq)]
+        enum TestInstruction {
+            CommitRun {
+                seed: [u8; 32],
+                class: u8,
+                strength: u32,
+            },
+        }
+
+        // 1. Define IDL arg types matching the enum variant fields
+        let seed_type = IdlType::Array {
+            array: (Box::new(IdlType::Primitive("u8".into())), 32),
+        };
+        let class_type = IdlType::Primitive("u8".into());
+        let strength_type = IdlType::Primitive("u32".into());
+
+        // 2. Parse CLI values exactly as spel would
+        let seed_hex = "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20";
+        let parsed_seed = parse_value(seed_hex, &seed_type).unwrap();
+        let parsed_class = parse_value("2", &class_type).unwrap();
+        let parsed_strength = parse_value("42", &strength_type).unwrap();
+
+        // 3. Serialize to u32 words (variant_index=0 for CommitRun)
+        let words = serialize_to_risc0(0, &[
+            (&seed_type, &parsed_seed),
+            (&class_type, &parsed_class),
+            (&strength_type, &parsed_strength),
+        ]);
+
+        // 4. Deserialize using risc0's Deserializer — the SAME code the guest runs
+        let instruction: TestInstruction =
+            TestInstruction::deserialize(&mut Deserializer::new(words.as_ref()))
+                .expect("guest-side deserialization must succeed");
+
+        // 5. Assert values survived the roundtrip
+        let expected_seed: [u8; 32] = [
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+            0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+            0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+            0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+        ];
+        assert_eq!(
+            instruction,
+            TestInstruction::CommitRun {
+                seed: expected_seed,
+                class: 2,
+                strength: 42,
+            }
+        );
+    }
+}

--- a/spel-framework-macros/src/lib.rs
+++ b/spel-framework-macros/src/lib.rs
@@ -754,40 +754,84 @@ fn to_pascal_case(ident: &Ident) -> Ident {
 
 // ─── IDL type conversion ─────────────────────────────────────────────────
 
-fn rust_type_to_idl_string(ty: &Type) -> String {
+/// Convert a Rust `syn::Type` to a `TokenStream` that constructs the correct `IdlType` variant.
+/// Used by `generate_idl_fn` to emit structured types (Array, Vec, Option) instead of
+/// flattening everything to `IdlType::Primitive(string)`.
+fn rust_type_to_idl_type_tokens(ty: &Type) -> proc_macro2::TokenStream {
     match ty {
         Type::Path(type_path) => {
             let segment = type_path.path.segments.last().unwrap();
             let ident = segment.ident.to_string();
             match ident.as_str() {
                 "u8" | "u16" | "u32" | "u64" | "u128" | "i8" | "i16" | "i32" | "i64"
-                | "i128" | "bool" | "String" => ident.to_lowercase(),
+                | "i128" | "bool" | "String" => {
+                    let name = ident.to_lowercase();
+                    quote! { spel_framework::idl::IdlType::Primitive(#name.to_string()) }
+                }
                 "Vec" => {
                     if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
                         if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
-                            format!("vec<{}>", rust_type_to_idl_string(inner))
+                            let inner_tokens = rust_type_to_idl_type_tokens(inner);
+                            quote! {
+                                spel_framework::idl::IdlType::Vec {
+                                    vec: Box::new(#inner_tokens)
+                                }
+                            }
                         } else {
-                            "vec<unknown>".to_string()
+                            quote! { spel_framework::idl::IdlType::Primitive("vec<unknown>".to_string()) }
                         }
                     } else {
-                        "vec<unknown>".to_string()
+                        quote! { spel_framework::idl::IdlType::Primitive("vec<unknown>".to_string()) }
                     }
                 }
-                "ProgramId" => "program_id".to_string(),
-                "AccountId" => "account_id".to_string(),
-                other => other.to_string(),
+                "Option" => {
+                    if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
+                        if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
+                            let inner_tokens = rust_type_to_idl_type_tokens(inner);
+                            quote! {
+                                spel_framework::idl::IdlType::Option {
+                                    option: Box::new(#inner_tokens)
+                                }
+                            }
+                        } else {
+                            quote! { spel_framework::idl::IdlType::Primitive("option<unknown>".to_string()) }
+                        }
+                    } else {
+                        quote! { spel_framework::idl::IdlType::Primitive("option<unknown>".to_string()) }
+                    }
+                }
+                "ProgramId" => {
+                    quote! { spel_framework::idl::IdlType::Primitive("program_id".to_string()) }
+                }
+                "AccountId" => {
+                    quote! { spel_framework::idl::IdlType::Primitive("account_id".to_string()) }
+                }
+                other => {
+                    let name = other.to_string();
+                    quote! { spel_framework::idl::IdlType::Defined { defined: #name.to_string() } }
+                }
             }
         }
         Type::Array(arr) => {
-            let elem = rust_type_to_idl_string(&arr.elem);
+            let elem_tokens = rust_type_to_idl_type_tokens(&arr.elem);
             if let syn::Expr::Lit(lit) = &arr.len {
                 if let syn::Lit::Int(n) = &lit.lit {
-                    return format!("[{}; {}]", elem, n);
+                    let size: usize = n.base10_parse().unwrap_or(0);
+                    quote! {
+                        spel_framework::idl::IdlType::Array {
+                            array: (Box::new(#elem_tokens), #size)
+                        }
+                    }
+                } else {
+                    quote! { spel_framework::idl::IdlType::Primitive("unknown".to_string()) }
                 }
+            } else {
+                quote! { spel_framework::idl::IdlType::Primitive("unknown".to_string()) }
             }
-            format!("[{}; ?]", elem)
         }
-        _ => "unknown".to_string(),
+        _ => {
+            quote! { spel_framework::idl::IdlType::Primitive("unknown".to_string()) }
+        }
     }
 }
 
@@ -907,11 +951,11 @@ fn generate_idl_fn(mod_name: &Ident, instructions: &[InstructionInfo], external_
                 .iter()
                 .map(|arg| {
                     let arg_name = arg.name.to_string().trim_start_matches('_').to_string();
-                    let type_str = rust_type_to_idl_string(&arg.ty);
+                    let type_tokens = rust_type_to_idl_type_tokens(&arg.ty);
                     quote! {
                         spel_framework::idl::IdlArg {
                             name: #arg_name.to_string(),
-                            type_: spel_framework::idl::IdlType::Primitive(#type_str.to_string()),
+                            type_: #type_tokens,
                         }
                     }
                 })


### PR DESCRIPTION
## Summary

- **fix(cli): parse PDA seed args through IDL type system** — `compute_pda_command` stored all seed args as `ParsedValue::Str(raw)` instead of routing through `parse_value()` with the IDL type. This meant `[u8; 32]` args were never parsed as `ByteArray`, producing wrong PDA hashes and "type mismatch in risc0 serialization" warnings.
- **fix(macros): emit structured IdlType variants** — `generate_idl_fn` wrapped every arg type in `IdlType::Primitive(string)`, so `[u8; 32]` became `Primitive("[u8; 32]")` instead of `Array{Primitive("u8"), 32}`. This caused `parse_value` to miss the Array dispatch, producing Raw values that broke PDA seed computation.
- **test(cli): add risc0 serde roundtrip tests** — Verified that spel's serialization matches the risc0 serde contract used by `nssa_core::program::read_nssa_inputs` at LEZ v0.2.0-rc1. Key finding: risc0 serializes each `u8` as its own `u32` word (zero-extended), not packed 4-per-word. The roundtrip test deserializes spel's output using `risc0_zkvm::serde::Deserializer` (the same code the guest runs) to prove on-chain compatibility.

## Test plan

- [x] Run `cargo +nightly build -p spel` — confirms compilation
- [x] Run `cargo test -p spel-framework-core` — existing PDA tests pass
- [x] Run `cargo +nightly test -p spel` — all 31 tests pass including 5 new serialization tests
- [x] Roundtrip test: spel serialize → risc0 Deserializer → assert values match (proves on-chain compat)
- [x] Manual: `spel pda <account> --<byte-array-arg> <64-char-hex>` produces correct PDA (no serialization warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)