### PR TITLE
feat(spel): enhance --dry-run with full tx summary and JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,12 +236,18 @@ spel inspect <account-id> --idl my_program-idl.json --type VaultState --data <bo
 # Show available commands
 spel --idl program-idl.json --help
 
-# Dry run an instruction
-spel --idl program-idl.json --dry-run -p program.bin \
+# Dry run an instruction — resolve everything (PDAs, accounts, serialized data,
+# signer nonces) and print without submitting. Accepts --dry-run (text default),
+# --dry-run=text, or --dry-run=json.
+spel --idl program-idl.json --dry-run -p program.bin -- \
   create-vault --token-name "MYTKN" --initial-supply 1000000
 
+# Machine-readable dry run for scripting / golden tests
+spel --idl program-idl.json --dry-run=json -p program.bin -- \
+  create-vault --token-name "MYTKN" --initial-supply 1000000 | jq .
+
 # Submit a transaction
-spel --idl program-idl.json -p program.bin \
+spel --idl program-idl.json -p program.bin -- \
   create-vault --token-name "MYTKN" --initial-supply 1000000
 
 # Use --program-id instead of binary (skips loading the file)

--- a/spel-cli/src/cli.rs
+++ b/spel-cli/src/cli.rs
@@ -16,7 +16,7 @@ pub fn print_help(idl: &SpelIdl, binary_name: &str) {
     println!("  -p, --program <NAME|HEX|FILE>");
     println!("                             Program name from spel.toml, 64-char hex program ID,");
     println!("                             or path to program binary (or set in spel.toml)");
-    println!("  --dry-run                  Print parsed/serialized data without submitting");
+    println!("  --dry-run[=text|json]      Resolve & print transaction without submitting (text default)");
     println!("  --bin-<NAME> <FILE>        Additional program binary (auto-fills --<NAME>-program-id)");
     println!();
     println!("COMMANDS:");

--- a/spel-cli/src/lib.rs
+++ b/spel-cli/src/lib.rs
@@ -45,7 +45,8 @@ pub async fn run() {
 
     let mut idl_path = String::new();
     let mut program_ref: Option<String> = None; // raw --program value
-    let mut dry_run = false;
+    // None = submit, Some("text") = dry-run text summary, Some("json") = dry-run JSON
+    let mut dry_run: Option<String> = None;
     let mut type_name: Option<String> = None;
     let mut data_hex: Option<String> = None;
     let mut extra_bins: HashMap<String, String> = HashMap::new();
@@ -82,7 +83,15 @@ pub async fn run() {
                 i += 1;
                 if i < args.len() { data_hex = Some(args[i].clone()); }
             }
-            "--dry-run" => { dry_run = true; }
+            "--dry-run" => { dry_run = Some("text".to_string()); }
+            s if s.starts_with("--dry-run=") => {
+                let fmt = &s["--dry-run=".len()..];
+                if fmt != "text" && fmt != "json" {
+                    eprintln!("❌ --dry-run=<fmt>: expected 'text' or 'json', got '{}'", fmt);
+                    process::exit(1);
+                }
+                dry_run = Some(fmt.to_string());
+            }
             s if s.starts_with("--bin-") => {
                 let name = s.strip_prefix("--bin-").unwrap().to_string();
                 i += 1;
@@ -372,7 +381,7 @@ pub async fn run() {
                     }
                     let cli_args = parse_instruction_args(&remaining_args[2..], ix);
                     execute_instruction(
-                        &idl, ix, &cli_args, program_path.as_deref(), program_id_hex.as_deref(), dry_run, &extra_bins,
+                        &idl, ix, &cli_args, program_path.as_deref(), program_id_hex.as_deref(), dry_run.as_deref(), &extra_bins,
                     ).await;
                 }
                 None => {

--- a/spel-cli/src/lib.rs
+++ b/spel-cli/src/lib.rs
@@ -45,8 +45,7 @@ pub async fn run() {
 
     let mut idl_path = String::new();
     let mut program_ref: Option<String> = None; // raw --program value
-    // None = submit, Some("text") = dry-run text summary, Some("json") = dry-run JSON
-    let mut dry_run: Option<String> = None;
+    let mut dry_run: Option<tx::DryRunFormat> = None;
     let mut type_name: Option<String> = None;
     let mut data_hex: Option<String> = None;
     let mut extra_bins: HashMap<String, String> = HashMap::new();
@@ -83,14 +82,16 @@ pub async fn run() {
                 i += 1;
                 if i < args.len() { data_hex = Some(args[i].clone()); }
             }
-            "--dry-run" => { dry_run = Some("text".to_string()); }
+            "--dry-run" => { dry_run = Some(tx::DryRunFormat::Text); }
             s if s.starts_with("--dry-run=") => {
-                let fmt = &s["--dry-run=".len()..];
-                if fmt != "text" && fmt != "json" {
-                    eprintln!("❌ --dry-run=<fmt>: expected 'text' or 'json', got '{}'", fmt);
-                    process::exit(1);
-                }
-                dry_run = Some(fmt.to_string());
+                dry_run = Some(match &s["--dry-run=".len()..] {
+                    "text" => tx::DryRunFormat::Text,
+                    "json" => tx::DryRunFormat::Json,
+                    other => {
+                        eprintln!("❌ --dry-run=<fmt>: expected 'text' or 'json', got '{}'", other);
+                        process::exit(1);
+                    }
+                });
             }
             s if s.starts_with("--bin-") => {
                 let name = s.strip_prefix("--bin-").unwrap().to_string();
@@ -381,7 +382,7 @@ pub async fn run() {
                     }
                     let cli_args = parse_instruction_args(&remaining_args[2..], ix);
                     execute_instruction(
-                        &idl, ix, &cli_args, program_path.as_deref(), program_id_hex.as_deref(), dry_run.as_deref(), &extra_bins,
+                        &idl, ix, &cli_args, program_path.as_deref(), program_id_hex.as_deref(), dry_run, &extra_bins,
                     ).await;
                 }
                 None => {

--- a/spel-cli/src/tx.rs
+++ b/spel-cli/src/tx.rs
@@ -1,6 +1,24 @@
 //! Transaction building and submission.
 
 use std::collections::HashMap;
+use std::fs;
+use std::process;
+use nssa::program::Program;
+use nssa::public_transaction::{Message, WitnessSet};
+use nssa::{AccountId, PublicTransaction};
+use nssa_core::program::ProgramId;
+use nssa_core::account::Nonce;
+use spel_framework_core::idl::{IdlSeed, SpelIdl, IdlInstruction};
+use crate::hex::{hex_encode, decode_bytes_32, parse_account_id};
+use crate::parse::{parse_value, ParsedValue};
+use crate::serialize::serialize_to_risc0;
+use crate::pda::compute_pda_from_seeds;
+use crate::cli::{snake_to_kebab, to_pascal_case};
+use common::transaction::NSSATransaction;
+use hex;
+use sequencer_service_rpc::RpcClient as _;
+use serde_json::{json, Value};
+use wallet::WalletCore;
 
 /// Format PDA seeds into a display string for human-readable output.
 /// E.g. `[program_id, "owner", Account(vault)]`
@@ -15,35 +33,27 @@ fn format_pda_seeds(seeds: &[IdlSeed]) -> String {
     format!("[{}]", parts.join(", "))
 }
 
-use crate::cli::{snake_to_kebab, to_pascal_case};
-use crate::hex::{decode_bytes_32, hex_encode, parse_account_id};
-use crate::parse::{parse_value, ParsedValue};
-use crate::pda::compute_pda_from_seeds;
-use crate::serialize::serialize_to_risc0;
-use common::transaction::NSSATransaction;
-use hex;
-use nssa::program::Program;
-use nssa::public_transaction::{Message, WitnessSet};
-use nssa::{AccountId, PublicTransaction};
-use nssa_core::program::ProgramId;
-use sequencer_service_rpc::RpcClient as _;
-use spel_framework_core::idl::{IdlInstruction, IdlSeed, SpelIdl};
-use std::fs;
-use std::process;
-use wallet::WalletCore;
-
 /// Execute an instruction: parse args, build TX, optionally submit.
+///
+/// `dry_run`:
+///   - `None`             — submit to the sequencer
+///   - `Some("text")`     — resolve & print human-readable summary, do not submit
+///   - `Some("json")`     — resolve & emit JSON to stdout, do not submit
 pub async fn execute_instruction(
     idl: &SpelIdl,
     ix: &IdlInstruction,
     args: &HashMap<String, String>,
     program_path: Option<&str>,
     program_id_hex: Option<&str>,
-    dry_run: bool,
+    dry_run: Option<&str>,
     extra_bins: &HashMap<String, String>,
 ) {
-    println!("📋 Instruction: {}", ix.name);
-    println!();
+    // In JSON dry-run mode, suppress all human-readable preamble — only emit JSON to stdout.
+    let json_mode = dry_run == Some("json");
+    macro_rules! info { ($($arg:tt)*) => { if !json_mode { println!($($arg)*); } } }
+
+    info!("📋 Instruction: {}", ix.name);
+    info!("");
 
     let mut args = args.clone();
 
@@ -55,7 +65,7 @@ pub async fn execute_instruction(
                     let id = program.id();
                     let id_str: Vec<String> = id.iter().map(|w| w.to_string()).collect();
                     let val = id_str.join(",");
-                    println!("  ℹ️  Auto-filled --{} from {}", key, bin_path);
+                    info!("  ℹ️  Auto-filled --{} from {}", key, bin_path);
                     args.insert(key.clone(), val);
                 }
             }
@@ -92,10 +102,7 @@ pub async fn execute_instruction(
         let raw = args.get(&key).unwrap();
         match parse_value(raw, &arg.type_) {
             Ok(val) => parsed_args.push((&arg.name, &arg.type_, val)),
-            Err(e) => {
-                eprintln!("❌ --{}: {}", key, e);
-                has_errors = true;
-            }
+            Err(e) => { eprintln!("❌ --{}: {}", key, e); has_errors = true; }
         }
     }
 
@@ -104,15 +111,7 @@ pub async fn execute_instruction(
     // rest accounts are variadic: each expands to 0 or more AccountIds
     let mut rest_accounts: Vec<(&str, Vec<(Vec<u8>, bool)>)> = Vec::new();
     for acc in &ix.accounts {
-        if acc.pda.is_some() {
-            continue;
-        }
-        if acc.rest {
-            let key = snake_to_kebab(&acc.name);
-            if !args.contains_key(&key) {
-                continue;
-            }
-        }
+        if acc.pda.is_some() { continue; }
         let key = snake_to_kebab(&acc.name);
         if acc.rest {
             // variadic: optional, comma-separated list of account IDs (0 entries is valid)
@@ -120,12 +119,10 @@ pub async fn execute_instruction(
                 raw.split(',')
                     .map(|s| s.trim())
                     .filter(|s| !s.is_empty())
-                    .map(|s| match parse_account_id(s) {
-                        Ok((bytes, is_priv)) => (bytes.to_vec(), is_priv),
-                        Err(e) => {
-                            eprintln!("❌ --{}: {}", key, e);
-                            has_errors = true;
-                            (vec![], false)
+                    .map(|s| {
+                        match parse_account_id(s) {
+                            Ok((bytes, is_priv)) => (bytes.to_vec(), is_priv),
+                            Err(e) => { eprintln!("❌ --{}: {}", key, e); has_errors = true; (vec![], false) }
                         }
                     })
                     .collect()
@@ -137,23 +134,14 @@ pub async fn execute_instruction(
             let raw = args.get(&key).unwrap();
             match parse_account_id(raw) {
                 Ok((bytes, is_priv)) => parsed_accounts.push((&acc.name, bytes.to_vec(), is_priv)),
-                Err(e) => {
-                    eprintln!("❌ --{}: {}", key, e);
-                    has_errors = true;
-                }
+                Err(e) => { eprintln!("❌ --{}: {}", key, e); has_errors = true; }
             }
         }
     }
-    if has_errors {
-        process::exit(1);
-    }
+    if has_errors { process::exit(1); }
 
     // Build risc0 serialized data
-    let ix_index = idl
-        .instructions
-        .iter()
-        .position(|i| i.name == ix.name)
-        .unwrap_or(0);
+    let ix_index = idl.instructions.iter().position(|i| i.name == ix.name).unwrap_or(0);
     let risc0_args: Vec<_> = parsed_args.iter().map(|(_, ty, val)| (*ty, val)).collect();
     let instruction_data = serialize_to_risc0(ix_index as u32, &risc0_args)
         .unwrap_or_else(|e| {
@@ -161,70 +149,8 @@ pub async fn execute_instruction(
             process::exit(1);
         });
 
-    // Display
-    println!("Accounts:");
-    for acc in &ix.accounts {
-        if acc.pda.is_some() {
-            println!("  📦 {} → auto-computed (PDA)", acc.name);
-        } else if acc.rest {
-            if let Some((_, entries)) = rest_accounts.iter().find(|(n, _)| *n == acc.name) {
-                if entries.is_empty() {
-                    println!("  📦 {} → (none — variadic rest)", acc.name);
-                } else {
-                    for (e, _) in entries {
-                        println!("  📦 {} → 0x{}", acc.name, hex_encode(e));
-                    }
-                }
-            }
-        } else {
-            let account_bytes = parsed_accounts
-                .iter()
-                .find(|(n, _, _)| *n == acc.name)
-                .unwrap();
-            println!("  📦 {} → 0x{}", acc.name, hex_encode(&account_bytes.1));
-        }
-    }
-    println!();
-    println!("Arguments (parsed):");
-    for (name, _, val) in &parsed_args {
-        println!("  {} = {}", name, val);
-    }
-    println!();
-    println!("🔧 Transaction:");
-    if let Some(pid) = program_id_hex {
-        println!("  program-id: {}", pid);
-    } else if let Some(path) = program_path {
-        println!("  program: {}", path);
-    }
-    println!("  instruction index: {}", ix_index);
-    println!("  instruction: {} {{", to_pascal_case(&ix.name));
-    for (name, _, val) in &parsed_args {
-        println!("    {}: {},", name, val);
-    }
-    println!("  }}");
-    println!();
-    println!(
-        "  Serialized instruction data ({} u32 words):",
-        instruction_data.len()
-    );
-    let hex_words: Vec<String> = instruction_data
-        .iter()
-        .map(|w| format!("{:08x}", w))
-        .collect();
-    println!("    [{}]", hex_words.join(", "));
-    println!();
-
-    if dry_run {
-        println!("⚠️  Dry run — omit --dry-run to submit the transaction.");
-        return;
-    }
-
-    // ─── Transaction submission ──────────────────────────────────
-    println!("📤 Submitting transaction...");
-
-    // Resolve program_id: from --program-id hex flag, or by loading the binary
-    let (program_id, program_obj): (ProgramId, Option<Program>) = if let Some(hex) = program_id_hex
-    {
+    // ─── Resolve program_id (load binary if needed) ─────────────
+    let (program_id, program_obj): (ProgramId, Option<Program>) = if let Some(hex) = program_id_hex {
         let bytes = decode_bytes_32(hex).unwrap_or_else(|e| {
             eprintln!("❌ Invalid program ID '{}': {}", hex, e);
             process::exit(1);
@@ -251,9 +177,13 @@ pub async fn execute_instruction(
         eprintln!("❌ No program specified. Use --program <name|hex|path> or configure in spel.toml.");
         process::exit(1);
     };
-    println!("  Program ID: {:?}", program_id);
+    let program_id_hex_str: String = program_id
+        .iter()
+        .flat_map(|w| w.to_le_bytes())
+        .map(|b| format!("{:02x}", b))
+        .collect();
 
-    // Build account map for PDA resolution
+    // ─── Build account map and resolve PDAs ─────────────────────
     let mut account_map: HashMap<String, AccountId> = HashMap::new();
     for (name, bytes, _) in &parsed_accounts {
         let mut arr = [0u8; 32];
@@ -279,19 +209,13 @@ pub async fn execute_instruction(
                         if let Some(raw) = args.get(&key) {
                             match decode_bytes_32(raw) {
                                 Ok(bytes) => {
-                                    println!("  ℹ️  Using --{} for PDA seed '{}'", key, path);
+                                    info!("  ℹ️  Using --{} for PDA seed '{}'", key, path);
                                     account_map.insert(path.clone(), AccountId::new(bytes));
                                 }
-                                Err(e) => {
-                                    eprintln!("❌ --{}: {}", key, e);
-                                    process::exit(1);
-                                }
+                                Err(e) => { eprintln!("❌ --{}: {}", key, e); process::exit(1); }
                             }
                         } else {
-                            eprintln!(
-                                "❌ PDA '{}' requires account '{}' — provide --{}",
-                                acc.name, path, key
-                            );
+                            eprintln!("❌ PDA '{}' requires account '{}' — provide --{}", acc.name, path, key);
                             process::exit(1);
                         }
                     }
@@ -305,14 +229,11 @@ pub async fn execute_instruction(
         parsed_arg_map.insert(name.to_string(), val.clone());
     }
 
-    // Resolve PDA accounts
+    // Compute PDAs
     for acc in &ix.accounts {
         if let Some(pda) = &acc.pda {
             match compute_pda_from_seeds(&pda.seeds, &program_id, &account_map, &parsed_arg_map) {
                 Ok(id) => {
-                    let seed_str = format_pda_seeds(&pda.seeds);
-                    println!("  PDA {} → {}", acc.name, id);
-                    println!("    seeds: {}", seed_str);
                     account_map.insert(acc.name.clone(), id);
                 }
                 Err(e) => {
@@ -323,6 +244,102 @@ pub async fn execute_instruction(
         }
     }
 
+    // ─── Dry-run summary ────────────────────────────────────────
+    if let Some(fmt) = dry_run {
+        let signer_names: Vec<&str> = ix.accounts.iter().filter(|a| a.signer).map(|a| a.name.as_str()).collect();
+        let signer_ids: Vec<AccountId> = signer_names.iter().filter_map(|n| account_map.get(*n).copied()).collect();
+
+        // Best-effort nonce fetch — graceful degradation if wallet unavailable.
+        let signer_nonces: Vec<Option<Nonce>> = if signer_ids.is_empty() {
+            vec![]
+        } else {
+            match WalletCore::from_env() {
+                Ok(wc) => match wc.get_accounts_nonces(signer_ids.clone()).await {
+                    Ok(ns) => ns.into_iter().map(Some).collect(),
+                    Err(_) => vec![None; signer_ids.len()],
+                },
+                Err(_) => vec![None; signer_ids.len()],
+            }
+        };
+
+        if fmt == "json" {
+            print_dry_run_json(
+                &program_id_hex_str,
+                ix,
+                &account_map,
+                &parsed_accounts,
+                &rest_accounts,
+                &parsed_args,
+                &instruction_data,
+                &signer_names,
+                &signer_nonces,
+            );
+        } else {
+            print_dry_run_text(
+                &program_id_hex_str,
+                ix,
+                &account_map,
+                &parsed_accounts,
+                &rest_accounts,
+                &parsed_args,
+                &instruction_data,
+                &signer_names,
+                &signer_nonces,
+            );
+        }
+        return;
+    }
+
+    // ─── Pre-submission display ─────────────────────────────────
+    info!("Accounts:");
+    for acc in &ix.accounts {
+        if let Some(pda) = &acc.pda {
+            let id = account_map.get(&acc.name).map(|a| format!("{}", a)).unwrap_or_default();
+            info!("  📦 {} → {} (PDA)", acc.name, id);
+            info!("    seeds: {}", format_pda_seeds(&pda.seeds));
+        } else if acc.rest {
+            if let Some((_, entries)) = rest_accounts.iter().find(|(n, _)| *n == acc.name) {
+                if entries.is_empty() {
+                    info!("  📦 {} → (none — variadic rest)", acc.name);
+                } else {
+                    for (e, _) in entries {
+                        info!("  📦 {} → 0x{}", acc.name, hex_encode(e));
+                    }
+                }
+            }
+        } else {
+            let account_bytes = parsed_accounts.iter().find(|(n, _, _)| *n == acc.name).unwrap();
+            info!("  📦 {} → 0x{}", acc.name, hex_encode(&account_bytes.1));
+        }
+    }
+    info!("");
+    info!("Arguments (parsed):");
+    for (name, _, val) in &parsed_args {
+        info!("  {} = {}", name, val);
+    }
+    info!("");
+    info!("🔧 Transaction:");
+    info!("  program-id: {}", program_id_hex_str);
+    if program_id_hex.is_none() {
+        if let Some(path) = program_path {
+            info!("  program:    {}", path);
+        }
+    }
+    info!("  instruction index: {}", ix_index);
+    info!("  instruction: {} {{", to_pascal_case(&ix.name));
+    for (name, _, val) in &parsed_args {
+        info!("    {}: {},", name, val);
+    }
+    info!("  }}");
+    info!("");
+    info!("  Serialized instruction data ({} u32 words):", instruction_data.len());
+    let hex_words: Vec<String> = instruction_data.iter().map(|w| format!("{:08x}", w)).collect();
+    info!("    [{}]", hex_words.join(", "));
+    info!("");
+
+    // ─── Transaction submission ─────────────────────────────────
+    info!("📤 Submitting transaction...");
+
     let wallet_core = WalletCore::from_env().unwrap_or_else(|e| {
         eprintln!("❌ Failed to initialize wallet: {:?}", e);
         eprintln!("   Set NSSA_WALLET_HOME_DIR environment variable");
@@ -331,19 +348,15 @@ pub async fn execute_instruction(
 
     // Check if any account has a Private/ prefix
     let has_private = parsed_accounts.iter().any(|(_, _, is_priv)| *is_priv)
-        || rest_accounts
-            .iter()
-            .any(|(_, entries)| entries.iter().any(|(_, is_priv)| *is_priv));
+        || rest_accounts.iter().any(|(_, entries)| entries.iter().any(|(_, is_priv)| *is_priv));
 
     if has_private {
         // ─── Privacy-preserving transaction ──────────────────
-        use nssa::privacy_preserving_transaction::circuit::ProgramWithDependencies;
         use wallet::PrivacyPreservingAccount;
+        use nssa::privacy_preserving_transaction::circuit::ProgramWithDependencies;
 
         let program = program_obj.unwrap_or_else(|| {
-            eprintln!(
-                "❌ Privacy-preserving transactions require the program binary (not --program-id)"
-            );
+            eprintln!("❌ Privacy-preserving transactions require the program binary (not --program-id)");
             process::exit(1);
         });
 
@@ -374,9 +387,7 @@ pub async fn execute_instruction(
                         }
                     }
                 }
-            } else if let Some((_, _, is_priv)) =
-                parsed_accounts.iter().find(|(n, _, _)| *n == acc.name)
-            {
+            } else if let Some((_, _, is_priv)) = parsed_accounts.iter().find(|(n, _, _)| *n == acc.name) {
                 let id = *account_map.get(&acc.name).unwrap_or_else(|| {
                     eprintln!("❌ Account '{}' not resolved", acc.name);
                     process::exit(1);
@@ -396,20 +407,18 @@ pub async fn execute_instruction(
             }
         }
 
-        let (response, _shared_secrets) = wallet_core
-            .send_privacy_preserving_tx(pp_accounts, instruction_data, &program_with_deps)
-            .await
-            .unwrap_or_else(|e| {
-                eprintln!(
-                    "❌ Failed to submit privacy-preserving transaction: {:?}",
-                    e
-                );
-                process::exit(1);
-            });
+        let (response, _shared_secrets) = wallet_core.send_privacy_preserving_tx(
+            pp_accounts,
+            instruction_data,
+            &program_with_deps,
+        ).await.unwrap_or_else(|e| {
+            eprintln!("❌ Failed to submit privacy-preserving transaction: {:?}", e);
+            process::exit(1);
+        });
 
-        println!("📤 Privacy-preserving transaction submitted!");
-        println!("   tx_hash: {}", hex::encode(response.0));
-        println!("   Waiting for confirmation...");
+        info!("📤 Privacy-preserving transaction submitted!");
+        info!("   tx_hash: {}", hex::encode(response.0));
+        info!("   Waiting for confirmation...");
 
         let poller = wallet::poller::TxPoller::new(
             wallet_core.config(),
@@ -417,7 +426,7 @@ pub async fn execute_instruction(
         );
 
         match poller.poll_tx(response).await {
-            Ok(_) => println!("✅ Transaction confirmed — included in a block."),
+            Ok(_) => info!("✅ Transaction confirmed — included in a block."),
             Err(e) => {
                 eprintln!("❌ Transaction NOT confirmed: {e:#}");
                 process::exit(1);
@@ -444,9 +453,7 @@ pub async fn execute_instruction(
             }
         }
 
-        let signer_accounts: Vec<AccountId> = ix
-            .accounts
-            .iter()
+        let signer_accounts: Vec<AccountId> = ix.accounts.iter()
             .filter(|a| a.signer)
             .map(|a| *account_map.get(&a.name).unwrap())
             .collect();
@@ -454,45 +461,31 @@ pub async fn execute_instruction(
         let nonces = if signer_accounts.is_empty() {
             vec![]
         } else {
-            wallet_core
-                .get_accounts_nonces(signer_accounts.clone())
-                .await
-                .unwrap_or_else(|e| {
-                    eprintln!("❌ Failed to fetch nonces: {:?}", e);
-                    process::exit(1);
-                })
+            wallet_core.get_accounts_nonces(signer_accounts.clone()).await.unwrap_or_else(|e| {
+                eprintln!("❌ Failed to fetch nonces: {:?}", e);
+                process::exit(1);
+            })
         };
 
-        let signing_keys: Vec<_> = signer_accounts
-            .iter()
-            .map(|id| {
-                wallet_core
-                    .storage()
-                    .user_data
-                    .get_pub_account_signing_key(*id)
-                    .unwrap_or_else(|| {
-                        eprintln!("❌ Signing key not found for account {}", id);
-                        process::exit(1);
-                    })
+        let signing_keys: Vec<_> = signer_accounts.iter().map(|id| {
+            wallet_core.storage().user_data.get_pub_account_signing_key(*id).unwrap_or_else(|| {
+                eprintln!("❌ Signing key not found for account {}", id);
+                process::exit(1);
             })
-            .collect();
+        }).collect();
 
         let message = Message::new_preserialized(program_id, account_ids, nonces, instruction_data);
         let witness_set = WitnessSet::for_message(&message, &signing_keys);
         let tx = PublicTransaction::new(message, witness_set);
 
-        let tx_hash = wallet_core
-            .sequencer_client
-            .send_transaction(NSSATransaction::Public(tx))
-            .await
-            .unwrap_or_else(|e| {
-                eprintln!("❌ Failed to submit transaction: {:?}", e);
-                process::exit(1);
-            });
+        let tx_hash = wallet_core.sequencer_client.send_transaction(NSSATransaction::Public(tx)).await.unwrap_or_else(|e| {
+            eprintln!("❌ Failed to submit transaction: {:?}", e);
+            process::exit(1);
+        });
 
-        println!("📤 Transaction submitted!");
-        println!("   tx_hash: {}", tx_hash);
-        println!("   Waiting for confirmation...");
+        info!("📤 Transaction submitted!");
+        info!("   tx_hash: {}", tx_hash);
+        info!("   Waiting for confirmation...");
 
         let poller = wallet::poller::TxPoller::new(
             wallet_core.config(),
@@ -500,11 +493,194 @@ pub async fn execute_instruction(
         );
 
         match poller.poll_tx(tx_hash).await {
-            Ok(_) => println!("✅ Transaction confirmed — included in a block."),
+            Ok(_) => info!("✅ Transaction confirmed — included in a block."),
             Err(e) => {
                 eprintln!("❌ Transaction NOT confirmed: {e:#}");
                 process::exit(1);
             }
         }
     }
+}
+
+/// Render an account list entry as JSON, including PDA seed metadata when applicable.
+fn account_to_json(
+    acc: &spel_framework_core::idl::IdlAccountItem,
+    id_str: String,
+) -> Value {
+    let mut flags: Vec<&str> = Vec::new();
+    if acc.signer { flags.push("signer"); }
+    if acc.writable { flags.push("writable"); }
+
+    let mut obj = json!({
+        "name": acc.name,
+        "id": id_str,
+        "flags": flags,
+    });
+    if let Some(pda) = &acc.pda {
+        let seeds: Vec<Value> = pda.seeds.iter().map(|s| match s {
+            IdlSeed::Const { value } => json!({"kind": "const", "value": value}),
+            IdlSeed::Account { path } => json!({"kind": "account", "path": path}),
+            IdlSeed::Arg { path } => json!({"kind": "arg", "path": path}),
+        }).collect();
+        obj["is_pda"] = json!(true);
+        obj["seeds"] = json!(seeds);
+    }
+    obj
+}
+
+#[allow(clippy::too_many_arguments)]
+fn print_dry_run_json(
+    program_id_hex: &str,
+    ix: &IdlInstruction,
+    account_map: &HashMap<String, AccountId>,
+    parsed_accounts: &[(&str, Vec<u8>, bool)],
+    rest_accounts: &[(&str, Vec<(Vec<u8>, bool)>)],
+    parsed_args: &[(&str, &spel_framework_core::idl::IdlType, ParsedValue)],
+    instruction_data: &[u32],
+    signer_names: &[&str],
+    signer_nonces: &[Option<Nonce>],
+) {
+    // accounts: include all (PDA, named, and per-entry rest accounts).
+    let mut accounts_json: Vec<Value> = Vec::new();
+    for acc in &ix.accounts {
+        if acc.rest {
+            if let Some((_, entries)) = rest_accounts.iter().find(|(n, _)| *n == acc.name) {
+                if entries.is_empty() {
+                    accounts_json.push(json!({
+                        "name": acc.name,
+                        "id": null,
+                        "flags": ["rest"],
+                        "is_rest": true,
+                    }));
+                } else {
+                    for (bytes, _) in entries {
+                        accounts_json.push(json!({
+                            "name": acc.name,
+                            "id": format!("0x{}", hex_encode(bytes)),
+                            "flags": ["rest"],
+                            "is_rest": true,
+                        }));
+                    }
+                }
+            }
+        } else {
+            let id_str = account_map
+                .get(&acc.name)
+                .map(|a| {
+                    if acc.pda.is_some() {
+                        format!("{}", a)
+                    } else if let Some((_, b, _)) = parsed_accounts.iter().find(|(n, _, _)| *n == acc.name) {
+                        format!("0x{}", hex_encode(b))
+                    } else {
+                        format!("{}", a)
+                    }
+                })
+                .unwrap_or_else(|| "(unresolved)".to_string());
+            accounts_json.push(account_to_json(acc, id_str));
+        }
+    }
+
+    let args_json: serde_json::Map<String, Value> = parsed_args.iter().map(|(name, _, val)| {
+        let v = match val {
+            ParsedValue::U8(n) => json!(n),
+            ParsedValue::U32(n) => json!(n),
+            ParsedValue::U64(n) => json!(n),
+            // u128 is not natively representable in JSON numbers — encode as decimal string.
+            ParsedValue::U128(n) => json!(n.to_string()),
+            other => json!(other.to_string()),
+        };
+        (name.to_string(), v)
+    }).collect();
+
+    let signers_json: serde_json::Map<String, Value> = signer_names.iter().enumerate().map(|(i, name)| {
+        let nonce_val = signer_nonces.get(i).and_then(|n| n.as_ref())
+            // u128 nonce — encode as decimal string to avoid silent truncation.
+            .map(|n| json!(n.0.to_string()))
+            .unwrap_or(Value::Null);
+        (name.to_string(), json!({"nonce": nonce_val}))
+    }).collect();
+
+    let ix_data_hex: String = instruction_data
+        .iter()
+        .flat_map(|w| w.to_le_bytes())
+        .map(|b| format!("{:02x}", b))
+        .collect();
+
+    let summary = json!({
+        "program_id": program_id_hex,
+        "instruction": ix.name,
+        "accounts": accounts_json,
+        "arguments": args_json,
+        "instruction_data": ix_data_hex,
+        "signers": signers_json,
+    });
+    println!("{}", serde_json::to_string_pretty(&summary).unwrap());
+}
+
+#[allow(clippy::too_many_arguments)]
+fn print_dry_run_text(
+    program_id_hex: &str,
+    ix: &IdlInstruction,
+    account_map: &HashMap<String, AccountId>,
+    parsed_accounts: &[(&str, Vec<u8>, bool)],
+    rest_accounts: &[(&str, Vec<(Vec<u8>, bool)>)],
+    parsed_args: &[(&str, &spel_framework_core::idl::IdlType, ParsedValue)],
+    instruction_data: &[u32],
+    signer_names: &[&str],
+    signer_nonces: &[Option<Nonce>],
+) {
+    println!("=== Dry Run ===");
+    println!("Program ID: {}", program_id_hex);
+    println!("Instruction: {}", ix.name);
+    println!();
+    println!("Accounts:");
+    for acc in &ix.accounts {
+        let mut flags: Vec<&str> = Vec::new();
+        if acc.signer { flags.push("signer"); }
+        if acc.writable { flags.push("writable"); }
+        let flags_str = if flags.is_empty() { String::new() } else { format!(" [{}]", flags.join(", ")) };
+
+        if let Some(pda) = &acc.pda {
+            let id = account_map.get(&acc.name).map(|a| format!("{}", a)).unwrap_or_else(|| "(unresolved)".into());
+            println!("  PDA {} → {}{}", acc.name, id, flags_str);
+            println!("    seeds: {}", format_pda_seeds(&pda.seeds));
+        } else if acc.rest {
+            if let Some((_, entries)) = rest_accounts.iter().find(|(n, _)| *n == acc.name) {
+                if entries.is_empty() {
+                    println!("  {} → (none — variadic rest){}", acc.name, flags_str);
+                } else {
+                    for (bytes, _) in entries {
+                        println!("  {} → 0x{}{}", acc.name, hex_encode(bytes), flags_str);
+                    }
+                }
+            }
+        } else if let Some((_, b, _)) = parsed_accounts.iter().find(|(n, _, _)| *n == acc.name) {
+            println!("  {} → 0x{}{}", acc.name, hex_encode(b), flags_str);
+        }
+    }
+    println!();
+    println!("Arguments:");
+    for (name, _, val) in parsed_args {
+        println!("  --{} {}", snake_to_kebab(name), val);
+    }
+    println!();
+    let ix_data_hex: String = instruction_data
+        .iter()
+        .flat_map(|w| w.to_le_bytes())
+        .map(|b| format!("{:02x}", b))
+        .collect();
+    println!("Instruction data: 0x{}", ix_data_hex);
+    if !signer_names.is_empty() {
+        println!();
+        println!("Signers:");
+        for (i, name) in signer_names.iter().enumerate() {
+            let nonce_str = match signer_nonces.get(i).and_then(|n| n.as_ref()) {
+                Some(n) => format!("nonce={}", n.0),
+                None => "nonce=(unknown)".to_string(),
+            };
+            println!("  {}: {}", name, nonce_str);
+        }
+    }
+    println!("================");
+    println!("Dry run complete — not submitted.");
 }

--- a/spel-cli/src/tx.rs
+++ b/spel-cli/src/tx.rs
@@ -33,27 +33,36 @@ fn format_pda_seeds(seeds: &[IdlSeed]) -> String {
     format!("[{}]", parts.join(", "))
 }
 
+/// Output format for a `--dry-run` summary.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum DryRunFormat {
+    Text,
+    Json,
+}
+
+const UNRESOLVED: &str = "(unresolved)";
+
 /// Execute an instruction: parse args, build TX, optionally submit.
 ///
 /// `dry_run`:
-///   - `None`             — submit to the sequencer
-///   - `Some("text")`     — resolve & print human-readable summary, do not submit
-///   - `Some("json")`     — resolve & emit JSON to stdout, do not submit
+///   - `None`                       — submit to the sequencer
+///   - `Some(DryRunFormat::Text)`   — resolve & print a human-readable summary
+///   - `Some(DryRunFormat::Json)`   — resolve & emit JSON to stdout
 pub async fn execute_instruction(
     idl: &SpelIdl,
     ix: &IdlInstruction,
     args: &HashMap<String, String>,
     program_path: Option<&str>,
     program_id_hex: Option<&str>,
-    dry_run: Option<&str>,
+    dry_run: Option<DryRunFormat>,
     extra_bins: &HashMap<String, String>,
 ) {
     // In JSON dry-run mode, suppress all human-readable preamble — only emit JSON to stdout.
-    let json_mode = dry_run == Some("json");
-    macro_rules! info { ($($arg:tt)*) => { if !json_mode { println!($($arg)*); } } }
+    let json_mode = dry_run == Some(DryRunFormat::Json);
+    macro_rules! say { ($($arg:tt)*) => { if !json_mode { println!($($arg)*); } } }
 
-    info!("📋 Instruction: {}", ix.name);
-    info!("");
+    say!("📋 Instruction: {}", ix.name);
+    say!("");
 
     let mut args = args.clone();
 
@@ -65,7 +74,7 @@ pub async fn execute_instruction(
                     let id = program.id();
                     let id_str: Vec<String> = id.iter().map(|w| w.to_string()).collect();
                     let val = id_str.join(",");
-                    info!("  ℹ️  Auto-filled --{} from {}", key, bin_path);
+                    say!("  ℹ️  Auto-filled --{} from {}", key, bin_path);
                     args.insert(key.clone(), val);
                 }
             }
@@ -114,20 +123,20 @@ pub async fn execute_instruction(
         if acc.pda.is_some() { continue; }
         let key = snake_to_kebab(&acc.name);
         if acc.rest {
-            // variadic: optional, comma-separated list of account IDs (0 entries is valid)
+            // variadic: optional, comma-separated list of account IDs (0 entries is valid).
+            // Failed entries are skipped (not pushed as placeholders) so downstream
+            // consumers never see a zero-length Vec where a 32-byte AccountId is expected.
             let entries: Vec<(Vec<u8>, bool)> = if let Some(raw) = args.get(&key) {
                 raw.split(',')
                     .map(|s| s.trim())
                     .filter(|s| !s.is_empty())
-                    .map(|s| {
-                        match parse_account_id(s) {
-                            Ok((bytes, is_priv)) => (bytes.to_vec(), is_priv),
-                            Err(e) => { eprintln!("❌ --{}: {}", key, e); has_errors = true; (vec![], false) }
-                        }
+                    .filter_map(|s| match parse_account_id(s) {
+                        Ok((bytes, is_priv)) => Some((bytes.to_vec(), is_priv)),
+                        Err(e) => { eprintln!("❌ --{}: {}", key, e); has_errors = true; None }
                     })
                     .collect()
             } else {
-                vec![] // rest accounts are optional — 0 is valid
+                vec![]
             };
             rest_accounts.push((&acc.name, entries));
         } else {
@@ -150,32 +159,36 @@ pub async fn execute_instruction(
         });
 
     // ─── Resolve program_id (load binary if needed) ─────────────
-    let (program_id, program_obj): (ProgramId, Option<Program>) = if let Some(hex) = program_id_hex {
-        let bytes = decode_bytes_32(hex).unwrap_or_else(|e| {
-            eprintln!("❌ Invalid program ID '{}': {}", hex, e);
-            process::exit(1);
-        });
-        let mut pid = [0u32; 8];
-        for (i, chunk) in bytes.chunks(4).enumerate() {
-            pid[i] = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+    let (program_id, program_obj): (ProgramId, Option<Program>) = match (program_id_hex, program_path) {
+        (Some(hex), _) => {
+            let bytes = decode_bytes_32(hex).unwrap_or_else(|e| {
+                eprintln!("❌ Invalid program ID '{}': {}", hex, e);
+                process::exit(1);
+            });
+            let mut pid = [0u32; 8];
+            for (i, chunk) in bytes.chunks(4).enumerate() {
+                pid[i] = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+            }
+            (pid, None)
         }
-        (pid, None)
-    } else if let Some(path) = program_path {
-        let program_bytecode = fs::read(path).unwrap_or_else(|e| {
-            eprintln!("❌ Failed to read program binary '{}': {}", path, e);
-            eprintln!("   Hint: pass --program <64-char-hex> to skip loading the binary.");
-            eprintln!("   Or configure in spel.toml.");
+        (None, Some(path)) => {
+            let program_bytecode = fs::read(path).unwrap_or_else(|e| {
+                eprintln!("❌ Failed to read program binary '{}': {}", path, e);
+                eprintln!("   Hint: pass --program <64-char-hex> to skip loading the binary.");
+                eprintln!("   Or configure in spel.toml.");
+                process::exit(1);
+            });
+            let program = Program::new(program_bytecode).unwrap_or_else(|e| {
+                eprintln!("❌ Failed to load program: {:?}", e);
+                process::exit(1);
+            });
+            let pid = program.id();
+            (pid, Some(program))
+        }
+        (None, None) => {
+            eprintln!("❌ No program specified. Use --program <name|hex|path> or configure in spel.toml.");
             process::exit(1);
-        });
-        let program = Program::new(program_bytecode).unwrap_or_else(|e| {
-            eprintln!("❌ Failed to load program: {:?}", e);
-            process::exit(1);
-        });
-        let pid = program.id();
-        (pid, Some(program))
-    } else {
-        eprintln!("❌ No program specified. Use --program <name|hex|path> or configure in spel.toml.");
-        process::exit(1);
+        }
     };
     let program_id_hex_str: String = program_id
         .iter()
@@ -209,7 +222,7 @@ pub async fn execute_instruction(
                         if let Some(raw) = args.get(&key) {
                             match decode_bytes_32(raw) {
                                 Ok(bytes) => {
-                                    info!("  ℹ️  Using --{} for PDA seed '{}'", key, path);
+                                    say!("  ℹ️  Using --{} for PDA seed '{}'", key, path);
                                     account_map.insert(path.clone(), AccountId::new(bytes));
                                 }
                                 Err(e) => { eprintln!("❌ --{}: {}", key, e); process::exit(1); }
@@ -248,97 +261,73 @@ pub async fn execute_instruction(
     if let Some(fmt) = dry_run {
         let signer_names: Vec<&str> = ix.accounts.iter().filter(|a| a.signer).map(|a| a.name.as_str()).collect();
         let signer_ids: Vec<AccountId> = signer_names.iter().filter_map(|n| account_map.get(*n).copied()).collect();
+        let signer_nonces = fetch_nonces_best_effort(signer_ids).await;
 
-        // Best-effort nonce fetch — graceful degradation if wallet unavailable.
-        let signer_nonces: Vec<Option<Nonce>> = if signer_ids.is_empty() {
-            vec![]
-        } else {
-            match WalletCore::from_env() {
-                Ok(wc) => match wc.get_accounts_nonces(signer_ids.clone()).await {
-                    Ok(ns) => ns.into_iter().map(Some).collect(),
-                    Err(_) => vec![None; signer_ids.len()],
-                },
-                Err(_) => vec![None; signer_ids.len()],
-            }
+        let summary = DryRunSummary {
+            program_id_hex: &program_id_hex_str,
+            ix,
+            account_map: &account_map,
+            parsed_account_ids: &parsed_accounts.iter().map(|(n, b, _)| (*n, b.as_slice())).collect::<Vec<_>>(),
+            rest_account_ids: &rest_accounts.iter().map(|(n, es)| (*n, es.iter().map(|(b, _)| b.as_slice()).collect::<Vec<_>>())).collect::<Vec<_>>(),
+            parsed_args: &parsed_args,
+            instruction_data: &instruction_data,
+            signer_names: &signer_names,
+            signer_nonces: &signer_nonces,
         };
-
-        if fmt == "json" {
-            print_dry_run_json(
-                &program_id_hex_str,
-                ix,
-                &account_map,
-                &parsed_accounts,
-                &rest_accounts,
-                &parsed_args,
-                &instruction_data,
-                &signer_names,
-                &signer_nonces,
-            );
-        } else {
-            print_dry_run_text(
-                &program_id_hex_str,
-                ix,
-                &account_map,
-                &parsed_accounts,
-                &rest_accounts,
-                &parsed_args,
-                &instruction_data,
-                &signer_names,
-                &signer_nonces,
-            );
+        match fmt {
+            DryRunFormat::Json => print_dry_run_json(&summary),
+            DryRunFormat::Text => print_dry_run_text(&summary),
         }
         return;
     }
 
     // ─── Pre-submission display ─────────────────────────────────
-    info!("Accounts:");
+    say!("Accounts:");
     for acc in &ix.accounts {
         if let Some(pda) = &acc.pda {
-            let id = account_map.get(&acc.name).map(|a| format!("{}", a)).unwrap_or_default();
-            info!("  📦 {} → {} (PDA)", acc.name, id);
-            info!("    seeds: {}", format_pda_seeds(&pda.seeds));
+            let id = account_map.get(&acc.name).map(|a| format!("{}", a)).unwrap_or_else(|| UNRESOLVED.to_string());
+            say!("  📦 {} → {} (PDA)", acc.name, id);
+            say!("    seeds: {}", format_pda_seeds(&pda.seeds));
         } else if acc.rest {
             if let Some((_, entries)) = rest_accounts.iter().find(|(n, _)| *n == acc.name) {
                 if entries.is_empty() {
-                    info!("  📦 {} → (none — variadic rest)", acc.name);
+                    say!("  📦 {} → (none — variadic rest)", acc.name);
                 } else {
                     for (e, _) in entries {
-                        info!("  📦 {} → 0x{}", acc.name, hex_encode(e));
+                        say!("  📦 {} → 0x{}", acc.name, hex_encode(e));
                     }
                 }
             }
         } else {
             let account_bytes = parsed_accounts.iter().find(|(n, _, _)| *n == acc.name).unwrap();
-            info!("  📦 {} → 0x{}", acc.name, hex_encode(&account_bytes.1));
+            say!("  📦 {} → 0x{}", acc.name, hex_encode(&account_bytes.1));
         }
     }
-    info!("");
-    info!("Arguments (parsed):");
+    say!("");
+    say!("Arguments (parsed):");
     for (name, _, val) in &parsed_args {
-        info!("  {} = {}", name, val);
+        say!("  {} = {}", name, val);
     }
-    info!("");
-    info!("🔧 Transaction:");
-    info!("  program-id: {}", program_id_hex_str);
-    if program_id_hex.is_none() {
-        if let Some(path) = program_path {
-            info!("  program:    {}", path);
-        }
+    say!("");
+    say!("🔧 Transaction:");
+    say!("  program-id: {}", program_id_hex_str);
+    if let (None, Some(path)) = (program_id_hex, program_path) {
+        say!("  program:    {}", path);
     }
-    info!("  instruction index: {}", ix_index);
-    info!("  instruction: {} {{", to_pascal_case(&ix.name));
+    say!("  instruction index: {}", ix_index);
+    say!("  instruction: {} {{", to_pascal_case(&ix.name));
     for (name, _, val) in &parsed_args {
-        info!("    {}: {},", name, val);
+        say!("    {}: {},", name, val);
     }
-    info!("  }}");
-    info!("");
-    info!("  Serialized instruction data ({} u32 words):", instruction_data.len());
+    say!("  }}");
+    say!("");
+    say!("  Serialized instruction data ({} u32 words):", instruction_data.len());
     let hex_words: Vec<String> = instruction_data.iter().map(|w| format!("{:08x}", w)).collect();
-    info!("    [{}]", hex_words.join(", "));
-    info!("");
+    say!("    [{}]", hex_words.join(", "));
+    say!("");
 
     // ─── Transaction submission ─────────────────────────────────
-    info!("📤 Submitting transaction...");
+    say!("📤 Submitting transaction...");
 
     let wallet_core = WalletCore::from_env().unwrap_or_else(|e| {
         eprintln!("❌ Failed to initialize wallet: {:?}", e);
@@ -416,9 +405,9 @@ pub async fn execute_instruction(
             process::exit(1);
         });
 
-        info!("📤 Privacy-preserving transaction submitted!");
-        info!("   tx_hash: {}", hex::encode(response.0));
-        info!("   Waiting for confirmation...");
+        say!("📤 Privacy-preserving transaction submitted!");
+        say!("   tx_hash: {}", hex::encode(response.0));
+        say!("   Waiting for confirmation...");
 
         let poller = wallet::poller::TxPoller::new(
             wallet_core.config(),
@@ -426,7 +415,7 @@ pub async fn execute_instruction(
         );
 
         match poller.poll_tx(response).await {
-            Ok(_) => info!("✅ Transaction confirmed — included in a block."),
+            Ok(_) => say!("✅ Transaction confirmed — included in a block."),
             Err(e) => {
                 eprintln!("❌ Transaction NOT confirmed: {e:#}");
                 process::exit(1);
@@ -483,9 +472,9 @@ pub async fn execute_instruction(
             process::exit(1);
         });
 
-        info!("📤 Transaction submitted!");
-        info!("   tx_hash: {}", tx_hash);
-        info!("   Waiting for confirmation...");
+        say!("📤 Transaction submitted!");
+        say!("   tx_hash: {}", tx_hash);
+        say!("   Waiting for confirmation...");
 
         let poller = wallet::poller::TxPoller::new(
             wallet_core.config(),
@@ -493,7 +482,7 @@ pub async fn execute_instruction(
         );
 
         match poller.poll_tx(tx_hash).await {
-            Ok(_) => info!("✅ Transaction confirmed — included in a block."),
+            Ok(_) => say!("✅ Transaction confirmed — included in a block."),
             Err(e) => {
                 eprintln!("❌ Transaction NOT confirmed: {e:#}");
                 process::exit(1);
@@ -502,7 +491,40 @@ pub async fn execute_instruction(
     }
 }
 
-/// Render an account list entry as JSON, including PDA seed metadata when applicable.
+/// Best-effort nonce fetch for a dry-run summary. Returns one entry per signer:
+/// `Some(Nonce)` on success, `None` if the wallet env is unavailable or the
+/// sequencer call fails.
+async fn fetch_nonces_best_effort(signer_ids: Vec<AccountId>) -> Vec<Option<Nonce>> {
+    if signer_ids.is_empty() {
+        return vec![];
+    }
+    let len = signer_ids.len();
+    let result = async {
+        let wc = WalletCore::from_env().ok()?;
+        wc.get_accounts_nonces(signer_ids).await.ok()
+    }.await;
+    match result {
+        Some(ns) => ns.into_iter().map(Some).collect(),
+        None => vec![None; len],
+    }
+}
+
+/// Bundle of resolved transaction data passed to the dry-run renderers.
+struct DryRunSummary<'a> {
+    program_id_hex: &'a str,
+    ix: &'a IdlInstruction,
+    account_map: &'a HashMap<String, AccountId>,
+    /// Named (non-PDA, non-rest) accounts: `(name, raw_32_bytes)`.
+    parsed_account_ids: &'a [(&'a str, &'a [u8])],
+    /// Rest (variadic) accounts: `(name, [raw_32_bytes…])`.
+    rest_account_ids: &'a [(&'a str, Vec<&'a [u8]>)],
+    parsed_args: &'a [(&'a str, &'a spel_framework_core::idl::IdlType, ParsedValue)],
+    instruction_data: &'a [u32],
+    signer_names: &'a [&'a str],
+    signer_nonces: &'a [Option<Nonce>],
+}
+
+/// Render a non-rest account as JSON, including PDA seed metadata when applicable.
 fn account_to_json(
     acc: &spel_framework_core::idl::IdlAccountItem,
     id_str: String,
@@ -528,23 +550,11 @@ fn account_to_json(
     obj
 }
 
-#[allow(clippy::too_many_arguments)]
-fn print_dry_run_json(
-    program_id_hex: &str,
-    ix: &IdlInstruction,
-    account_map: &HashMap<String, AccountId>,
-    parsed_accounts: &[(&str, Vec<u8>, bool)],
-    rest_accounts: &[(&str, Vec<(Vec<u8>, bool)>)],
-    parsed_args: &[(&str, &spel_framework_core::idl::IdlType, ParsedValue)],
-    instruction_data: &[u32],
-    signer_names: &[&str],
-    signer_nonces: &[Option<Nonce>],
-) {
-    // accounts: include all (PDA, named, and per-entry rest accounts).
+fn print_dry_run_json(s: &DryRunSummary<'_>) {
     let mut accounts_json: Vec<Value> = Vec::new();
-    for acc in &ix.accounts {
+    for acc in &s.ix.accounts {
         if acc.rest {
-            if let Some((_, entries)) = rest_accounts.iter().find(|(n, _)| *n == acc.name) {
+            if let Some((_, entries)) = s.rest_account_ids.iter().find(|(n, _)| *n == acc.name) {
                 if entries.is_empty() {
                     accounts_json.push(json!({
                         "name": acc.name,
@@ -553,7 +563,7 @@ fn print_dry_run_json(
                         "is_rest": true,
                     }));
                 } else {
-                    for (bytes, _) in entries {
+                    for bytes in entries {
                         accounts_json.push(json!({
                             "name": acc.name,
                             "id": format!("0x{}", hex_encode(bytes)),
@@ -563,52 +573,52 @@ fn print_dry_run_json(
                     }
                 }
             }
+        } else if acc.pda.is_some() {
+            let id_str = s.account_map.get(&acc.name).map(|a| format!("{}", a)).unwrap_or_else(|| UNRESOLVED.to_string());
+            accounts_json.push(account_to_json(acc, id_str));
         } else {
-            let id_str = account_map
-                .get(&acc.name)
-                .map(|a| {
-                    if acc.pda.is_some() {
-                        format!("{}", a)
-                    } else if let Some((_, b, _)) = parsed_accounts.iter().find(|(n, _, _)| *n == acc.name) {
-                        format!("0x{}", hex_encode(b))
-                    } else {
-                        format!("{}", a)
-                    }
-                })
-                .unwrap_or_else(|| "(unresolved)".to_string());
+            // Non-rest, non-PDA accounts must be in parsed_account_ids by construction
+            // (validated via `missing` check earlier in execute_instruction).
+            let id_str = match s.parsed_account_ids.iter().find(|(n, _)| *n == acc.name) {
+                Some((_, b)) => format!("0x{}", hex_encode(b)),
+                None => {
+                    debug_assert!(false, "non-rest non-PDA account '{}' missing from parsed_account_ids", acc.name);
+                    UNRESOLVED.to_string()
+                }
+            };
             accounts_json.push(account_to_json(acc, id_str));
         }
     }
 
-    let args_json: serde_json::Map<String, Value> = parsed_args.iter().map(|(name, _, val)| {
+    let args_json: serde_json::Map<String, Value> = s.parsed_args.iter().map(|(name, _, val)| {
         let v = match val {
             ParsedValue::U8(n) => json!(n),
             ParsedValue::U32(n) => json!(n),
             ParsedValue::U64(n) => json!(n),
-            // u128 is not natively representable in JSON numbers — encode as decimal string.
+            // u128 exceeds JSON's 53-bit integer precision — encode as decimal string.
             ParsedValue::U128(n) => json!(n.to_string()),
             other => json!(other.to_string()),
         };
         (name.to_string(), v)
     }).collect();
 
-    let signers_json: serde_json::Map<String, Value> = signer_names.iter().enumerate().map(|(i, name)| {
-        let nonce_val = signer_nonces.get(i).and_then(|n| n.as_ref())
+    let signers_json: serde_json::Map<String, Value> = s.signer_names.iter().enumerate().map(|(i, name)| {
+        let nonce_val = s.signer_nonces.get(i).and_then(|n| n.as_ref())
             // u128 nonce — encode as decimal string to avoid silent truncation.
             .map(|n| json!(n.0.to_string()))
             .unwrap_or(Value::Null);
         (name.to_string(), json!({"nonce": nonce_val}))
     }).collect();
 
-    let ix_data_hex: String = instruction_data
+    let ix_data_hex: String = s.instruction_data
         .iter()
         .flat_map(|w| w.to_le_bytes())
         .map(|b| format!("{:02x}", b))
         .collect();
 
     let summary = json!({
-        "program_id": program_id_hex,
-        "instruction": ix.name,
+        "program_id": s.program_id_hex,
+        "instruction": s.ix.name,
         "accounts": accounts_json,
         "arguments": args_json,
         "instruction_data": ix_data_hex,
@@ -617,64 +627,57 @@ fn print_dry_run_json(
     println!("{}", serde_json::to_string_pretty(&summary).unwrap());
 }
 
-#[allow(clippy::too_many_arguments)]
-fn print_dry_run_text(
-    program_id_hex: &str,
-    ix: &IdlInstruction,
-    account_map: &HashMap<String, AccountId>,
-    parsed_accounts: &[(&str, Vec<u8>, bool)],
-    rest_accounts: &[(&str, Vec<(Vec<u8>, bool)>)],
-    parsed_args: &[(&str, &spel_framework_core::idl::IdlType, ParsedValue)],
-    instruction_data: &[u32],
-    signer_names: &[&str],
-    signer_nonces: &[Option<Nonce>],
-) {
+fn print_dry_run_text(s: &DryRunSummary<'_>) {
     println!("=== Dry Run ===");
-    println!("Program ID: {}", program_id_hex);
-    println!("Instruction: {}", ix.name);
+    println!("Program ID: {}", s.program_id_hex);
+    println!("Instruction: {}", s.ix.name);
     println!();
     println!("Accounts:");
-    for acc in &ix.accounts {
+    for acc in &s.ix.accounts {
         let mut flags: Vec<&str> = Vec::new();
         if acc.signer { flags.push("signer"); }
         if acc.writable { flags.push("writable"); }
+        if acc.rest { flags.push("rest"); }
         let flags_str = if flags.is_empty() { String::new() } else { format!(" [{}]", flags.join(", ")) };
 
         if let Some(pda) = &acc.pda {
-            let id = account_map.get(&acc.name).map(|a| format!("{}", a)).unwrap_or_else(|| "(unresolved)".into());
+            let id = s.account_map.get(&acc.name).map(|a| format!("{}", a)).unwrap_or_else(|| UNRESOLVED.to_string());
             println!("  PDA {} → {}{}", acc.name, id, flags_str);
             println!("    seeds: {}", format_pda_seeds(&pda.seeds));
         } else if acc.rest {
-            if let Some((_, entries)) = rest_accounts.iter().find(|(n, _)| *n == acc.name) {
+            if let Some((_, entries)) = s.rest_account_ids.iter().find(|(n, _)| *n == acc.name) {
                 if entries.is_empty() {
                     println!("  {} → (none — variadic rest){}", acc.name, flags_str);
                 } else {
-                    for (bytes, _) in entries {
+                    for bytes in entries {
                         println!("  {} → 0x{}{}", acc.name, hex_encode(bytes), flags_str);
                     }
                 }
             }
-        } else if let Some((_, b, _)) = parsed_accounts.iter().find(|(n, _, _)| *n == acc.name) {
+        } else if let Some((_, b)) = s.parsed_account_ids.iter().find(|(n, _)| *n == acc.name) {
             println!("  {} → 0x{}{}", acc.name, hex_encode(b), flags_str);
+        } else {
+            debug_assert!(false, "non-rest non-PDA account '{}' missing from parsed_account_ids", acc.name);
+            println!("  {} → {}{}", acc.name, UNRESOLVED, flags_str);
         }
     }
     println!();
     println!("Arguments:");
-    for (name, _, val) in parsed_args {
+    for (name, _, val) in s.parsed_args {
         println!("  --{} {}", snake_to_kebab(name), val);
     }
     println!();
-    let ix_data_hex: String = instruction_data
+    let ix_data_hex: String = s.instruction_data
         .iter()
         .flat_map(|w| w.to_le_bytes())
         .map(|b| format!("{:02x}", b))
         .collect();
     println!("Instruction data: 0x{}", ix_data_hex);
-    if !signer_names.is_empty() {
+    if !s.signer_names.is_empty() {
         println!();
         println!("Signers:");
-        for (i, name) in signer_names.iter().enumerate() {
-            let nonce_str = match signer_nonces.get(i).and_then(|n| n.as_ref()) {
+        for (i, name) in s.signer_names.iter().enumerate() {
+            let nonce_str = match s.signer_nonces.get(i).and_then(|n| n.as_ref()) {
                 Some(n) => format!("nonce={}", n.0),
                 None => "nonce=(unknown)".to_string(),
             };


### PR DESCRIPTION
## Summary

Enhances `spel --dry-run` to walk the full resolution path — program load, PDA computation, best-effort nonce fetch — before exiting. Developers can see exactly what would be submitted, in either human-readable text or JSON for scripting.

## Usage

```bash
# Text summary (default)
spel --idl my-idl.json -p target/program.bin \
     submit-transfer --target Owner/abc123... --amount 100 \
     --dry-run

# JSON output — stdout is clean JSON, safe to pipe
spel --idl my-idl.json -p target/program.bin \
     submit-transfer --target Owner/abc123... --amount 100 \
     --dry-run=json > dry-run.json
```

`--dry-run=<fmt>` uses the equals syntax. Unknown formats are rejected.

## Files

- `spel-cli/src/lib.rs` — parse `--dry-run` / `--dry-run=<fmt>`
- `spel-cli/src/cli.rs` — help text
- `spel-cli/src/tx.rs` — restructure `execute_instruction`: program + PDA resolution moved before the dry-run gate; add `print_dry_run_text` / `print_dry_run_json` helpers

## Review notes

- The privacy-preserving submission path requires the program binary (unchanged). If dry-running with `--program <hex>`, only the public-path metadata is visible — privacy-preserving wouldn't have been submittable anyway.
- Nonce fetch is best-effort in dry-run: if the wallet env isn't set, nonces show `(unknown)` / `null` rather than failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)