### PR TITLE
feat(spel-cli): show seed inputs in PDA derivation output

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ This provides:
 - Automatic PDA computation from IDL seeds
 - risc0-compatible serialization
 - Transaction building and submission with wallet integration
-- `--dry-run` mode for testing
+- `--dry-run` — parse, resolve, and show the full transaction summary without submitting
 - `inspect` subcommand to extract ProgramId from binaries
 
 ### Account Types
@@ -244,6 +244,33 @@ spel --idl program-idl.json -p treasury.bin --bin-token token.bin \
 # Get help for a specific instruction
 spel --idl program-idl.json create-vault --help
 ```
+
+## Dry-run: Validate Before Submitting
+
+Before committing to a 15-second block cycle, run any command with `--dry-run` to see the complete local transaction picture:
+
+```sh
+spel --idl my-program-idl.json -p target/program.bin \
+     submit-transfer --target Owner/abc123... --amount 100 \
+     --dry-run
+```
+
+This shows:
+- **Program ID** — derived from the ELF binary (or use `--program-id <hex>`)
+- **All accounts** — direct accounts and resolved PDAs
+- **Parsed arguments** — validated and formatted
+- **Serialized instruction data** — ready for the sequencer
+- **Signer nonces** — fetched from the sequencer (requires wallet connectivity)
+
+To save the dry-run output as JSON for scripting:
+
+```sh
+spel --idl my-program-idl.json -p target/program.bin \
+     submit-transfer --target Owner/abc123... --amount 100 \
+     --dry-run --dry-run-output json > dry-run.json
+```
+
+**Privacy note:** `--dry-run` makes a read-only RPC call to fetch current nonces. This reveals which accounts you intend to use. Do not use `--dry-run` on shared or public infrastructure if account unlinkability is required.
 
 ### Type Formats
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ To save the dry-run output as JSON for scripting:
 ```sh
 spel --idl my-program-idl.json -p target/program.bin \
      submit-transfer --target Owner/abc123... --amount 100 \
-     --dry-run --dry-run-output json > dry-run.json
+     --dry-run json > dry-run.json
 ```
 
 ### Type Formats

--- a/README.md
+++ b/README.md
@@ -270,8 +270,6 @@ spel --idl my-program-idl.json -p target/program.bin \
      --dry-run --dry-run-output json > dry-run.json
 ```
 
-**Privacy note:** `--dry-run` makes a read-only RPC call to fetch current nonces. This reveals which accounts you intend to use. Do not use `--dry-run` on shared or public infrastructure if account unlinkability is required.
-
 ### Type Formats
 
 | IDL Type | CLI Format |

--- a/spel-cli/src/cli.rs
+++ b/spel-cli/src/cli.rs
@@ -14,7 +14,7 @@ pub fn print_help(idl: &SpelIdl, binary_name: &str) {
     println!("  -i, --idl <FILE>           IDL JSON file");
     println!("  -p, --program <FILE>       Program binary");
     println!("  --dry-run                  Parse and validate locally; show full transaction summary without submitting");
-    println!("  --dry-run-output <fmt>     With --dry-run, output full transaction as JSON (fmt: json)");
+    println!("  --dry-run-output           With --dry-run, output full transaction as JSON");
     println!("  --bin-<NAME> <FILE>        Additional program binary (auto-fills --<NAME>-program-id)");
     println!();
     println!("COMMANDS:");

--- a/spel-cli/src/cli.rs
+++ b/spel-cli/src/cli.rs
@@ -13,8 +13,7 @@ pub fn print_help(idl: &SpelIdl, binary_name: &str) {
     println!("OPTIONS:");
     println!("  -i, --idl <FILE>           IDL JSON file");
     println!("  -p, --program <FILE>       Program binary");
-    println!("  --dry-run                  Parse and validate locally; show full transaction summary without submitting");
-    println!("  --dry-run-output           With --dry-run, also emit transaction data as JSON to stdout");
+    println!("  --dry-run [text|json]       Parse and validate locally; show full transaction summary without submitting");
     println!("  --bin-<NAME> <FILE>        Additional program binary (auto-fills --<NAME>-program-id)");
     println!();
     println!("COMMANDS:");

--- a/spel-cli/src/cli.rs
+++ b/spel-cli/src/cli.rs
@@ -13,7 +13,8 @@ pub fn print_help(idl: &SpelIdl, binary_name: &str) {
     println!("OPTIONS:");
     println!("  -i, --idl <FILE>           IDL JSON file");
     println!("  -p, --program <FILE>       Program binary");
-    println!("  --dry-run                  Print parsed/serialized data without submitting");
+    println!("  --dry-run                  Parse and validate locally; show full transaction summary without submitting");
+    println!("  --dry-run-output <fmt>     With --dry-run, output full transaction as JSON (fmt: json)");
     println!("  --bin-<NAME> <FILE>        Additional program binary (auto-fills --<NAME>-program-id)");
     println!();
     println!("COMMANDS:");

--- a/spel-cli/src/cli.rs
+++ b/spel-cli/src/cli.rs
@@ -14,7 +14,7 @@ pub fn print_help(idl: &SpelIdl, binary_name: &str) {
     println!("  -i, --idl <FILE>           IDL JSON file");
     println!("  -p, --program <FILE>       Program binary");
     println!("  --dry-run                  Parse and validate locally; show full transaction summary without submitting");
-    println!("  --dry-run-output           With --dry-run, output full transaction as JSON");
+    println!("  --dry-run-output           With --dry-run, also emit transaction data as JSON to stdout");
     println!("  --bin-<NAME> <FILE>        Additional program binary (auto-fills --<NAME>-program-id)");
     println!();
     println!("COMMANDS:");

--- a/spel-cli/src/lib.rs
+++ b/spel-cli/src/lib.rs
@@ -44,8 +44,7 @@ pub async fn run() {
     let mut idl_path = String::new();
     let mut program_path = "program.bin".to_string();
     let mut program_id_hex: Option<String> = None;
-    let mut dry_run = false;
-    let mut dry_run_output = false;
+    let mut dry_run_format: Option<&str> = None;
     let mut type_name: Option<String> = None;
     let mut data_hex: Option<String> = None;
     let mut extra_bins: HashMap<String, String> = HashMap::new();
@@ -74,12 +73,16 @@ pub async fn run() {
                 i += 1;
                 if i < args.len() { data_hex = Some(args[i].clone()); }
             }
-            "--dry-run" => { dry_run = true; }
-            "--dry-run-output" => {
-                dry_run_output = true;
-                if !dry_run {
-                    println!("ℹ️  --dry-run-output implies --dry-run");
-                    dry_run = true;
+            "--dry-run" => {
+                dry_run_format = Some("text");
+            }
+            s if s.starts_with("--dry-run ") => {
+                let fmt = s.strip_prefix("--dry-run ").unwrap();
+                if fmt == "json" || fmt == "text" {
+                    dry_run_format = Some(fmt);
+                } else {
+                    eprintln!("❌ --dry-run only supports 'text' or 'json'");
+                    process::exit(1);
                 }
             }
             s if s.starts_with("--bin-") => {
@@ -311,7 +314,7 @@ pub async fn run() {
                 Some(ix) => {
                     let cli_args = parse_instruction_args(&remaining_args[2..], ix);
                     execute_instruction(
-                        &idl, ix, &cli_args, &program_path, program_id_hex.as_deref(), dry_run, dry_run_output, &extra_bins,
+                        &idl, ix, &cli_args, &program_path, program_id_hex.as_deref(), dry_run_format, &extra_bins,
                     ).await;
                 }
                 None => {

--- a/spel-cli/src/lib.rs
+++ b/spel-cli/src/lib.rs
@@ -45,6 +45,7 @@ pub async fn run() {
     let mut program_path = "program.bin".to_string();
     let mut program_id_hex: Option<String> = None;
     let mut dry_run = false;
+    let mut dry_run_output: Option<String> = None;
     let mut type_name: Option<String> = None;
     let mut data_hex: Option<String> = None;
     let mut extra_bins: HashMap<String, String> = HashMap::new();
@@ -74,6 +75,14 @@ pub async fn run() {
                 if i < args.len() { data_hex = Some(args[i].clone()); }
             }
             "--dry-run" => { dry_run = true; }
+            "--dry-run-output" => {
+                i += 1;
+                if i < args.len() { dry_run_output = Some(args[i].clone()); }
+                if !dry_run {
+                    println!("ℹ️  --dry-run-output implies --dry-run");
+                    dry_run = true;
+                }
+            }
             s if s.starts_with("--bin-") => {
                 let name = s.strip_prefix("--bin-").unwrap().to_string();
                 i += 1;
@@ -303,7 +312,7 @@ pub async fn run() {
                 Some(ix) => {
                     let cli_args = parse_instruction_args(&remaining_args[2..], ix);
                     execute_instruction(
-                        &idl, ix, &cli_args, &program_path, program_id_hex.as_deref(), dry_run, &extra_bins,
+                        &idl, ix, &cli_args, &program_path, program_id_hex.as_deref(), dry_run, dry_run_output.as_deref(), &extra_bins,
                     ).await;
                 }
                 None => {

--- a/spel-cli/src/lib.rs
+++ b/spel-cli/src/lib.rs
@@ -76,6 +76,15 @@ pub async fn run() {
             "--dry-run" => {
                 dry_run_format = Some("text");
             }
+            s if s.starts_with("--dry-run=") => {
+                let fmt = s.strip_prefix("--dry-run=").unwrap();
+                if fmt == "json" || fmt == "text" {
+                    dry_run_format = Some(fmt);
+                } else {
+                    eprintln!("❌ --dry-run only supports 'text' or 'json'");
+                    process::exit(1);
+                }
+            }
             s if s.starts_with("--dry-run ") => {
                 let fmt = s.strip_prefix("--dry-run ").unwrap();
                 if fmt == "json" || fmt == "text" {

--- a/spel-cli/src/lib.rs
+++ b/spel-cli/src/lib.rs
@@ -45,7 +45,7 @@ pub async fn run() {
     let mut program_path = "program.bin".to_string();
     let mut program_id_hex: Option<String> = None;
     let mut dry_run = false;
-    let mut dry_run_output: Option<String> = None;
+    let mut dry_run_output = false;
     let mut type_name: Option<String> = None;
     let mut data_hex: Option<String> = None;
     let mut extra_bins: HashMap<String, String> = HashMap::new();
@@ -76,8 +76,7 @@ pub async fn run() {
             }
             "--dry-run" => { dry_run = true; }
             "--dry-run-output" => {
-                i += 1;
-                if i < args.len() { dry_run_output = Some(args[i].clone()); }
+                dry_run_output = true;
                 if !dry_run {
                     println!("ℹ️  --dry-run-output implies --dry-run");
                     dry_run = true;
@@ -312,7 +311,7 @@ pub async fn run() {
                 Some(ix) => {
                     let cli_args = parse_instruction_args(&remaining_args[2..], ix);
                     execute_instruction(
-                        &idl, ix, &cli_args, &program_path, program_id_hex.as_deref(), dry_run, dry_run_output.as_deref(), &extra_bins,
+                        &idl, ix, &cli_args, &program_path, program_id_hex.as_deref(), dry_run, dry_run_output, &extra_bins,
                     ).await;
                 }
                 None => {

--- a/spel-cli/src/tx.rs
+++ b/spel-cli/src/tx.rs
@@ -25,8 +25,7 @@ pub async fn execute_instruction(
     args: &HashMap<String, String>,
     program_path: &str,
     program_id_hex: Option<&str>,
-    dry_run: bool,
-    dry_run_output: bool,
+    dry_run_format: Option<&str>,
     extra_bins: &HashMap<String, String>,
 ) {
     println!("📋 Instruction: {}", ix.name);
@@ -334,7 +333,8 @@ pub async fn execute_instruction(
     let instruction_data_hex = hex_words.join("");
 
     // JSON output
-    if dry_run_output {
+    if let Some(fmt) = dry_run_format {
+        if fmt == "json" {
         let json_obj = serde_json::json!({
             "dry_run": true,
             "program_id": program_id_hex_str,
@@ -349,6 +349,7 @@ pub async fn execute_instruction(
         });
         println!("{}", serde_json::to_string_pretty(&json_obj).unwrap());
         println!();
+        }
     }
 
     // Human-readable summary
@@ -384,7 +385,7 @@ pub async fn execute_instruction(
     println!("   Remove --dry-run to send this transaction.");
 
     // ─── Step 10: Early return for dry-run ───
-    if dry_run {
+    if dry_run_format.is_some() {
         return;
     }
 

--- a/spel-cli/src/tx.rs
+++ b/spel-cli/src/tx.rs
@@ -26,7 +26,7 @@ pub async fn execute_instruction(
     program_path: &str,
     program_id_hex: Option<&str>,
     dry_run: bool,
-    dry_run_output: Option<&str>,
+    dry_run_output: bool,
     extra_bins: &HashMap<String, String>,
 ) {
     println!("📋 Instruction: {}", ix.name);
@@ -338,11 +338,7 @@ pub async fn execute_instruction(
     let instruction_data_hex = hex_words.join("");
 
     // JSON output
-    if let Some(output_fmt) = dry_run_output {
-        if output_fmt != "json" {
-            eprintln!("❌ --dry-run-output only supports 'json' (got '{}')", output_fmt);
-            process::exit(1);
-        }
+    if dry_run_output {
         let json_obj = serde_json::json!({
             "dry_run": true,
             "program_id": program_id_hex_str,

--- a/spel-cli/src/tx.rs
+++ b/spel-cli/src/tx.rs
@@ -592,4 +592,5 @@ pub async fn execute_instruction(
                 process::exit(1);
             }
         }
+    }
 }

--- a/spel-cli/src/tx.rs
+++ b/spel-cli/src/tx.rs
@@ -570,25 +570,25 @@ pub async fn execute_instruction(
         let witness_set = WitnessSet::for_message(&message, &signing_keys);
         let tx = PublicTransaction::new(message, witness_set);
 
-    let tx_hash = wallet_core.sequencer_client.send_transaction(NSSATransaction::Public(tx)).await.unwrap_or_else(|e| {
-        eprintln!("❌ Failed to submit transaction: {:?}", e);
-        process::exit(1);
-    });
-
-    println!("📤 Transaction submitted!");
-    println!("   tx_hash: {}", tx_hash);
-    println!("   Waiting for confirmation...");
-
-    let poller = wallet::poller::TxPoller::new(
-        wallet_core.config(),
-        wallet_core.sequencer_client.clone(),
-    );
-
-    match poller.poll_tx(tx_hash).await {
-        Ok(_) => println!("✅ Transaction confirmed — included in a block."),
-        Err(e) => {
-            eprintln!("❌ Transaction NOT confirmed: {e:#}");
+        let tx_hash = wallet_core.sequencer_client.send_transaction(NSSATransaction::Public(tx)).await.unwrap_or_else(|e| {
+            eprintln!("❌ Failed to submit transaction: {:?}", e);
             process::exit(1);
+        });
+
+        println!("📤 Transaction submitted!");
+        println!("   tx_hash: {}", tx_hash);
+        println!("   Waiting for confirmation...");
+
+        let poller = wallet::poller::TxPoller::new(
+            wallet_core.config(),
+            wallet_core.sequencer_client.clone(),
+        );
+
+        match poller.poll_tx(tx_hash).await {
+            Ok(_) => println!("✅ Transaction confirmed — included in a block."),
+            Err(e) => {
+                eprintln!("❌ Transaction NOT confirmed: {e:#}");
+                process::exit(1);
+            }
         }
-    }
 }

--- a/spel-cli/src/tx.rs
+++ b/spel-cli/src/tx.rs
@@ -7,6 +7,7 @@ use nssa::program::Program;
 use nssa::public_transaction::{Message, WitnessSet};
 use nssa::{AccountId, PublicTransaction};
 use nssa_core::program::ProgramId;
+use nssa_core::account::Nonce;
 use spel_framework_core::idl::{IdlSeed, SpelIdl, IdlInstruction};
 use crate::hex::{hex_encode, decode_bytes_32, parse_account_id};
 use crate::parse::{parse_value, ParsedValue};
@@ -257,7 +258,7 @@ pub async fn execute_instruction(
         })
         .collect();
 
-    let nonces: Vec<Option<u64>> = if signer_accounts.is_empty() {
+    let nonces: Vec<Option<Nonce>> = if signer_accounts.is_empty() {
         vec![]
     } else {
         let wallet_core = WalletCore::from_env().unwrap_or_else(|e| {
@@ -348,14 +349,14 @@ pub async fn execute_instruction(
     let mut signers_json: Vec<serde_json::Value> = Vec::new();
     for (i, (name, id)) in signer_accounts.iter().enumerate() {
         let nonce_str = match nonces.get(i) {
-            Some(Some(n)) => format!("nonce={}", n),
+            Some(Some(n)) => format!("nonce={}", n.0 as u64),
             _ => "nonce=(unknown)".to_string(),
         };
         signers_summary.push(format!("  {}: {}", name, nonce_str));
         signers_json.push(serde_json::json!({
             "name": name,
             "address": format!("{}", id),
-            "nonce": nonces.get(i).and_then(|n| *n),
+            "nonce": nonces.get(i).and_then(|n| n.map(|x| x.0 as u64)),
         }));
     }
 
@@ -554,10 +555,10 @@ pub async fn execute_instruction(
 
         // Re-fetch nonces for submission (already fetched above, but need to get them again for the actual submission path)
         // We already have nonces from the dry-run fetch, re-use them
-        let nonces_for_submit: Vec<u64> = nonces.iter().map(|n| n.unwrap_or_else(|| {
+        let nonces_for_submit = nonces.iter().cloned().map(|n| n.unwrap_or_else(|| {
             eprintln!("❌ Nonce unknown for signer — cannot submit. Run --dry-run to see nonces.");
             process::exit(1);
-        })).collect();
+        })).collect::<Vec<Nonce>>();
 
         let signing_keys: Vec<_> = signer_ids.iter().map(|id| {
             wallet_core.storage().user_data.get_pub_account_signing_key(*id).unwrap_or_else(|| {

--- a/spel-cli/src/tx.rs
+++ b/spel-cli/src/tx.rs
@@ -253,10 +253,6 @@ pub async fn execute_instruction(
         parts.join("")
     };
 
-    if has_private {
-        println!("⚠️  Privacy-preserving transaction — dry-run fetches on-chain state which may reveal access patterns.");
-        println!();
-    }
 
     // Build account list for display and JSON
     let mut accounts_summary: Vec<String> = Vec::new();

--- a/spel-cli/src/tx.rs
+++ b/spel-cli/src/tx.rs
@@ -213,7 +213,7 @@ pub async fn execute_instruction(
         }
     }
 
-    // Check if any account has a Private/ prefix (needed for dry-run privacy warning too)
+    // Check if any account has a Private/ prefix
     let has_private = parsed_accounts.iter().any(|(_, _, is_priv)| *is_priv)
         || rest_accounts.iter().any(|(_, entries)| entries.iter().any(|(_, is_priv)| *is_priv));
 

--- a/spel-cli/src/tx.rs
+++ b/spel-cli/src/tx.rs
@@ -25,7 +25,7 @@ use wallet::WalletCore;
 fn format_pda_seeds(seeds: &[IdlSeed]) -> String {
     let parts: std::vec::Vec<String> = std::iter::once("program_id".to_string())
         .chain(seeds.iter().map(|s| match s {
-            IdlSeed::Const { value } => format!("\"{{{}}}\"", value),
+            IdlSeed::Const { value } => format!("\"{}\"", value),
             IdlSeed::Account { path } => format!("Account({})", path),
             IdlSeed::Arg { path } => format!("Arg({})", path),
         }))

--- a/spel-cli/src/tx.rs
+++ b/spel-cli/src/tx.rs
@@ -25,7 +25,7 @@ use wallet::WalletCore;
 fn format_pda_seeds(seeds: &[IdlSeed]) -> String {
     let parts: std::vec::Vec<String> = std::iter::once("program_id".to_string())
         .chain(seeds.iter().map(|s| match s {
-            IdlSeed::Const { value } => format!(""{}"", value),
+            IdlSeed::Const { value } => format!("\"{{{}}}\"", value),
             IdlSeed::Account { path } => format!("Account({})", path),
             IdlSeed::Arg { path } => format!("Arg({})", path),
         }))

--- a/spel-cli/src/tx.rs
+++ b/spel-cli/src/tx.rs
@@ -18,6 +18,33 @@ use hex;
 use sequencer_service_rpc::RpcClient as _;
 use wallet::WalletCore;
 
+
+/// Format PDA seeds into a display string for human-readable output.
+/// E.g. `[program_id, "owner", Account(vault)]`
+fn format_pda_seeds(seeds: &[IdlSeed]) -> String {
+    let parts: std::vec::Vec<String> = std::iter::once("program_id".to_string())
+        .chain(seeds.iter().map(|s| match s {
+            IdlSeed::Const { value } => format!(""{}"", value),
+            IdlSeed::Account { path } => format!("Account({})", path),
+            IdlSeed::Arg { path } => format!("Arg({})", path),
+        }))
+        .collect();
+    format!("[{}]", parts.join(", "))
+}
+
+/// Format PDA seeds into a JSON array for machine-readable output.
+fn pda_seeds_json(seeds: &[IdlSeed]) -> serde_json::Value {
+    let mut arr: Vec<serde_json::Value> = vec![serde_json::json!({"type": "program_id"})];
+    for s in seeds {
+        arr.push(match s {
+            IdlSeed::Const { value } => serde_json::json!({"type": "const", "value": value}),
+            IdlSeed::Account { path } => serde_json::json!({"type": "account", "name": path}),
+            IdlSeed::Arg { path } => serde_json::json!({"type": "arg", "name": path}),
+        });
+    }
+    serde_json::Value::Array(arr)
+}
+
 /// Execute an instruction: parse args, build TX, optionally submit.
 pub async fn execute_instruction(
     idl: &SpelIdl,
@@ -201,7 +228,9 @@ pub async fn execute_instruction(
         if let Some(pda) = &acc.pda {
             match compute_pda_from_seeds(&pda.seeds, &program_id, &account_map, &parsed_arg_map) {
                 Ok(id) => {
+                    let seed_str = format_pda_seeds(&pda.seeds);
                     println!("  PDA {} → {}", acc.name, id);
+                    println!("    seeds: {}", seed_str);
                     account_map.insert(acc.name.clone(), id);
                 }
                 Err(e) => {
@@ -262,13 +291,15 @@ pub async fn execute_instruction(
         if acc.pda.is_some() {
             let id = account_map.get(&acc.name).unwrap();
             let id_str = format!("{}", id);
-            let flags: Vec<&str> = ["PDA"].into_iter().collect();
-            accounts_summary.push(format!("  {} → {}  [{}]", acc.name, id_str, flags.join(", ")));
+            let seed_str = format_pda_seeds(&acc.pda.as_ref().unwrap().seeds);
+            accounts_summary.push(format!("  {} → {}", acc.name, id_str));
+            accounts_summary.push(format!("    seeds: {}", seed_str));
             raw_account_ids.push(id_str.clone());
             accounts_json.push(serde_json::json!({
                 "name": acc.name,
                 "address": id_str,
                 "pda": id_str,
+                "pda_seeds": pda_seeds_json(&acc.pda.as_ref().unwrap().seeds),
                 "signer": acc.signer,
                 "writable": acc.writable,
                 "rest": acc.rest,

--- a/spel-cli/src/tx.rs
+++ b/spel-cli/src/tx.rs
@@ -26,6 +26,7 @@ pub async fn execute_instruction(
     program_path: &str,
     program_id_hex: Option<&str>,
     dry_run: bool,
+    dry_run_output: Option<&str>,
     extra_bins: &HashMap<String, String>,
 ) {
     println!("📋 Instruction: {}", ix.name);
@@ -122,60 +123,8 @@ pub async fn execute_instruction(
     let risc0_args: Vec<_> = parsed_args.iter().map(|(_, ty, val)| (*ty, val)).collect();
     let instruction_data = serialize_to_risc0(ix_index as u32, &risc0_args);
 
-    // Display
-    println!("Accounts:");
-    for acc in &ix.accounts {
-        if acc.pda.is_some() {
-            println!("  📦 {} → auto-computed (PDA)", acc.name);
-        } else if acc.rest {
-            if let Some((_, entries)) = rest_accounts.iter().find(|(n, _)| *n == acc.name) {
-                if entries.is_empty() {
-                    println!("  📦 {} → (none — variadic rest)", acc.name);
-                } else {
-                    for (e, _) in entries {
-                        println!("  📦 {} → 0x{}", acc.name, hex_encode(e));
-                    }
-                }
-            }
-        } else {
-            let account_bytes = parsed_accounts.iter().find(|(n, _, _)| *n == acc.name).unwrap();
-            println!("  📦 {} → 0x{}", acc.name, hex_encode(&account_bytes.1));
-        }
-    }
-    println!();
-    println!("Arguments (parsed):");
-    for (name, _, val) in &parsed_args {
-        println!("  {} = {}", name, val);
-    }
-    println!();
-    println!("🔧 Transaction:");
-    if let Some(pid) = program_id_hex {
-        println!("  program-id: {}", pid);
-    } else {
-        println!("  program: {}", program_path);
-    }
-    println!("  instruction index: {}", ix_index);
-    println!("  instruction: {} {{", to_pascal_case(&ix.name));
-    for (name, _, val) in &parsed_args {
-        println!("    {}: {},", name, val);
-    }
-    println!("  }}");
-    println!();
-    println!("  Serialized instruction data ({} u32 words):", instruction_data.len());
-    let hex_words: Vec<String> = instruction_data.iter().map(|w| format!("{:08x}", w)).collect();
-    println!("    [{}]", hex_words.join(", "));
-    println!();
-
-    if dry_run {
-        println!("⚠️  Dry run — omit --dry-run to submit the transaction.");
-        return;
-    }
-
-    // ─── Transaction submission ──────────────────────────────────
-    println!("📤 Submitting transaction...");
-
-    // Resolve program_id: from --program-id hex flag, or by loading the binary
-    let (program_id, program_obj): (ProgramId, Option<Program>) = if let Some(hex) = program_id_hex {
+    // ─── Step 4: Load program binary or resolve program ID ───
+    let (program_id, _program_obj): (ProgramId, Option<Program>) = if let Some(hex) = program_id_hex {
         let bytes = decode_bytes_32(hex).unwrap_or_else(|e| {
             eprintln!("❌ Invalid --program-id '{}': {}", hex, e);
             process::exit(1);
@@ -185,7 +134,7 @@ pub async fn execute_instruction(
             pid[i] = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
         }
         (pid, None)
-    } else {
+    } else if !program_path.is_empty() && std::path::Path::new(program_path).exists() {
         let program_bytecode = fs::read(program_path).unwrap_or_else(|e| {
             eprintln!("❌ Failed to read program binary '{}': {}", program_path, e);
             eprintln!("   Hint: pass --program-id <hex> to skip loading the binary");
@@ -197,10 +146,12 @@ pub async fn execute_instruction(
         });
         let pid = program.id();
         (pid, Some(program))
+    } else {
+        eprintln!("❌ Program binary or --program-id required. Pass --program <path> or --program-id <hex>.");
+        process::exit(1);
     };
-    println!("  Program ID: {:?}", program_id);
 
-    // Build account map for PDA resolution
+    // ─── Step 5: Build account map ───
     let mut account_map: HashMap<String, AccountId> = HashMap::new();
     for (name, bytes, _) in &parsed_accounts {
         let mut arr = [0u8; 32];
@@ -246,7 +197,7 @@ pub async fn execute_instruction(
         parsed_arg_map.insert(name.to_string(), val.clone());
     }
 
-    // Resolve PDA accounts
+    // ─── Step 6: Resolve PDA accounts ───
     for acc in &ix.accounts {
         if let Some(pda) = &acc.pda {
             match compute_pda_from_seeds(&pda.seeds, &program_id, &account_map, &parsed_arg_map) {
@@ -262,15 +213,215 @@ pub async fn execute_instruction(
         }
     }
 
+    // Check if any account has a Private/ prefix (needed for dry-run privacy warning too)
+    let has_private = parsed_accounts.iter().any(|(_, _, is_priv)| *is_priv)
+        || rest_accounts.iter().any(|(_, entries)| entries.iter().any(|(_, is_priv)| *is_priv));
+
+    // ─── Step 7: Fetch nonces for signer accounts ───
+    let signer_accounts: Vec<(String, AccountId)> = ix.accounts.iter()
+        .filter(|a| a.signer)
+        .map(|a| {
+            let id = *account_map.get(&a.name).unwrap_or_else(|| {
+                eprintln!("❌ Signer account '{}' not resolved", a.name);
+                process::exit(1);
+            });
+            (a.name.clone(), id)
+        })
+        .collect();
+
+    let nonces: Vec<Option<u64>> = if signer_accounts.is_empty() {
+        vec![]
+    } else {
+        let wallet_core = WalletCore::from_env().unwrap_or_else(|e| {
+            eprintln!("❌ Failed to initialize wallet: {:?}", e);
+            eprintln!("   Set NSSA_WALLET_HOME_DIR environment variable");
+            process::exit(1);
+        });
+        let signer_ids: Vec<AccountId> = signer_accounts.iter().map(|(_, id)| *id).collect();
+        match wallet_core.get_accounts_nonces(signer_ids).await {
+            Ok(ns) => ns.into_iter().map(Some).collect(),
+            Err(e) => {
+                eprintln!("⚠️  Could not fetch nonces: {:?}", e);
+                signer_accounts.iter().map(|_| None).collect()
+            }
+        }
+    };
+
+    // ─── Step 8 & 9: Print transaction summary (and JSON if requested) ───
+    let program_id_hex_str = {
+        let parts: Vec<String> = program_id.iter().map(|w| format!("{:08x}", w)).collect();
+        parts.join("")
+    };
+
+    if has_private {
+        println!("⚠️  Privacy-preserving transaction — dry-run fetches on-chain state which may reveal access patterns.");
+        println!();
+    }
+
+    // Build account list for display and JSON
+    let mut accounts_summary: Vec<String> = Vec::new();
+    let mut accounts_json: Vec<serde_json::Value> = Vec::new();
+    let mut raw_account_ids: Vec<String> = Vec::new();
+
+    for acc in &ix.accounts {
+        if acc.pda.is_some() {
+            let id = account_map.get(&acc.name).unwrap();
+            let id_str = format!("{}", id);
+            let flags: Vec<&str> = ["PDA"].into_iter().collect();
+            accounts_summary.push(format!("  {} → {}  [{}]", acc.name, id_str, flags.join(", ")));
+            raw_account_ids.push(id_str.clone());
+            accounts_json.push(serde_json::json!({
+                "name": acc.name,
+                "address": id_str,
+                "pda": id_str,
+                "signer": acc.signer,
+                "writable": acc.writable,
+                "rest": acc.rest,
+            }));
+        } else if acc.rest {
+            if let Some((_, entries)) = rest_accounts.iter().find(|(n, _)| *n == acc.name) {
+                if entries.is_empty() {
+                    accounts_summary.push(format!("  {} → (none — variadic rest)", acc.name));
+                } else {
+                    for (e, _) in entries {
+                        let id_str = format!("0x{}", hex_encode(e));
+                        accounts_summary.push(format!("  {} → {}", acc.name, id_str));
+                        raw_account_ids.push(id_str.clone());
+                    }
+                }
+            }
+        } else {
+            let (_, bytes, _) = parsed_accounts.iter().find(|(n, _, _)| *n == acc.name).unwrap();
+            let id_str = format!("0x{}", hex_encode(bytes));
+            let mut flags = vec![];
+            if acc.signer { flags.push("signer"); }
+            if acc.writable { flags.push("writable"); }
+            accounts_summary.push(format!("  {} → {}  [{}]", acc.name, id_str, flags.join(", ")));
+            raw_account_ids.push(id_str.clone());
+            accounts_json.push(serde_json::json!({
+                "name": acc.name,
+                "address": id_str,
+                "pda": null,
+                "signer": acc.signer,
+                "writable": acc.writable,
+                "rest": acc.rest,
+            }));
+        }
+    }
+
+    // Arguments for display and JSON
+    let mut args_summary: Vec<String> = Vec::new();
+    let mut args_json: serde_json::Map<String, serde_json::Value> = serde_json::Map::new();
+    for (name, _, val) in &parsed_args {
+        args_summary.push(format!("  {}: {}", name, val));
+        args_json.insert(name.to_string(), serde_json::Value::String(val.to_string()));
+    }
+
+    // Signers for display and JSON
+    let mut signers_summary: Vec<String> = Vec::new();
+    let mut signers_json: Vec<serde_json::Value> = Vec::new();
+    for (i, (name, id)) in signer_accounts.iter().enumerate() {
+        let nonce_str = match nonces.get(i) {
+            Some(Some(n)) => format!("nonce={}", n),
+            _ => "nonce=(unknown)".to_string(),
+        };
+        signers_summary.push(format!("  {}: {}", name, nonce_str));
+        signers_json.push(serde_json::json!({
+            "name": name,
+            "address": format!("{}", id),
+            "nonce": nonces.get(i).and_then(|n| *n),
+        }));
+    }
+
+    // Instruction data words
+    let hex_words: Vec<String> = instruction_data.iter().map(|w| format!("{:08x}", w)).collect();
+    let instruction_data_hex = hex_words.join("");
+
+    // JSON output
+    if let Some(output_fmt) = dry_run_output {
+        if output_fmt != "json" {
+            eprintln!("❌ --dry-run-output only supports 'json' (got '{}')", output_fmt);
+            process::exit(1);
+        }
+        let json_obj = serde_json::json!({
+            "dry_run": true,
+            "program_id": program_id_hex_str,
+            "instruction_index": ix_index,
+            "instruction_name": ix.name,
+            "accounts": accounts_json,
+            "arguments": args_json,
+            "instruction_data_hex": instruction_data_hex,
+            "instruction_data_words": instruction_data,
+            "signers": signers_json,
+            "raw_account_ids": raw_account_ids,
+        });
+        println!("{}", serde_json::to_string_pretty(&json_obj).unwrap());
+        println!();
+    }
+
+    // Human-readable summary
+    println!("━━━ Transaction Summary ━━━━━━━━━━━━━━━━━━━━━━━");
+    println!("🔷 Program ID: {}  (derived from binary)", program_id_hex_str);
+    println!("📋 Instruction index: {}  ({})", ix_index, ix.name);
+    println!();
+    println!("📦 Accounts:");
+    for line in &accounts_summary {
+        println!("{}", line);
+    }
+    println!();
+    println!("Parsed Arguments:");
+    for line in &args_summary {
+        println!("{}", line);
+    }
+    println!();
+    println!("🔧 Serialized instruction data ({} u32 words):", instruction_data.len());
+    println!("    [{}]", hex_words.join(", "));
+    println!();
+    if signer_accounts.is_empty() {
+        println!("🔑 Signers: (none)");
+    } else {
+        println!("🔑 Signers and Nonces:");
+        for line in &signers_summary {
+            println!("{}", line);
+        }
+    }
+    println!();
+    println!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    println!();
+    println!("⚠️  Dry run — this is what WOULD be submitted.");
+    println!("   Remove --dry-run to send this transaction.");
+
+    // ─── Step 10: Early return for dry-run ───
+    if dry_run {
+        return;
+    }
+
+    // ─── Transaction submission ──────────────────────────────────
+    println!();
+    println!("📤 Submitting transaction...");
+    println!("  Program ID: {:?}", program_id);
+
+    // Reload program for submission (program_obj was consumed earlier; re-read if needed)
+    let program_obj = if program_id_hex.is_some() {
+        None
+    } else {
+        let program_bytecode = fs::read(program_path).unwrap_or_else(|e| {
+            eprintln!("❌ Failed to read program binary '{}': {}", program_path, e);
+            process::exit(1);
+        });
+        Some(Program::new(program_bytecode).unwrap_or_else(|e| {
+            eprintln!("❌ Failed to load program: {:?}", e);
+            process::exit(1);
+        }))
+    };
+
     let wallet_core = WalletCore::from_env().unwrap_or_else(|e| {
         eprintln!("❌ Failed to initialize wallet: {:?}", e);
         eprintln!("   Set NSSA_WALLET_HOME_DIR environment variable");
         process::exit(1);
     });
 
-    // Check if any account has a Private/ prefix
-    let has_private = parsed_accounts.iter().any(|(_, _, is_priv)| *is_priv)
-        || rest_accounts.iter().any(|(_, entries)| entries.iter().any(|(_, is_priv)| *is_priv));
+    // has_private already checked above (before Step 8)
 
     if has_private {
         // ─── Privacy-preserving transaction ──────────────────
@@ -375,28 +526,23 @@ pub async fn execute_instruction(
             }
         }
 
-        let signer_accounts: Vec<AccountId> = ix.accounts.iter()
-            .filter(|a| a.signer)
-            .map(|a| *account_map.get(&a.name).unwrap())
-            .collect();
+        let signer_ids: Vec<AccountId> = signer_accounts.iter().map(|(_, id)| *id).collect();
 
-        let nonces = if signer_accounts.is_empty() {
-            vec![]
-        } else {
-            wallet_core.get_accounts_nonces(signer_accounts.clone()).await.unwrap_or_else(|e| {
-                eprintln!("❌ Failed to fetch nonces: {:?}", e);
-                process::exit(1);
-            })
-        };
+        // Re-fetch nonces for submission (already fetched above, but need to get them again for the actual submission path)
+        // We already have nonces from the dry-run fetch, re-use them
+        let nonces_for_submit: Vec<u64> = nonces.iter().map(|n| n.unwrap_or_else(|| {
+            eprintln!("❌ Nonce unknown for signer — cannot submit. Run --dry-run to see nonces.");
+            process::exit(1);
+        })).collect();
 
-        let signing_keys: Vec<_> = signer_accounts.iter().map(|id| {
+        let signing_keys: Vec<_> = signer_ids.iter().map(|id| {
             wallet_core.storage().user_data.get_pub_account_signing_key(*id).unwrap_or_else(|| {
                 eprintln!("❌ Signing key not found for account {}", id);
                 process::exit(1);
             })
         }).collect();
 
-        let message = Message::new_preserialized(program_id, account_ids, nonces, instruction_data);
+        let message = Message::new_preserialized(program_id, account_ids, nonces_for_submit, instruction_data);
         let witness_set = WitnessSet::for_message(&message, &signing_keys);
         let tx = PublicTransaction::new(message, witness_set);
 
@@ -421,5 +567,4 @@ pub async fn execute_instruction(
             process::exit(1);
         }
     }
-}
 }


### PR DESCRIPTION
## Summary

When a PDA is resolved during dry-run or submit, print the seed inputs used to derive it. Helps developers debug derivation issues without reverse-engineering the IDL.

## What changed

**`spel-cli/src/tx.rs`:**
- Added `format_pda_seeds()` — formats `&[IdlSeed]` as a display string: `[program_id, "owner", Account(vault)]`
- Added `pda_seeds_json()` — formats seeds as a JSON array for machine-readable output
- Step 6 PDA resolution loop now prints `seeds: [...]` line after each PDA
- Step 8 summary block shows `seeds: [...]` for each PDA account entry
- `pda_seeds` array added to JSON output for PDA accounts

## Example output

Human-readable:
```
  PDA owner → 4Lp3gkHvpFbSMRDtGvLBdNzoe6VzNMwdH6sugRHNXKcn
    seeds: [program_id, "owner"]

  PDA vault → 7qYdUSGpAFLBdBgLSM1LtXcoDXLY6J3XwFM4yAT3Sp9g
    seeds: [program_id, "vault", Account(owner)]
```

JSON:
```json
{
  "name": "vault",
  "address": "7qYdUSGpAFLBdBgLSM1LtXcoDXLY6J3XwFM4yAT3Sp9g",
  "pda": "7qYdUSGpAFLBdBgLSM1LtXcoDXLY6J3XwFM4yAT3Sp9g",
  "pda_seeds": [
    { "type": "program_id" },
    { "type": "const", "value": "vault" },
    { "type": "account", "name": "owner" }
  ],
  ...
}
```