### PR TITLE
feat(spel-cli): show seed inputs in PDA derivation output

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,19 @@ mod my_program {
 | `#[account(pda = arg("create_key"))]` | PDA derived from an instruction argument |
 | `members: Vec<AccountWithMetadata>` | Variable-length trailing account list |
 
+### PDA Seed Display
+
+When the CLI derives PDA accounts during transaction execution, it prints the seed inputs used for each derivation:
+
+```
+  PDA vault → 4Lp3gkH...
+    seeds: [program_id, "state"]
+  PDA token_account → 7xQ2m...
+    seeds: [program_id, Account(owner), Arg(create_key)]
+```
+
+Seeds always start with `program_id`, followed by the seeds declared in the account attribute. Constant strings appear quoted, account references as `Account(name)`, and instruction arguments as `Arg(name)`.
+
 ### Runtime Validation
 
 Accounts marked with `#[account(signer)]` or `#[account(init)]` get **automatic runtime checks** before your handler runs:
@@ -236,6 +249,10 @@ spel --idl program-idl.json --program-id <64-char-hex>   create-vault --token-na
 
 # Compute a PDA from the IDL
 spel --idl program-idl.json --program-id <64-char-hex> pda vault --create-key my-multisig
+
+# PDA derivation output shows seed inputs:
+#   PDA vault → 4Lp3gkH...
+#     seeds: [program_id, "state"]
 
 # Auto-fill program IDs from binaries
 spel --idl program-idl.json -p treasury.bin --bin-token token.bin \

--- a/spel-cli/src/tx.rs
+++ b/spel-cli/src/tx.rs
@@ -1,21 +1,35 @@
 //! Transaction building and submission.
 
 use std::collections::HashMap;
-use std::fs;
-use std::process;
+
+/// Format PDA seeds into a display string for human-readable output.
+/// E.g. `[program_id, "owner", Account(vault)]`
+fn format_pda_seeds(seeds: &[IdlSeed]) -> String {
+    let parts: Vec<String> = std::iter::once("program_id".to_string())
+        .chain(seeds.iter().map(|s| match s {
+            IdlSeed::Const { value } => format!("\"{}\"", value),
+            IdlSeed::Account { path } => format!("Account({})", path),
+            IdlSeed::Arg { path } => format!("Arg({})", path),
+        }))
+        .collect();
+    format!("[{}]", parts.join(", "))
+}
+
+use crate::cli::{snake_to_kebab, to_pascal_case};
+use crate::hex::{decode_bytes_32, hex_encode, parse_account_id};
+use crate::parse::{parse_value, ParsedValue};
+use crate::pda::compute_pda_from_seeds;
+use crate::serialize::serialize_to_risc0;
+use common::transaction::NSSATransaction;
+use hex;
 use nssa::program::Program;
 use nssa::public_transaction::{Message, WitnessSet};
 use nssa::{AccountId, PublicTransaction};
 use nssa_core::program::ProgramId;
-use spel_framework_core::idl::{IdlSeed, SpelIdl, IdlInstruction};
-use crate::hex::{hex_encode, decode_bytes_32, parse_account_id};
-use crate::parse::{parse_value, ParsedValue};
-use crate::serialize::serialize_to_risc0;
-use crate::pda::compute_pda_from_seeds;
-use crate::cli::{snake_to_kebab, to_pascal_case};
-use common::transaction::NSSATransaction;
-use hex;
 use sequencer_service_rpc::RpcClient as _;
+use spel_framework_core::idl::{IdlInstruction, IdlSeed, SpelIdl};
+use std::fs;
+use std::process;
 use wallet::WalletCore;
 
 /// Execute an instruction: parse args, build TX, optionally submit.
@@ -78,7 +92,10 @@ pub async fn execute_instruction(
         let raw = args.get(&key).unwrap();
         match parse_value(raw, &arg.type_) {
             Ok(val) => parsed_args.push((&arg.name, &arg.type_, val)),
-            Err(e) => { eprintln!("❌ --{}: {}", key, e); has_errors = true; }
+            Err(e) => {
+                eprintln!("❌ --{}: {}", key, e);
+                has_errors = true;
+            }
         }
     }
 
@@ -87,8 +104,15 @@ pub async fn execute_instruction(
     // rest accounts are variadic: each expands to 0 or more AccountIds
     let mut rest_accounts: Vec<(&str, Vec<(Vec<u8>, bool)>)> = Vec::new();
     for acc in &ix.accounts {
-        if acc.pda.is_some() { continue; }
-        if acc.rest { let key = snake_to_kebab(&acc.name); if !args.contains_key(&key) { continue; } }
+        if acc.pda.is_some() {
+            continue;
+        }
+        if acc.rest {
+            let key = snake_to_kebab(&acc.name);
+            if !args.contains_key(&key) {
+                continue;
+            }
+        }
         let key = snake_to_kebab(&acc.name);
         if acc.rest {
             // variadic: optional, comma-separated list of account IDs (0 entries is valid)
@@ -96,10 +120,12 @@ pub async fn execute_instruction(
                 raw.split(',')
                     .map(|s| s.trim())
                     .filter(|s| !s.is_empty())
-                    .map(|s| {
-                        match parse_account_id(s) {
-                            Ok((bytes, is_priv)) => (bytes.to_vec(), is_priv),
-                            Err(e) => { eprintln!("❌ --{}: {}", key, e); has_errors = true; (vec![], false) }
+                    .map(|s| match parse_account_id(s) {
+                        Ok((bytes, is_priv)) => (bytes.to_vec(), is_priv),
+                        Err(e) => {
+                            eprintln!("❌ --{}: {}", key, e);
+                            has_errors = true;
+                            (vec![], false)
                         }
                     })
                     .collect()
@@ -111,14 +137,23 @@ pub async fn execute_instruction(
             let raw = args.get(&key).unwrap();
             match parse_account_id(raw) {
                 Ok((bytes, is_priv)) => parsed_accounts.push((&acc.name, bytes.to_vec(), is_priv)),
-                Err(e) => { eprintln!("❌ --{}: {}", key, e); has_errors = true; }
+                Err(e) => {
+                    eprintln!("❌ --{}: {}", key, e);
+                    has_errors = true;
+                }
             }
         }
     }
-    if has_errors { process::exit(1); }
+    if has_errors {
+        process::exit(1);
+    }
 
     // Build risc0 serialized data
-    let ix_index = idl.instructions.iter().position(|i| i.name == ix.name).unwrap_or(0);
+    let ix_index = idl
+        .instructions
+        .iter()
+        .position(|i| i.name == ix.name)
+        .unwrap_or(0);
     let risc0_args: Vec<_> = parsed_args.iter().map(|(_, ty, val)| (*ty, val)).collect();
     let instruction_data = serialize_to_risc0(ix_index as u32, &risc0_args)
         .unwrap_or_else(|e| {
@@ -142,7 +177,10 @@ pub async fn execute_instruction(
                 }
             }
         } else {
-            let account_bytes = parsed_accounts.iter().find(|(n, _, _)| *n == acc.name).unwrap();
+            let account_bytes = parsed_accounts
+                .iter()
+                .find(|(n, _, _)| *n == acc.name)
+                .unwrap();
             println!("  📦 {} → 0x{}", acc.name, hex_encode(&account_bytes.1));
         }
     }
@@ -165,8 +203,14 @@ pub async fn execute_instruction(
     }
     println!("  }}");
     println!();
-    println!("  Serialized instruction data ({} u32 words):", instruction_data.len());
-    let hex_words: Vec<String> = instruction_data.iter().map(|w| format!("{:08x}", w)).collect();
+    println!(
+        "  Serialized instruction data ({} u32 words):",
+        instruction_data.len()
+    );
+    let hex_words: Vec<String> = instruction_data
+        .iter()
+        .map(|w| format!("{:08x}", w))
+        .collect();
     println!("    [{}]", hex_words.join(", "));
     println!();
 
@@ -179,7 +223,8 @@ pub async fn execute_instruction(
     println!("📤 Submitting transaction...");
 
     // Resolve program_id: from --program-id hex flag, or by loading the binary
-    let (program_id, program_obj): (ProgramId, Option<Program>) = if let Some(hex) = program_id_hex {
+    let (program_id, program_obj): (ProgramId, Option<Program>) = if let Some(hex) = program_id_hex
+    {
         let bytes = decode_bytes_32(hex).unwrap_or_else(|e| {
             eprintln!("❌ Invalid program ID '{}': {}", hex, e);
             process::exit(1);
@@ -237,10 +282,16 @@ pub async fn execute_instruction(
                                     println!("  ℹ️  Using --{} for PDA seed '{}'", key, path);
                                     account_map.insert(path.clone(), AccountId::new(bytes));
                                 }
-                                Err(e) => { eprintln!("❌ --{}: {}", key, e); process::exit(1); }
+                                Err(e) => {
+                                    eprintln!("❌ --{}: {}", key, e);
+                                    process::exit(1);
+                                }
                             }
                         } else {
-                            eprintln!("❌ PDA '{}' requires account '{}' — provide --{}", acc.name, path, key);
+                            eprintln!(
+                                "❌ PDA '{}' requires account '{}' — provide --{}",
+                                acc.name, path, key
+                            );
                             process::exit(1);
                         }
                     }
@@ -259,7 +310,9 @@ pub async fn execute_instruction(
         if let Some(pda) = &acc.pda {
             match compute_pda_from_seeds(&pda.seeds, &program_id, &account_map, &parsed_arg_map) {
                 Ok(id) => {
+                    let seed_str = format_pda_seeds(&pda.seeds);
                     println!("  PDA {} → {}", acc.name, id);
+                    println!("    seeds: {}", seed_str);
                     account_map.insert(acc.name.clone(), id);
                 }
                 Err(e) => {
@@ -278,15 +331,19 @@ pub async fn execute_instruction(
 
     // Check if any account has a Private/ prefix
     let has_private = parsed_accounts.iter().any(|(_, _, is_priv)| *is_priv)
-        || rest_accounts.iter().any(|(_, entries)| entries.iter().any(|(_, is_priv)| *is_priv));
+        || rest_accounts
+            .iter()
+            .any(|(_, entries)| entries.iter().any(|(_, is_priv)| *is_priv));
 
     if has_private {
         // ─── Privacy-preserving transaction ──────────────────
-        use wallet::PrivacyPreservingAccount;
         use nssa::privacy_preserving_transaction::circuit::ProgramWithDependencies;
+        use wallet::PrivacyPreservingAccount;
 
         let program = program_obj.unwrap_or_else(|| {
-            eprintln!("❌ Privacy-preserving transactions require the program binary (not --program-id)");
+            eprintln!(
+                "❌ Privacy-preserving transactions require the program binary (not --program-id)"
+            );
             process::exit(1);
         });
 
@@ -317,7 +374,9 @@ pub async fn execute_instruction(
                         }
                     }
                 }
-            } else if let Some((_, _, is_priv)) = parsed_accounts.iter().find(|(n, _, _)| *n == acc.name) {
+            } else if let Some((_, _, is_priv)) =
+                parsed_accounts.iter().find(|(n, _, _)| *n == acc.name)
+            {
                 let id = *account_map.get(&acc.name).unwrap_or_else(|| {
                     eprintln!("❌ Account '{}' not resolved", acc.name);
                     process::exit(1);
@@ -337,14 +396,16 @@ pub async fn execute_instruction(
             }
         }
 
-        let (response, _shared_secrets) = wallet_core.send_privacy_preserving_tx(
-            pp_accounts,
-            instruction_data,
-            &program_with_deps,
-        ).await.unwrap_or_else(|e| {
-            eprintln!("❌ Failed to submit privacy-preserving transaction: {:?}", e);
-            process::exit(1);
-        });
+        let (response, _shared_secrets) = wallet_core
+            .send_privacy_preserving_tx(pp_accounts, instruction_data, &program_with_deps)
+            .await
+            .unwrap_or_else(|e| {
+                eprintln!(
+                    "❌ Failed to submit privacy-preserving transaction: {:?}",
+                    e
+                );
+                process::exit(1);
+            });
 
         println!("📤 Privacy-preserving transaction submitted!");
         println!("   tx_hash: {}", hex::encode(response.0));
@@ -383,7 +444,9 @@ pub async fn execute_instruction(
             }
         }
 
-        let signer_accounts: Vec<AccountId> = ix.accounts.iter()
+        let signer_accounts: Vec<AccountId> = ix
+            .accounts
+            .iter()
             .filter(|a| a.signer)
             .map(|a| *account_map.get(&a.name).unwrap())
             .collect();
@@ -391,43 +454,57 @@ pub async fn execute_instruction(
         let nonces = if signer_accounts.is_empty() {
             vec![]
         } else {
-            wallet_core.get_accounts_nonces(signer_accounts.clone()).await.unwrap_or_else(|e| {
-                eprintln!("❌ Failed to fetch nonces: {:?}", e);
-                process::exit(1);
-            })
+            wallet_core
+                .get_accounts_nonces(signer_accounts.clone())
+                .await
+                .unwrap_or_else(|e| {
+                    eprintln!("❌ Failed to fetch nonces: {:?}", e);
+                    process::exit(1);
+                })
         };
 
-        let signing_keys: Vec<_> = signer_accounts.iter().map(|id| {
-            wallet_core.storage().user_data.get_pub_account_signing_key(*id).unwrap_or_else(|| {
-                eprintln!("❌ Signing key not found for account {}", id);
-                process::exit(1);
+        let signing_keys: Vec<_> = signer_accounts
+            .iter()
+            .map(|id| {
+                wallet_core
+                    .storage()
+                    .user_data
+                    .get_pub_account_signing_key(*id)
+                    .unwrap_or_else(|| {
+                        eprintln!("❌ Signing key not found for account {}", id);
+                        process::exit(1);
+                    })
             })
-        }).collect();
+            .collect();
 
         let message = Message::new_preserialized(program_id, account_ids, nonces, instruction_data);
         let witness_set = WitnessSet::for_message(&message, &signing_keys);
         let tx = PublicTransaction::new(message, witness_set);
 
-    let tx_hash = wallet_core.sequencer_client.send_transaction(NSSATransaction::Public(tx)).await.unwrap_or_else(|e| {
-        eprintln!("❌ Failed to submit transaction: {:?}", e);
-        process::exit(1);
-    });
+        let tx_hash = wallet_core
+            .sequencer_client
+            .send_transaction(NSSATransaction::Public(tx))
+            .await
+            .unwrap_or_else(|e| {
+                eprintln!("❌ Failed to submit transaction: {:?}", e);
+                process::exit(1);
+            });
 
-    println!("📤 Transaction submitted!");
-    println!("   tx_hash: {}", tx_hash);
-    println!("   Waiting for confirmation...");
+        println!("📤 Transaction submitted!");
+        println!("   tx_hash: {}", tx_hash);
+        println!("   Waiting for confirmation...");
 
-    let poller = wallet::poller::TxPoller::new(
-        wallet_core.config(),
-        wallet_core.sequencer_client.clone(),
-    );
+        let poller = wallet::poller::TxPoller::new(
+            wallet_core.config(),
+            wallet_core.sequencer_client.clone(),
+        );
 
-    match poller.poll_tx(tx_hash).await {
-        Ok(_) => println!("✅ Transaction confirmed — included in a block."),
-        Err(e) => {
-            eprintln!("❌ Transaction NOT confirmed: {e:#}");
-            process::exit(1);
+        match poller.poll_tx(tx_hash).await {
+            Ok(_) => println!("✅ Transaction confirmed — included in a block."),
+            Err(e) => {
+                eprintln!("❌ Transaction NOT confirmed: {e:#}");
+                process::exit(1);
+            }
         }
     }
-}
 }


### PR DESCRIPTION
## Summary

Show seed inputs when displaying PDA derivation, so it's clear which seeds were used to derive each PDA.

When a PDA is resolved during dry-run or submit, the output now shows:


**Clean PR** — only the seed display feature, no dry-run infrastructure changes.

## What changed

- Added  function: formats Const seeds as , Account seeds as , Arg seeds as 
- Added  after each PDA derivation line

## Testing
- `cargo fmt --check` ✅
- `cargo check` ✅

## Related
Part of logos-co/spel#10 (wishlist)