### PR TITLE
feat(spel-framework): support LEZ validity windows in program output

### DIFF
--- a/spel-framework-core/src/lib.rs
+++ b/spel-framework-core/src/lib.rs
@@ -18,5 +18,9 @@ pub mod prelude {
     pub use crate::spel_output::AutoClaim;
     pub use crate::types::{IntoPostState, SpelOutput, AccountConstraint};
     pub use nssa_core::account::{Account, AccountWithMetadata};
-    pub use nssa_core::program::{AccountPostState, ChainedCall, Claim, PdaSeed, ProgramId};
+    pub use nssa_core::program::{
+        AccountPostState, BlockValidityWindow, ChainedCall, Claim, InvalidWindow, PdaSeed,
+        ProgramId, TimestampValidityWindow, ValidityWindow,
+    };
+    pub use nssa_core::{BlockId, Timestamp};
 }

--- a/spel-framework-core/src/spel_output.rs
+++ b/spel-framework-core/src/spel_output.rs
@@ -5,7 +5,7 @@
 //! `(Account, AutoClaim)` pairs into the correct `AccountPostState` values.
 
 use nssa_core::account::Account;
-use nssa_core::program::{AccountPostState, ChainedCall, Claim, PdaSeed};
+use nssa_core::program::{AccountPostState, ChainedCall, Claim, PdaSeed, ValidityWindow};
 
 use crate::types::{IntoPostState, SpelOutput};
 
@@ -128,6 +128,8 @@ impl SpelOutput {
         Self {
             post_states,
             chained_calls: calls,
+            block_validity_window: ValidityWindow::new_unbounded(),
+            timestamp_validity_window: ValidityWindow::new_unbounded(),
         }
     }
 
@@ -159,6 +161,8 @@ impl SpelOutput {
         Self {
             post_states,
             chained_calls: calls,
+            block_validity_window: ValidityWindow::new_unbounded(),
+            timestamp_validity_window: ValidityWindow::new_unbounded(),
         }
     }
 }
@@ -248,5 +252,112 @@ mod tests {
     fn pda_from_seeds_multi() {
         let claim = AutoClaim::pda_from_seeds(&[&[1u8; 32], &[2u8; 32]]);
         assert!(claim.is_claimed());
+    }
+
+    // ── Validity window tests ────────────────────────────────────────────
+
+    /// Existing programs that don't call any validity window builder get unbounded
+    /// windows, which matches the prior hard-coded behavior.
+    #[test]
+    fn default_output_has_unbounded_windows() {
+        let output = SpelOutput::execute(Vec::<(Account, AutoClaim)>::new(), vec![]);
+        assert_eq!(output.block_validity_window.start(), None);
+        assert_eq!(output.block_validity_window.end(), None);
+        assert_eq!(output.timestamp_validity_window.start(), None);
+        assert_eq!(output.timestamp_validity_window.end(), None);
+    }
+
+    #[test]
+    fn execute_with_claims_default_windows_unbounded() {
+        let output = SpelOutput::execute_with_claims(&[], &[], vec![]);
+        assert_eq!(output.block_validity_window.start(), None);
+        assert_eq!(output.block_validity_window.end(), None);
+    }
+
+    #[test]
+    fn with_block_validity_window_range_from() {
+        let output = SpelOutput::execute(Vec::<(Account, AutoClaim)>::new(), vec![])
+            .with_block_validity_window(42u64..);
+        assert_eq!(output.block_validity_window.start(), Some(42));
+        assert_eq!(output.block_validity_window.end(), None);
+    }
+
+    #[test]
+    fn with_block_validity_window_range_to() {
+        let output = SpelOutput::execute(Vec::<(Account, AutoClaim)>::new(), vec![])
+            .with_block_validity_window(..100u64);
+        assert_eq!(output.block_validity_window.start(), None);
+        assert_eq!(output.block_validity_window.end(), Some(100));
+    }
+
+    #[test]
+    fn with_block_validity_window_unbounded() {
+        let output = SpelOutput::execute(Vec::<(Account, AutoClaim)>::new(), vec![])
+            .with_block_validity_window(..);
+        assert_eq!(output.block_validity_window.start(), None);
+        assert_eq!(output.block_validity_window.end(), None);
+    }
+
+    #[test]
+    fn try_with_block_validity_window_valid_range() {
+        let output = SpelOutput::execute(Vec::<(Account, AutoClaim)>::new(), vec![])
+            .try_with_block_validity_window(10u64..20)
+            .expect("10..20 is a valid range");
+        assert_eq!(output.block_validity_window.start(), Some(10));
+        assert_eq!(output.block_validity_window.end(), Some(20));
+    }
+
+    #[test]
+    fn try_with_block_validity_window_empty_range_errors() {
+        let result = SpelOutput::execute(Vec::<(Account, AutoClaim)>::new(), vec![])
+            .try_with_block_validity_window(5u64..5);
+        assert!(result.is_err(), "empty range should return Err");
+    }
+
+    #[test]
+    fn try_with_block_validity_window_inverted_range_errors() {
+        let result = SpelOutput::execute(Vec::<(Account, AutoClaim)>::new(), vec![])
+            .try_with_block_validity_window(10u64..5);
+        assert!(result.is_err(), "inverted range should return Err");
+    }
+
+    #[test]
+    fn with_timestamp_validity_window_range_from() {
+        let output = SpelOutput::execute(Vec::<(Account, AutoClaim)>::new(), vec![])
+            .with_timestamp_validity_window(1_700_000_000u64..);
+        assert_eq!(output.timestamp_validity_window.start(), Some(1_700_000_000));
+        assert_eq!(output.timestamp_validity_window.end(), None);
+    }
+
+    #[test]
+    fn try_with_timestamp_validity_window_valid_range() {
+        let output = SpelOutput::execute(Vec::<(Account, AutoClaim)>::new(), vec![])
+            .try_with_timestamp_validity_window(1_000u64..2_000)
+            .expect("1000..2000 is a valid range");
+        assert_eq!(output.timestamp_validity_window.start(), Some(1_000));
+        assert_eq!(output.timestamp_validity_window.end(), Some(2_000));
+    }
+
+    #[test]
+    fn try_with_timestamp_validity_window_empty_range_errors() {
+        let result = SpelOutput::execute(Vec::<(Account, AutoClaim)>::new(), vec![])
+            .try_with_timestamp_validity_window(99u64..99);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn into_parts_includes_windows() {
+        let output = SpelOutput::execute(Vec::<(Account, AutoClaim)>::new(), vec![])
+            .with_block_validity_window(5u64..)
+            .try_with_timestamp_validity_window(100u64..200)
+            .unwrap();
+
+        let (post_states, chained_calls, block_window, ts_window) = output.into_parts_with_windows();
+        assert!(post_states.is_empty());
+        assert!(chained_calls.is_empty());
+        assert_eq!(block_window.start(), Some(5));
+        assert_eq!(block_window.end(), None);
+        assert_eq!(ts_window.start(), Some(100));
+        assert_eq!(ts_window.end(), Some(200));
     }
 }

--- a/spel-framework-core/src/types.rs
+++ b/spel-framework-core/src/types.rs
@@ -3,7 +3,7 @@
 //! These are thin wrappers/adapters that bridge framework ergonomics
 //! with real SPEL core types.
 
-use nssa_core::program::{AccountPostState, ChainedCall};
+use nssa_core::program::{AccountPostState, BlockValidityWindow, ChainedCall, InvalidWindow, TimestampValidityWindow, ValidityWindow};
 
 /// Trait for types that can be converted into an [`AccountPostState`].
 ///
@@ -18,6 +18,8 @@ pub trait IntoPostState {
 pub struct SpelOutput {
     pub post_states: Vec<AccountPostState>,
     pub chained_calls: Vec<ChainedCall>,
+    pub block_validity_window: BlockValidityWindow,
+    pub timestamp_validity_window: TimestampValidityWindow,
 }
 
 impl SpelOutput {
@@ -27,6 +29,8 @@ impl SpelOutput {
         Self {
             post_states,
             chained_calls: vec![],
+            block_validity_window: ValidityWindow::new_unbounded(),
+            timestamp_validity_window: ValidityWindow::new_unbounded(),
         }
     }
 
@@ -39,6 +43,8 @@ impl SpelOutput {
         Self {
             post_states,
             chained_calls,
+            block_validity_window: ValidityWindow::new_unbounded(),
+            timestamp_validity_window: ValidityWindow::new_unbounded(),
         }
     }
 
@@ -47,12 +53,75 @@ impl SpelOutput {
         Self {
             post_states: vec![],
             chained_calls: vec![],
+            block_validity_window: ValidityWindow::new_unbounded(),
+            timestamp_validity_window: ValidityWindow::new_unbounded(),
         }
     }
 
-    /// Convert to the tuple form expected by `write_nssa_outputs_with_chained_call`.
+    /// Restrict the block range in which the transaction is valid.
+    ///
+    /// Accepts any infallible range conversion: `1..`, `..100`, or `..` (unbounded).
+    pub fn with_block_validity_window<W: Into<BlockValidityWindow>>(mut self, window: W) -> Self {
+        self.block_validity_window = window.into();
+        self
+    }
+
+    /// Restrict the block range in which the transaction is valid.
+    ///
+    /// Returns `Err` if `window` is an empty range (e.g. `5..5` or `10..5`).
+    pub fn try_with_block_validity_window<W: TryInto<BlockValidityWindow, Error = InvalidWindow>>(
+        mut self,
+        window: W,
+    ) -> Result<Self, InvalidWindow> {
+        self.block_validity_window = window.try_into()?;
+        Ok(self)
+    }
+
+    /// Restrict the timestamp range in which the transaction is valid.
+    ///
+    /// Accepts any infallible range conversion: `1..`, `..100`, or `..` (unbounded).
+    pub fn with_timestamp_validity_window<W: Into<TimestampValidityWindow>>(
+        mut self,
+        window: W,
+    ) -> Self {
+        self.timestamp_validity_window = window.into();
+        self
+    }
+
+    /// Restrict the timestamp range in which the transaction is valid.
+    ///
+    /// Returns `Err` if `window` is an empty range (e.g. `5..5` or `10..5`).
+    pub fn try_with_timestamp_validity_window<
+        W: TryInto<TimestampValidityWindow, Error = InvalidWindow>,
+    >(
+        mut self,
+        window: W,
+    ) -> Result<Self, InvalidWindow> {
+        self.timestamp_validity_window = window.try_into()?;
+        Ok(self)
+    }
+
+    /// Convert to the original tuple form of post-states and chained calls.
+    #[deprecated(note = "Use SpelOutput::into_parts_with_windows() to also retrieve validity windows")]
     pub fn into_parts(self) -> (Vec<AccountPostState>, Vec<ChainedCall>) {
         (self.post_states, self.chained_calls)
+    }
+
+    /// Convert to the tuple form including validity windows.
+    pub fn into_parts_with_windows(
+        self,
+    ) -> (
+        Vec<AccountPostState>,
+        Vec<ChainedCall>,
+        BlockValidityWindow,
+        TimestampValidityWindow,
+    ) {
+        (
+            self.post_states,
+            self.chained_calls,
+            self.block_validity_window,
+            self.timestamp_validity_window,
+        )
     }
 }
 

--- a/spel-framework-macros/src/lib.rs
+++ b/spel-framework-macros/src/lib.rs
@@ -267,14 +267,19 @@ fn expand_lez_program(input: ItemMod, config: ProgramConfig) -> syn::Result<Toke
 
             // Dispatch to instruction handler
             let result: Result<
-                (Vec<nssa_core::program::AccountPostState>, Vec<nssa_core::program::ChainedCall>),
+                (
+                    Vec<nssa_core::program::AccountPostState>,
+                    Vec<nssa_core::program::ChainedCall>,
+                    nssa_core::program::BlockValidityWindow,
+                    nssa_core::program::TimestampValidityWindow,
+                ),
                 spel_framework::error::SpelError
             > = match instruction {
                 #(#match_arms)*
             };
 
             // Handle result
-            let (post_states, chained_calls) = match result {
+            let (post_states, chained_calls, block_validity_window, timestamp_validity_window) = match result {
                 Ok(output) => output,
                 Err(e) => {
                     panic!("Program error [{}]: {}", e.error_code(), e);
@@ -318,6 +323,8 @@ fn expand_lez_program(input: ItemMod, config: ProgramConfig) -> syn::Result<Toke
                 filtered_post,
             )
             .with_chained_calls(chained_calls)
+            .with_block_validity_window(block_validity_window)
+            .with_timestamp_validity_window(timestamp_validity_window)
             .write();
         }
     };
@@ -801,7 +808,7 @@ fn generate_match_arms(mod_name: &Ident, instructions: &[InstructionInfo]) -> Ve
                     #account_destructure
                     #validation_call
                     #mod_name::#fn_name(#(#call_args),*)
-                        .map(|output| (output.post_states, output.chained_calls))
+                        .map(|output| output.into_parts_with_windows())
                 }
             }
         })


### PR DESCRIPTION
Add block and timestamp validity window support to SpelOutput so that SPEL programs can restrict the block or timestamp range in which their transaction is valid — a LEZ feature that was previously inaccessible.

Previously the macro-generated main() hardcoded unbounded validity windows in ProgramOutput regardless of what the program returned. SpelOutput now carries both windows and the macro threads them through, so a handler can express constraints like:

```
    Ok(SpelOutput::execute(accounts, calls)
        .with_block_validity_window(100..)
        .try_with_timestamp_validity_window(1_700_000_000..1_800_000_000)?)
```

Changes:
- spel-framework-core: add block_validity_window and timestamp_validity_window fields to SpelOutput; add four builder methods (with_block_validity_window, try_with_block_validity_window, with_timestamp_validity_window, try_with_timestamp_validity_window)
- spel-framework-core: export ValidityWindow, BlockValidityWindow, TimestampValidityWindow, InvalidWindow, BlockId, Timestamp from prelude so programs can construct windows without extra imports
- spel-framework-macros: extract windows from SpelOutput in match arms and pass them to ProgramOutput instead of hardcoding unbounded
- Existing programs are unaffected: all constructors default to ValidityWindow::new_unbounded(), preserving prior behaviour