### PR TITLE
fix: map lowercase 'string' IDL type to Rust 'String'

### DIFF
--- a/spel-client-gen/src/tests.rs
+++ b/spel-client-gen/src/tests.rs
@@ -694,3 +694,33 @@ fn test_no_pda_no_helpers() {
         "should not generate fetch helpers when no PDAs"
     );
 }
+
+#[test]
+fn test_string_type_lowercased() {
+    let idl = r#"{
+        "version": "0.1.0",
+        "name": "whisper_wall",
+        "instructions": [{
+            "name": "whisper",
+            "accounts": [
+                {"name": "user", "writable": true, "signer": true, "init": false}
+            ],
+            "args": [{"name": "msg", "type": "string"}]
+        }]
+    }"#;
+    let output = generate_from_idl_json(idl).expect("codegen should succeed");
+    
+    // Client code should use `String` (uppercase), not `string` (lowercase)
+    assert!(
+        output.client_code.contains("msg: String"),
+        "client code should have msg: String, got:\n{}",
+        output.client_code
+    );
+    
+    // FFI code should also use `String`
+    assert!(
+        output.ffi_code.contains("msg: String"),
+        "ffi code should have msg: String, got:\n{}",
+        output.ffi_code
+    );
+}

--- a/spel-client-gen/src/util.rs
+++ b/spel-client-gen/src/util.rs
@@ -57,6 +57,7 @@ pub fn idl_type_to_rust(ty: &spel_framework_core::idl::IdlType) -> String {
         IdlType::Primitive(p) => match p.as_str() {
             "account_id" | "AccountId" | "[u8; 32]" | "[u8;32]" => "AccountId".to_string(),
             "ProgramId" | "[u32; 8]" | "[u32;8]" => "ProgramId".to_string(),
+            "string" => "String".to_string(),
             s => s.to_string(),
         },
         IdlType::Vec { vec } => format!("Vec<{}>", idl_type_to_rust(vec)),
@@ -80,7 +81,7 @@ pub fn idl_type_to_json_parse(ty: &spel_framework_core::idl::IdlType, var: &str)
             "ProgramId" | "[u32; 8]" | "[u32;8]" => {
                 format!("parse_program_id({var}.as_str().ok_or(\"expected string for ProgramId\")?)?")
             }
-            "String" => format!("{var}.as_str().ok_or(\"expected string\")?.to_string()"),
+            "string" | "String" => format!("{var}.as_str().ok_or(\"expected string\")?.to_string()"),
             "bool" => format!("{var}.as_bool().ok_or(\"expected bool\")?"),
             "u8" | "u16" | "u32" | "u64" | "u128" => {
                 format!("{var}.as_u64().ok_or(\"expected number\")? as {p}")


### PR DESCRIPTION
## Summary

Fixes #142 - `spel-client-gen` generates invalid Rust code when an IDL argument has type `"string"` (lowercase). The generated file does not compile because `string` is not a valid Rust type.

## Changes

- Add `"string" => "String"` mapping in `idl_type_to_rust()` to fix client code generation
- Add `"string" | "String"` handling in `idl_type_to_json_parse()` for FFI code generation
- Add test case `test_string_type_lowercased` to verify the fix

## Test plan

- [x] All 21 existing tests pass
- [x] New test `test_string_type_lowercased` passes
