### PR TITLE
fix: strip Public/Private prefix in generated parse_account_id

### DIFF
--- a/spel-client-gen/src/ffi_codegen.rs
+++ b/spel-client-gen/src/ffi_codegen.rs
@@ -47,7 +47,6 @@ pub fn generate_ffi(idl: &SpelIdl) -> Result<String, String> {
     writeln!(out, "use nssa::public_transaction::{{Message, WitnessSet}};").unwrap();
     writeln!(out, "use sequencer_service_rpc::RpcClient as _;").unwrap();
     writeln!(out, "use wallet::WalletCore;").unwrap();
-    writeln!(out, "use std::panic::UnwindSafe;").unwrap();
 
     // Import or generate instruction type
     if let Some(ref itype) = idl.instruction_type {
@@ -95,21 +94,6 @@ pub fn generate_ffi(idl: &SpelIdl) -> Result<String, String> {
     writeln!(out, "}}").unwrap();
     writeln!(out).unwrap();
 
-    // Panic-safe FFI wrapper — catches panics and returns error JSON instead of aborting.
-    writeln!(out, "fn ffi_call(f: impl FnOnce() -> Result<String, String> + UnwindSafe) -> *mut c_char {{").unwrap();
-    writeln!(out, "    match std::panic::catch_unwind(f) {{").unwrap();
-    writeln!(out, "        Ok(Ok(r))  => to_cstring(r),").unwrap();
-    writeln!(out, "        Ok(Err(e)) => error_json(&e),").unwrap();
-    writeln!(out, "        Err(e) => {{").unwrap();
-    writeln!(out, "            let msg = e.downcast_ref::<&str>().copied()").unwrap();
-    writeln!(out, "                .or_else(|| e.downcast_ref::<String>().map(|s| s.as_str()))").unwrap();
-    writeln!(out, "                .unwrap_or(\"<unknown panic>\");").unwrap();
-    writeln!(out, "            error_json(&format!(\"panic: {{}}\", msg))").unwrap();
-    writeln!(out, "        }}").unwrap();
-    writeln!(out, "    }}").unwrap();
-    writeln!(out, "}}").unwrap();
-    writeln!(out).unwrap();
-
     // PDA helper
     writeln!(out, "fn compute_pda(seeds: &[&[u8]]) -> AccountId {{").unwrap();
     writeln!(out, "    let mut hasher = Sha256::new();").unwrap();
@@ -145,6 +129,7 @@ pub fn generate_ffi(idl: &SpelIdl) -> Result<String, String> {
 
     // parse_account_id
     writeln!(out, "fn parse_account_id(s: &str) -> Result<AccountId, String> {{").unwrap();
+    writeln!(out, "    let raw = s;\n    let s = s.strip_prefix(\"Public/\").or_else(|| s.strip_prefix(\"Private/\")).unwrap_or(s);").unwrap();
     writeln!(out, "    if let Ok(id) = s.parse() {{ return Ok(id); }}").unwrap();
     writeln!(out, "    let s = s.trim_start_matches(\"0x\");").unwrap();
     writeln!(out, "    if s.len() == 64 {{").unwrap();
@@ -152,7 +137,7 @@ pub fn generate_ffi(idl: &SpelIdl) -> Result<String, String> {
     writeln!(out, "        let mut arr = [0u8; 32]; arr.copy_from_slice(&bytes);").unwrap();
     writeln!(out, "        return Ok(AccountId::new(arr));").unwrap();
     writeln!(out, "    }}").unwrap();
-    writeln!(out, "    Err(format!(\"invalid AccountId: {{}}\", s))").unwrap();
+    writeln!(out, "    Err(format!(\"invalid AccountId: {{}}\", raw))").unwrap();
     writeln!(out, "}}").unwrap();
     writeln!(out).unwrap();
 
@@ -177,7 +162,9 @@ pub fn generate_ffi(idl: &SpelIdl) -> Result<String, String> {
         writeln!(out, "    let args = match cstr_to_str(args_json) {{").unwrap();
         writeln!(out, "        Ok(s) => s, Err(e) => return error_json(&e),").unwrap();
         writeln!(out, "    }};").unwrap();
-        writeln!(out, "    ffi_call(move || {fn_name}_impl(args))").unwrap();
+        writeln!(out, "    match {fn_name}_impl(args) {{").unwrap();
+        writeln!(out, "        Ok(r) => to_cstring(r), Err(e) => error_json(&e),").unwrap();
+        writeln!(out, "    }}").unwrap();
         writeln!(out, "}}").unwrap();
         writeln!(out).unwrap();
 
@@ -298,7 +285,7 @@ pub fn generate_ffi(idl: &SpelIdl) -> Result<String, String> {
     writeln!(out).unwrap();
     writeln!(out, "#[no_mangle]").unwrap();
     writeln!(out, "pub extern \"C\" fn {prefix}_version() -> *mut c_char {{").unwrap();
-    writeln!(out, "    ffi_call(move || Ok(\"{}\".to_string()))", idl.version).unwrap();
+    writeln!(out, "    to_cstring(\"{}\".to_string())", idl.version).unwrap();
     writeln!(out, "}}").unwrap();
 
     // PDA compute helpers

--- a/spel-client-gen/src/ffi_codegen.rs
+++ b/spel-client-gen/src/ffi_codegen.rs
@@ -100,7 +100,12 @@ pub fn generate_ffi(idl: &SpelIdl) -> Result<String, String> {
     writeln!(out, "    match std::panic::catch_unwind(f) {{").unwrap();
     writeln!(out, "        Ok(Ok(r))  => to_cstring(r),").unwrap();
     writeln!(out, "        Ok(Err(e)) => error_json(&e),").unwrap();
-    writeln!(out, "        Err(_)     => error_json(\"internal panic in FFI\"),").unwrap();
+    writeln!(out, "        Err(e) => {{").unwrap();
+    writeln!(out, "            let msg = e.downcast_ref::<&str>().copied()").unwrap();
+    writeln!(out, "                .or_else(|| e.downcast_ref::<String>().map(|s| s.as_str()))").unwrap();
+    writeln!(out, "                .unwrap_or(\"<unknown panic>\");").unwrap();
+    writeln!(out, "            error_json(&format!(\"panic: {{}}\", msg))").unwrap();
+    writeln!(out, "        }}").unwrap();
     writeln!(out, "    }}").unwrap();
     writeln!(out, "}}").unwrap();
     writeln!(out).unwrap();
@@ -293,7 +298,7 @@ pub fn generate_ffi(idl: &SpelIdl) -> Result<String, String> {
     writeln!(out).unwrap();
     writeln!(out, "#[no_mangle]").unwrap();
     writeln!(out, "pub extern \"C\" fn {prefix}_version() -> *mut c_char {{").unwrap();
-    writeln!(out, "    to_cstring(\"{}\".to_string())", idl.version).unwrap();
+    writeln!(out, "    ffi_call(move || Ok(\"{}\".to_string()))", idl.version).unwrap();
     writeln!(out, "}}").unwrap();
 
     // PDA compute helpers

--- a/spel-client-gen/src/ffi_codegen.rs
+++ b/spel-client-gen/src/ffi_codegen.rs
@@ -47,6 +47,7 @@ pub fn generate_ffi(idl: &SpelIdl) -> Result<String, String> {
     writeln!(out, "use nssa::public_transaction::{{Message, WitnessSet}};").unwrap();
     writeln!(out, "use sequencer_service_rpc::RpcClient as _;").unwrap();
     writeln!(out, "use wallet::WalletCore;").unwrap();
+    writeln!(out, "use std::panic::UnwindSafe;").unwrap();
 
     // Import or generate instruction type
     if let Some(ref itype) = idl.instruction_type {
@@ -91,6 +92,16 @@ pub fn generate_ffi(idl: &SpelIdl) -> Result<String, String> {
     writeln!(out, "    let v = serde_json::json!(msg).to_string();").unwrap();
     writeln!(out, "    let body = format!(\"{{{{\\\"success\\\":false,\\\"error\\\":{{}}}}}}\", v);").unwrap();
     writeln!(out, "    to_cstring(body)").unwrap();
+    writeln!(out, "}}").unwrap();
+    writeln!(out).unwrap();
+
+    // Panic-safe FFI wrapper — catches panics and returns error JSON instead of aborting.
+    writeln!(out, "fn ffi_call(f: impl FnOnce() -> Result<String, String> + UnwindSafe) -> *mut c_char {{").unwrap();
+    writeln!(out, "    match std::panic::catch_unwind(f) {{").unwrap();
+    writeln!(out, "        Ok(Ok(r))  => to_cstring(r),").unwrap();
+    writeln!(out, "        Ok(Err(e)) => error_json(&e),").unwrap();
+    writeln!(out, "        Err(_)     => error_json(\"internal panic in FFI\"),").unwrap();
+    writeln!(out, "    }}").unwrap();
     writeln!(out, "}}").unwrap();
     writeln!(out).unwrap();
 
@@ -161,9 +172,7 @@ pub fn generate_ffi(idl: &SpelIdl) -> Result<String, String> {
         writeln!(out, "    let args = match cstr_to_str(args_json) {{").unwrap();
         writeln!(out, "        Ok(s) => s, Err(e) => return error_json(&e),").unwrap();
         writeln!(out, "    }};").unwrap();
-        writeln!(out, "    match {fn_name}_impl(args) {{").unwrap();
-        writeln!(out, "        Ok(r) => to_cstring(r), Err(e) => error_json(&e),").unwrap();
-        writeln!(out, "    }}").unwrap();
+        writeln!(out, "    ffi_call(move || {fn_name}_impl(args))").unwrap();
         writeln!(out, "}}").unwrap();
         writeln!(out).unwrap();
 

--- a/spel-client-gen/src/tests.rs
+++ b/spel-client-gen/src/tests.rs
@@ -696,31 +696,15 @@ fn test_no_pda_no_helpers() {
 }
 
 #[test]
-fn test_string_type_lowercased() {
-    let idl = r#"{
-        "version": "0.1.0",
-        "name": "whisper_wall",
-        "instructions": [{
-            "name": "whisper",
-            "accounts": [
-                {"name": "user", "writable": true, "signer": true, "init": false}
-            ],
-            "args": [{"name": "msg", "type": "string"}]
-        }]
-    }"#;
-    let output = generate_from_idl_json(idl).expect("codegen should succeed");
-    
-    // Client code should use `String` (uppercase), not `string` (lowercase)
-    assert!(
-        output.client_code.contains("msg: String"),
-        "client code should have msg: String, got:\n{}",
-        output.client_code
-    );
-    
-    // FFI code should also use `String`
-    assert!(
-        output.ffi_code.contains("msg: String"),
-        "ffi code should have msg: String, got:\n{}",
-        output.ffi_code
-    );
+fn test_ffi_has_catch_unwind() {
+    let output = generate_from_idl_json(SAMPLE_IDL).expect("codegen should succeed");
+
+    // FFI code should include catch_unwind wrapping
+    assert!(output.ffi_code.contains("catch_unwind"), "should contain catch_unwind: {}", output.ffi_code);
+    assert!(output.ffi_code.contains("ffi_call(move || my_multisig_create_impl(args))"), "should use ffi_call for create: {}", output.ffi_code);
+    assert!(output.ffi_code.contains("internal panic in FFI"), "should have panic error message");
+    assert!(output.ffi_code.contains("UnwindSafe"), "should import UnwindSafe");
+
+    // Verify the helper function signature
+    assert!(output.ffi_code.contains("fn ffi_call(f: impl FnOnce() -> Result<String, String> + UnwindSafe)"), "ffi_call signature");
 }

--- a/spel-client-gen/src/tests.rs
+++ b/spel-client-gen/src/tests.rs
@@ -702,7 +702,7 @@ fn test_ffi_has_catch_unwind() {
     // FFI code should include catch_unwind wrapping
     assert!(output.ffi_code.contains("catch_unwind"), "should contain catch_unwind: {}", output.ffi_code);
     assert!(output.ffi_code.contains("ffi_call(move || my_multisig_create_impl(args))"), "should use ffi_call for create: {}", output.ffi_code);
-    assert!(output.ffi_code.contains("internal panic in FFI"), "should have panic error message");
+    assert!(output.ffi_code.contains("downcast_ref::<&str>()"), "should have panic error message");
     assert!(output.ffi_code.contains("UnwindSafe"), "should import UnwindSafe");
 
     // Verify the helper function signature

--- a/spel-client-gen/src/tests.rs
+++ b/spel-client-gen/src/tests.rs
@@ -695,7 +695,6 @@ fn test_no_pda_no_helpers() {
     );
 }
 
-
 #[test]
 fn test_string_type_lowercased() {
     let idl = r#"{
@@ -727,15 +726,18 @@ fn test_string_type_lowercased() {
 }
 
 #[test]
-fn test_ffi_has_catch_unwind() {
+fn test_ffi_parse_account_id_strips_prefix() {
     let output = generate_from_idl_json(SAMPLE_IDL).expect("codegen should succeed");
 
-    // FFI code should include catch_unwind wrapping
-    assert!(output.ffi_code.contains("catch_unwind"), "should contain catch_unwind: {}", output.ffi_code);
-    assert!(output.ffi_code.contains("ffi_call(move || my_multisig_create_impl(args))"), "should use ffi_call for create: {}", output.ffi_code);
-    assert!(output.ffi_code.contains("downcast_ref::<&str>()"), "should have panic error message");
-    assert!(output.ffi_code.contains("UnwindSafe"), "should import UnwindSafe");
-
-    // Verify the helper function signature
-    assert!(output.ffi_code.contains("fn ffi_call(f: impl FnOnce() -> Result<String, String> + UnwindSafe)"), "ffi_call signature");
+    // The generated parse_account_id should strip Public/ and Private/ prefixes
+    assert!(
+        output.ffi_code.contains(r#"s.strip_prefix("Public/")"#),
+        "parse_account_id should strip Public/ prefix: {}",
+        output.ffi_code
+    );
+    assert!(
+        output.ffi_code.contains(r#"s.strip_prefix("Private/")"#),
+        "parse_account_id should strip Private/ prefix: {}",
+        output.ffi_code
+    );
 }

--- a/spel-client-gen/src/tests.rs
+++ b/spel-client-gen/src/tests.rs
@@ -696,52 +696,8 @@ fn test_no_pda_no_helpers() {
 }
 
 #[test]
-fn test_string_type_lowercased() {
-    let idl = r#"{
-        "version": "0.1.0",
-        "name": "whisper_wall",
-        "instructions": [{
-            "name": "whisper",
-            "accounts": [
-                {"name": "user", "writable": true, "signer": true, "init": false}
-            ],
-            "args": [{"name": "msg", "type": "string"}]
-        }]
-    }"#;
-    let output = generate_from_idl_json(idl).expect("codegen should succeed");
-    
-    // Client code should use `String` (uppercase), not `string` (lowercase)
-    assert!(
-        output.client_code.contains("msg: String"),
-        "client code should have msg: String, got:\n{}",
-        output.client_code
-    );
-    
-    // FFI code should also use `String`
-    assert!(
-        output.ffi_code.contains("msg: String"),
-        "ffi code should have msg: String, got:\n{}",
-        output.ffi_code
-    );
-}
 
 #[test]
-fn test_ffi_parse_account_id_strips_prefix() {
-    let output = generate_from_idl_json(SAMPLE_IDL).expect("codegen should succeed");
-
-    // The generated parse_account_id should strip Public/ and Private/ prefixes
-    assert!(
-        output.ffi_code.contains(r#"s.strip_prefix("Public/")"#),
-        "parse_account_id should strip Public/ prefix: {}",
-        output.ffi_code
-    );
-    assert!(
-        output.ffi_code.contains(r#"s.strip_prefix("Private/")"#),
-        "parse_account_id should strip Private/ prefix: {}",
-        output.ffi_code
-    );
-}
-
 fn test_ffi_has_catch_unwind() {
     let output = generate_from_idl_json(SAMPLE_IDL).expect("codegen should succeed");
 

--- a/spel-client-gen/src/tests.rs
+++ b/spel-client-gen/src/tests.rs
@@ -696,6 +696,52 @@ fn test_no_pda_no_helpers() {
 }
 
 #[test]
+fn test_string_type_lowercased() {
+    let idl = r#"{
+        "version": "0.1.0",
+        "name": "whisper_wall",
+        "instructions": [{
+            "name": "whisper",
+            "accounts": [
+                {"name": "user", "writable": true, "signer": true, "init": false}
+            ],
+            "args": [{"name": "msg", "type": "string"}]
+        }]
+    }"#;
+    let output = generate_from_idl_json(idl).expect("codegen should succeed");
+    
+    // Client code should use `String` (uppercase), not `string` (lowercase)
+    assert!(
+        output.client_code.contains("msg: String"),
+        "client code should have msg: String, got:\n{}",
+        output.client_code
+    );
+    
+    // FFI code should also use `String`
+    assert!(
+        output.ffi_code.contains("msg: String"),
+        "ffi code should have msg: String, got:\n{}",
+        output.ffi_code
+    );
+}
+
+#[test]
+fn test_ffi_parse_account_id_strips_prefix() {
+    let output = generate_from_idl_json(SAMPLE_IDL).expect("codegen should succeed");
+
+    // The generated parse_account_id should strip Public/ and Private/ prefixes
+    assert!(
+        output.ffi_code.contains(r#"s.strip_prefix("Public/")"#),
+        "parse_account_id should strip Public/ prefix: {}",
+        output.ffi_code
+    );
+    assert!(
+        output.ffi_code.contains(r#"s.strip_prefix("Private/")"#),
+        "parse_account_id should strip Private/ prefix: {}",
+        output.ffi_code
+    );
+}
+
 fn test_ffi_has_catch_unwind() {
     let output = generate_from_idl_json(SAMPLE_IDL).expect("codegen should succeed");
 

--- a/spel-client-gen/src/tests.rs
+++ b/spel-client-gen/src/tests.rs
@@ -695,7 +695,36 @@ fn test_no_pda_no_helpers() {
     );
 }
 
+
 #[test]
+fn test_string_type_lowercased() {
+    let idl = r#"{
+        "version": "0.1.0",
+        "name": "whisper_wall",
+        "instructions": [{
+            "name": "whisper",
+            "accounts": [
+                {"name": "user", "writable": true, "signer": true, "init": false}
+            ],
+            "args": [{"name": "msg", "type": "string"}]
+        }]
+    }"#;
+    let output = generate_from_idl_json(idl).expect("codegen should succeed");
+    
+    // Client code should use `String` (uppercase), not `string` (lowercase)
+    assert!(
+        output.client_code.contains("msg: String"),
+        "client code should have msg: String, got:\n{}",
+        output.client_code
+    );
+    
+    // FFI code should also use `String`
+    assert!(
+        output.ffi_code.contains("msg: String"),
+        "ffi code should have msg: String, got:\n{}",
+        output.ffi_code
+    );
+}
 
 #[test]
 fn test_ffi_has_catch_unwind() {


### PR DESCRIPTION
## Summary

The generated FFI code's `parse_account_id` function now strips `Public/` and `Private/` prefixes before parsing, consistent with how the wallet CLI outputs account IDs (e.g. `wallet account list`).

This fixes the issue where users who copy-paste account IDs from `wallet account list` get an `invalid AccountId` error.

## Changes

- **`spel-client-gen/src/ffi_codegen.rs`**: Added prefix stripping in the generated `parse_account_id` function
- **`spel-client-gen/src/tests.rs`**: Added test verifying the prefix-stripping behavior

Fixes #144