### PR TITLE
fix: bump default spel-tag to v0.2.0-rc.3 and pin ruint=1.17.0

### DIFF
--- a/spel-cli/src/init.rs
+++ b/spel-cli/src/init.rs
@@ -284,7 +284,7 @@ risc0-zkvm = {{ version = "=3.0.5", features = ["std"] }}
     let spel_ref = match (spel_tag, spel_rev) {
         (Some(t), _) => format!("tag = \"{}\"", t),
         (_, Some(r)) => format!("rev = \"{}\"", r),
-        _ => "tag = \"v0.2.0-rc.1\"".to_string(),
+        _ => "tag = \"v0.2.0-rc.3\"".to_string(),
     };
     // methods/guest/Cargo.toml
     write_file(root, "methods/guest/Cargo.toml", &format!(r#"[package]
@@ -305,6 +305,7 @@ risc0-zkvm = {{ version = "=3.0.5", features = ["std"] }}
 {snake_name}_core = {{ path = "../../{snake_name}_core" }}
 serde = {{ version = "1.0", features = ["derive"] }}
 borsh = "1.5"
+ruint = "=1.17.0"
 
 "#));
 


### PR DESCRIPTION
## Summary

Fixes #140 — `spel init` produces a scaffold that does not build out of the box.

Two independent problems have been addressed:

### 1. Stale default `--spel-tag`

Bumped the default `spel_ref` in `spel-cli/src/init.rs` from `tag = "v0.2.0-rc.1"` to `tag = "v0.2.0-rc.3"`. 

The `v0.2.0-rc.1` tag's `spel-framework/Cargo.toml` resolves `nssa_core` via a stale git rev, causing `#[lez_program]` macro expansion failures with type mismatches (e.g., `this function takes 5 arguments but 3 arguments were supplied`). The `v0.2.0-rc.3` tag has the correct aligned pin.

### 2. `ruint@1.18.0` MSRV clash

Pinned `ruint = "=1.17.0"` as a direct dependency in the scaffolded `methods/guest/Cargo.toml`. The `ruint@1.18.0` package (transitive via `risc0-binfmt → risc0-build → risc0-zkvm`) requires rustc 1.90, but the RISC-Zero docker image ships rustc 1.88.0-dev. Pinning to 1.17.0 avoids this MSRV error without requiring users to manually run `cargo update -p ruint --precise 1.17.0`.

## Changes

- `spel-cli/src/init.rs`: Bump default spel_ref, add ruint as direct dependency in methods/guest/Cargo.toml template

## Testing

Verified that `spel init testproj` now produces a scaffold that builds without errors:
- `spel-framework` resolves to `v0.2.0-rc.3`
- `nssa_core` resolves to `v0.2.0-rc1` (unchanged, correct)
- `ruint` is locked to `1.17.0` in the generated lockfile