### PR TITLE
feat: re-export nssa_core/nssa types from spel-framework prelude

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
       lez-rev: ${{ steps.lez-ref.outputs.LEZ_REV }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Generate Cargo.lock
@@ -138,6 +140,20 @@ jobs:
           path: /tmp/lssa/target/release/wallet
           key: wallet-${{ steps.lez-ref.outputs.LEZ_REV }}
 
+      - name: Build spel CLI
+        run: cargo build -p spel --release
+
+      - name: Copy spel CLI to LEZ dir
+        run: |
+          mkdir -p /tmp/lssa/target/release
+          cp target/release/spel /tmp/lssa/target/release/spel
+
+      - name: Save spel CLI cache (PR-specific key)
+        uses: actions/cache/save@v4
+        with:
+          path: /tmp/lssa/target/release/spel
+          key: spel-cli-${{ steps.lez-ref.outputs.LEZ_REV }}-pr${{ github.event.pull_request.number || 'main' }}
+
   privacy-smoke-test:
     name: Privacy Smoke Test
     needs: [sequencer-setup]
@@ -147,6 +163,8 @@ jobs:
       RISC0_VERSION: "3.0.5"
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Clone LEZ at correct revision
@@ -169,11 +187,11 @@ jobs:
           path: /tmp/lssa/target/release/wallet
           key: wallet-${{ needs.sequencer-setup.outputs.lez-rev }}
 
-      - name: Build spel CLI
-        run: |
-          cargo build -p spel --release
-          mkdir -p /tmp/lssa/target/release
-          cp target/release/spel /tmp/lssa/target/release/spel
+      - name: Restore spel CLI cache (PR-specific)
+        uses: actions/cache@v4
+        with:
+          path: /tmp/lssa/target/release/spel
+          key: spel-cli-${{ needs.sequencer-setup.outputs.lez-rev }}-pr${{ github.event.pull_request.number || 'main' }}
 
       - name: Determine SPEL ref for testing
         id: spel-ref
@@ -217,6 +235,8 @@ jobs:
       RISC0_VERSION: "3.0.5"
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Clone LEZ at correct revision
@@ -239,11 +259,11 @@ jobs:
           path: /tmp/lssa/target/release/wallet
           key: wallet-${{ needs.sequencer-setup.outputs.lez-rev }}
 
-      - name: Build spel CLI
-        run: |
-          cargo build -p spel --release
-          mkdir -p /tmp/lssa/target/release
-          cp target/release/spel /tmp/lssa/target/release/spel
+      - name: Restore spel CLI cache (PR-specific)
+        uses: actions/cache@v4
+        with:
+          path: /tmp/lssa/target/release/spel
+          key: spel-cli-${{ needs.sequencer-setup.outputs.lez-rev }}-pr${{ github.event.pull_request.number || 'main' }}
 
       - name: Determine SPEL ref for testing
         id: spel-ref

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,21 +138,6 @@ jobs:
           path: /tmp/lssa/target/release/wallet
           key: wallet-${{ steps.lez-ref.outputs.LEZ_REV }}
 
-      - name: Build spel CLI
-        run: cargo build -p spel --release
-
-      - name: Copy spel CLI to LEZ dir
-        run: |
-          mkdir -p /tmp/lssa/target/release
-          cp target/release/spel /tmp/lssa/target/release/spel
-
-      - name: Save spel CLI cache
-        if: always()
-        uses: actions/cache/save@v4
-        with:
-          path: /tmp/lssa/target/release/spel
-          key: spel-cli-${{ steps.lez-ref.outputs.LEZ_REV }}
-
   privacy-smoke-test:
     name: Privacy Smoke Test
     needs: [sequencer-setup]
@@ -184,11 +169,11 @@ jobs:
           path: /tmp/lssa/target/release/wallet
           key: wallet-${{ needs.sequencer-setup.outputs.lez-rev }}
 
-      - name: Restore spel CLI cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/lssa/target/release/spel
-          key: spel-cli-${{ needs.sequencer-setup.outputs.lez-rev }}
+      - name: Build spel CLI
+        run: |
+          cargo build -p spel --release
+          mkdir -p /tmp/lssa/target/release
+          cp target/release/spel /tmp/lssa/target/release/spel
 
       - name: Determine SPEL ref for testing
         id: spel-ref
@@ -254,11 +239,11 @@ jobs:
           path: /tmp/lssa/target/release/wallet
           key: wallet-${{ needs.sequencer-setup.outputs.lez-rev }}
 
-      - name: Restore spel CLI cache
-        uses: actions/cache@v4
-        with:
-          path: /tmp/lssa/target/release/spel
-          key: spel-cli-${{ needs.sequencer-setup.outputs.lez-rev }}
+      - name: Build spel CLI
+        run: |
+          cargo build -p spel --release
+          mkdir -p /tmp/lssa/target/release
+          cp target/release/spel /tmp/lssa/target/release/spel
 
       - name: Determine SPEL ref for testing
         id: spel-ref

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,12 @@ jobs:
           mkdir -p /tmp/lssa/target/release
           cp target/release/spel /tmp/lssa/target/release/spel
 
+      - name: Save spel CLI cache (PR-specific key)
+        uses: actions/cache/save@v4
+        with:
+          path: /tmp/lssa/target/release/spel
+          key: spel-cli-${{ steps.lez-ref.outputs.LEZ_REV }}-pr${{ github.event.pull_request.number || 'main' }}-${{ github.run_id }}
+
   privacy-smoke-test:
     name: Privacy Smoke Test
     needs: [sequencer-setup]
@@ -181,11 +187,23 @@ jobs:
           path: /tmp/lssa/target/release/wallet
           key: wallet-${{ needs.sequencer-setup.outputs.lez-rev }}
 
-      - name: Build spel CLI
+      - name: Install logos-blockchain-circuits
         run: |
-          cargo build -p spel --release
-          mkdir -p /tmp/lssa/target/release
-          cp target/release/spel /tmp/lssa/target/release/spel
+          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/main/scripts/setup-logos-blockchain-circuits.sh | bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install logos-blockchain-circuits
+        run: |
+          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/main/scripts/setup-logos-blockchain-circuits.sh | bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Restore spel CLI cache (PR-specific)
+        uses: actions/cache@v4
+        with:
+          path: /tmp/lssa/target/release/spel
+          key: spel-cli-${{ needs.sequencer-setup.outputs.lez-rev }}-pr${{ github.event.pull_request.number || 'main' }}-${{ github.run_id }}
 
       - name: Determine SPEL ref for testing
         id: spel-ref
@@ -253,11 +271,23 @@ jobs:
           path: /tmp/lssa/target/release/wallet
           key: wallet-${{ needs.sequencer-setup.outputs.lez-rev }}
 
-      - name: Build spel CLI
+      - name: Install logos-blockchain-circuits
         run: |
-          cargo build -p spel --release
-          mkdir -p /tmp/lssa/target/release
-          cp target/release/spel /tmp/lssa/target/release/spel
+          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/main/scripts/setup-logos-blockchain-circuits.sh | bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install logos-blockchain-circuits
+        run: |
+          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/main/scripts/setup-logos-blockchain-circuits.sh | bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Restore spel CLI cache (PR-specific)
+        uses: actions/cache@v4
+        with:
+          path: /tmp/lssa/target/release/spel
+          key: spel-cli-${{ needs.sequencer-setup.outputs.lez-rev }}-pr${{ github.event.pull_request.number || 'main' }}-${{ github.run_id }}
 
       - name: Determine SPEL ref for testing
         id: spel-ref

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,12 +148,6 @@ jobs:
           mkdir -p /tmp/lssa/target/release
           cp target/release/spel /tmp/lssa/target/release/spel
 
-      - name: Save spel CLI cache (PR-specific key)
-        uses: actions/cache/save@v4
-        with:
-          path: /tmp/lssa/target/release/spel
-          key: spel-cli-${{ steps.lez-ref.outputs.LEZ_REV }}-pr${{ github.event.pull_request.number || 'main' }}
-
   privacy-smoke-test:
     name: Privacy Smoke Test
     needs: [sequencer-setup]
@@ -187,11 +181,11 @@ jobs:
           path: /tmp/lssa/target/release/wallet
           key: wallet-${{ needs.sequencer-setup.outputs.lez-rev }}
 
-      - name: Restore spel CLI cache (PR-specific)
-        uses: actions/cache@v4
-        with:
-          path: /tmp/lssa/target/release/spel
-          key: spel-cli-${{ needs.sequencer-setup.outputs.lez-rev }}-pr${{ github.event.pull_request.number || 'main' }}
+      - name: Build spel CLI
+        run: |
+          cargo build -p spel --release
+          mkdir -p /tmp/lssa/target/release
+          cp target/release/spel /tmp/lssa/target/release/spel
 
       - name: Determine SPEL ref for testing
         id: spel-ref
@@ -259,11 +253,11 @@ jobs:
           path: /tmp/lssa/target/release/wallet
           key: wallet-${{ needs.sequencer-setup.outputs.lez-rev }}
 
-      - name: Restore spel CLI cache (PR-specific)
-        uses: actions/cache@v4
-        with:
-          path: /tmp/lssa/target/release/spel
-          key: spel-cli-${{ needs.sequencer-setup.outputs.lez-rev }}-pr${{ github.event.pull_request.number || 'main' }}
+      - name: Build spel CLI
+        run: |
+          cargo build -p spel --release
+          mkdir -p /tmp/lssa/target/release
+          cp target/release/spel /tmp/lssa/target/release/spel
 
       - name: Determine SPEL ref for testing
         id: spel-ref

--- a/spel-cli/src/init.rs
+++ b/spel-cli/src/init.rs
@@ -341,12 +341,11 @@ mod {snake_name} {{
         let mut acc = state.account.clone();
         let ps = ProgramState {{
             initialized: true,
-            owner: acc.program_owner,
+            owner: owner.account.program_owner,
         }};
         let bytes = borsh::to_vec(&ps).map_err(|e| SpelError::custom(999, format!("borsh error: {{e}}")))?;
         acc.data = Data::try_from(bytes).map_err(|_| SpelError::custom(999, "data too big"))?;
-        let owner_post = AccountPostState::new(owner.account.clone());
-        Ok(SpelOutput::states_only(vec![AccountPostState::new_claimed(acc, Claim::Authorized), owner_post]))
+        Ok(SpelOutput::execute(vec![acc], vec![]))
     }}
 
     /// Example instruction — replace with your own.

--- a/spel-cli/src/init.rs
+++ b/spel-cli/src/init.rs
@@ -341,7 +341,7 @@ mod {snake_name} {{
         let mut acc = state.account.clone();
         let ps = ProgramState {{
             initialized: true,
-            owner: owner.account.program_owner,
+            owner: AccountId::from(owner.account),
         }};
         let bytes = borsh::to_vec(&ps).map_err(|e| SpelError::custom(999, format!("borsh error: {{e}}")))?;
         acc.data = Data::try_from(bytes).map_err(|_| SpelError::custom(999, "data too big"))?;

--- a/spel-cli/src/init.rs
+++ b/spel-cli/src/init.rs
@@ -313,7 +313,7 @@ ruint = "=1.17.0"
     write_file(root, &format!("methods/guest/src/bin/{}.rs", snake_name), &format!(r#"#![no_main]
 
 use spel_framework::prelude::*;
-use nssa_core::account::Data;
+use nssa_core::account::{AccountId, Data};
 
 risc0_zkvm::guest::entry!(main);
 

--- a/spel-cli/src/init.rs
+++ b/spel-cli/src/init.rs
@@ -341,7 +341,7 @@ mod {snake_name} {{
         let mut acc = state.account.clone();
         let ps = ProgramState {{
             initialized: true,
-            owner: acc.owner,
+            owner: acc.program_owner,
         }};
         let bytes = borsh::to_vec(&ps).map_err(|e| SpelError::custom(999, format!("borsh error: {{e}}")))?;
         acc.data = Data::try_from(bytes).map_err(|_| SpelError::custom(999, "data too big"))?;

--- a/spel-cli/src/init.rs
+++ b/spel-cli/src/init.rs
@@ -341,7 +341,7 @@ mod {snake_name} {{
         let mut acc = state.account.clone();
         let ps = ProgramState {{
             initialized: true,
-            owner: owner.account_id.value(),
+            owner: *owner.account_id.value(),
         }};
         let bytes = borsh::to_vec(&ps).map_err(|e| SpelError::custom(999, format!("borsh error: {{e}}")))?;
         acc.data = Data::try_from(bytes).map_err(|_| SpelError::custom(999, "data too big"))?;

--- a/spel-cli/src/init.rs
+++ b/spel-cli/src/init.rs
@@ -248,7 +248,7 @@ borsh = "1.5"
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProgramState {
     pub initialized: bool,
-    pub owner: AccountId,
+    pub owner: [u8; 32],
 }
 "#);
 
@@ -313,7 +313,7 @@ ruint = "=1.17.0"
     write_file(root, &format!("methods/guest/src/bin/{}.rs", snake_name), &format!(r#"#![no_main]
 
 use spel_framework::prelude::*;
-use nssa_core::account::{AccountId, Data};
+use nssa_core::account::Data;
 
 risc0_zkvm::guest::entry!(main);
 
@@ -327,7 +327,7 @@ mod {snake_name} {{
     #[account_type]
     pub struct ProgramState {{
         pub initialized: bool,
-        pub owner: AccountId,
+        pub owner: [u8; 32],
     }}
 
     /// Initialize the program state.
@@ -341,7 +341,7 @@ mod {snake_name} {{
         let mut acc = state.account.clone();
         let ps = ProgramState {{
             initialized: true,
-            owner: owner.account_id,
+            owner: owner.account_id.value(),
         }};
         let bytes = borsh::to_vec(&ps).map_err(|e| SpelError::custom(999, format!("borsh error: {{e}}")))?;
         acc.data = Data::try_from(bytes).map_err(|_| SpelError::custom(999, "data too big"))?;

--- a/spel-cli/src/init.rs
+++ b/spel-cli/src/init.rs
@@ -248,7 +248,7 @@ borsh = "1.5"
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProgramState {
     pub initialized: bool,
-    pub owner: [u8; 32],
+    pub owner: AccountId,
 }
 "#);
 
@@ -327,7 +327,7 @@ mod {snake_name} {{
     #[account_type]
     pub struct ProgramState {{
         pub initialized: bool,
-        pub owner: [u8; 32],
+        pub owner: AccountId,
     }}
 
     /// Initialize the program state.
@@ -341,7 +341,7 @@ mod {snake_name} {{
         let mut acc = state.account.clone();
         let ps = ProgramState {{
             initialized: true,
-            owner: AccountId::from(owner.account),
+            owner: owner.account_id,
         }};
         let bytes = borsh::to_vec(&ps).map_err(|e| SpelError::custom(999, format!("borsh error: {{e}}")))?;
         acc.data = Data::try_from(bytes).map_err(|_| SpelError::custom(999, "data too big"))?;

--- a/spel-framework-core/Cargo.toml
+++ b/spel-framework-core/Cargo.toml
@@ -7,6 +7,7 @@ description = "Core types for the SPEL program framework"
 [features]
 default = []
 idl-gen = ["dep:syn"]
+host = ["dep:nssa"]
 
 [dependencies]
 nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1", features = ["host"] }
@@ -15,6 +16,7 @@ thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
-nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1" }
+
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1", optional = true }
 
 syn = { version = "2.0", features = ["full", "extra-traits"], optional = true }

--- a/spel-framework-core/Cargo.toml
+++ b/spel-framework-core/Cargo.toml
@@ -15,4 +15,6 @@ thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1" }
+
 syn = { version = "2.0", features = ["full", "extra-traits"], optional = true }

--- a/spel-framework-core/src/lib.rs
+++ b/spel-framework-core/src/lib.rs
@@ -17,10 +17,23 @@ pub mod prelude {
     pub use crate::pda::{compute_pda, compute_pda_multi, seed_from_str, ToSeed};
     pub use crate::spel_output::AutoClaim;
     pub use crate::types::{IntoPostState, SpelOutput, AccountConstraint};
-    pub use nssa_core::account::{Account, AccountWithMetadata};
+
+    // nssa_core::account
+    pub use nssa_core::account::{Account, AccountId, AccountWithMetadata};
+
+    // nssa_core::program
     pub use nssa_core::program::{
         AccountPostState, BlockValidityWindow, ChainedCall, Claim, InvalidWindow, PdaSeed,
         ProgramId, TimestampValidityWindow, ValidityWindow,
     };
+
+    // nssa_core extras
     pub use nssa_core::{BlockId, Timestamp};
+
+    // spel-framework additional re-exports
+    pub use nssa_core::program::{InstructionData, ProgramInput, ProgramOutput, read_nssa_inputs};
+
+    // nssa::public_transaction (host-only)
+    #[cfg(feature = "host")]
+    pub use nssa::public_transaction::{Message, WitnessSet};
 }

--- a/spel-framework/Cargo.toml
+++ b/spel-framework/Cargo.toml
@@ -4,10 +4,15 @@ version = "0.2.0"
 edition = "2021"
 description = "Developer framework for building SPEL programs (like Anchor for Solana)"
 
+[features]
+default = []
+host = ["dep:nssa", "spel-framework-core/host"]
+
 [dependencies]
 spel-framework-core = { path = "../spel-framework-core" }
 spel-framework-macros = { path = "../spel-framework-macros" }
 nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1", features = ["host"] }
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1", optional = true }
 borsh = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 

--- a/spel-framework/src/lib.rs
+++ b/spel-framework/src/lib.rs
@@ -21,4 +21,8 @@ pub mod prelude {
     pub use spel_framework_core::spel_output::AutoClaim;
     pub use spel_framework_core::error::{SpelError, SpelResult};
     pub use borsh::{BorshSerialize, BorshDeserialize};
+
+    // nssa::public_transaction (host-only)
+    #[cfg(feature = "host")]
+    pub use spel_framework_core::prelude::{Message, WitnessSet};
 }


### PR DESCRIPTION
## Description

Re-export fundamental LEZ types from `spel_framework::prelude` so downstream crates only need a single `spel-framework` dependency.

## Changes

- Add `nssa` as a dependency of `spel-framework-core`
- Re-export `AccountId` from `nssa_core::account`
- Re-export `InstructionData`, `ProgramInput`, `ProgramOutput`, `read_nssa_inputs` from `nssa_core::program`
- Re-export `Message`, `WitnessSet` from `nssa::public_transaction`

Downstream crates can now use `use spel_framework::prelude::*;` to access all types without pinning `logos-execution-zone` directly.

## Checklist

- [x] Builds cleanly
- [x] Tests pass
- [x] Branch is off `main`