### PR TITLE
feat: re-export nssa_core types and add host feature

### DIFF
--- a/spel-framework-core/Cargo.toml
+++ b/spel-framework-core/Cargo.toml
@@ -7,6 +7,7 @@ description = "Core types for the SPEL program framework"
 [features]
 default = []
 idl-gen = ["dep:syn"]
+host = ["dep:nssa"]
 
 [dependencies]
 nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1", features = ["host"] }
@@ -15,6 +16,7 @@ thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
-nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1" }
+
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1", optional = true }
 
 syn = { version = "2.0", features = ["full", "extra-traits"], optional = true }

--- a/spel-framework-core/Cargo.toml
+++ b/spel-framework-core/Cargo.toml
@@ -15,4 +15,6 @@ thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc1" }
+
 syn = { version = "2.0", features = ["full", "extra-traits"], optional = true }

--- a/spel-framework-core/src/lib.rs
+++ b/spel-framework-core/src/lib.rs
@@ -27,6 +27,7 @@ pub mod prelude {
         ProgramOutput, read_nssa_inputs,
     };
 
-    // nssa::public_transaction
+    // nssa::public_transaction (host-only)
+    #[cfg(feature = "host")]
     pub use nssa::public_transaction::{Message, WitnessSet};
 }

--- a/spel-framework-core/src/lib.rs
+++ b/spel-framework-core/src/lib.rs
@@ -17,6 +17,16 @@ pub mod prelude {
     pub use crate::pda::{compute_pda, compute_pda_multi, seed_from_str, ToSeed};
     pub use crate::spel_output::AutoClaim;
     pub use crate::types::{IntoPostState, SpelOutput, AccountConstraint};
-    pub use nssa_core::account::{Account, AccountWithMetadata};
-    pub use nssa_core::program::{AccountPostState, ChainedCall, Claim, PdaSeed, ProgramId};
+
+    // nssa_core::account
+    pub use nssa_core::account::{Account, AccountId, AccountWithMetadata};
+
+    // nssa_core::program
+    pub use nssa_core::program::{
+        AccountPostState, ChainedCall, Claim, InstructionData, PdaSeed, ProgramId, ProgramInput,
+        ProgramOutput, read_nssa_inputs,
+    };
+
+    // nssa::public_transaction
+    pub use nssa::public_transaction::{Message, WitnessSet};
 }


### PR DESCRIPTION
## Summary

- Add `host` feature flag to spel-framework-core that enables the nssa dependency
- Re-export nssa_core::account::{Account, AccountId, AccountWithMetadata} in prelude
- Re-export nssa_core::program::{AccountPostState, ChainedCall, Claim, InstructionData, PdaSeed, ProgramId, ProgramInput, ProgramOutput, read_nssa_inputs} in prelude
- Conditionally re-export nssa::public_transaction::{Message, WitnessSet} behind the host feature

## Changes

**spel-framework-core/Cargo.toml**
- Added `host` feature that enables dep:nssa
- Made nssa dependency optional

**spel-framework-core/src/lib.rs**
- Expanded prelude with nssa_core account and program types
- Added cfg-gated re-exports for host-only types
