### PR TITLE
fix: collect #[account_type] structs defined inside #[lez_program] module

### DIFF
--- a/spel-framework-core/src/idl_gen.rs
+++ b/spel-framework-core/src/idl_gen.rs
@@ -184,7 +184,9 @@ fn generate_idl_from_str(content: &str, source_label: &str) -> Result<SpelIdl, I
         })
         .collect();
 
-    let (accounts, types) = collect_account_types(&file.items);
+    let mut all_items: Vec<syn::Item> = file.items.clone();
+    all_items.extend(items.clone());
+    let (accounts, types) = collect_account_types(&all_items);
 
     Ok(SpelIdl {
         version: "0.1.0".to_string(),

--- a/spel-framework-macros/src/lib.rs
+++ b/spel-framework-macros/src/lib.rs
@@ -401,7 +401,20 @@ fn expand_lez_program(input: ItemMod, config: ProgramConfig) -> syn::Result<Toke
                 if let Ok(content_str) = std::fs::read_to_string(guest_path) {
                     if let Ok(parsed_file) = syn::parse_file(&content_str) {
                         if file_matches_module(&parsed_file) {
-                            result = account_types::collect_account_types(&parsed_file.items);
+                            // Collect from top-level items AND from inside the
+                            // #[lez_program] module body (account types are often
+                            // defined inside the module).
+                            let mut all_items: Vec<syn::Item> = parsed_file.items.clone();
+                            for item in &parsed_file.items {
+                                if let syn::Item::Mod(m) = item {
+                                    if m.ident == *mod_name {
+                                        if let Some((_, mod_items)) = &m.content {
+                                            all_items.extend(mod_items.clone());
+                                        }
+                                    }
+                                }
+                            }
+                            result = account_types::collect_account_types(&all_items);
                             break;
                         }
                     }
@@ -1808,8 +1821,12 @@ fn expand_generate_idl(file_path: &str, span_token: &syn::LitStr) -> syn::Result
             ext
         });
 
-    // Collect #[account_type] annotated types from the file's top-level items
-    let (accounts, types) = account_types::collect_account_types(&file.items);
+    // Collect #[account_type] annotated types: search both the file's top-level
+    // items and the items inside the #[lez_program] module body, since user code
+    // commonly defines account structs inside the program module.
+    let mut all_items: Vec<syn::Item> = file.items.clone();
+    all_items.extend(items.clone());
+    let (accounts, types) = account_types::collect_account_types(&all_items);
 
     // Generate the IDL JSON
     let idl_json = generate_idl_json(mod_name, &instructions, external_instruction_str.as_deref(), accounts, types);


### PR DESCRIPTION
## Summary

- All three IDL-generation paths (`generate_idl!` macro, `#[lez_program]` macro, `spel-cli generate-idl`) called `collect_account_types(&file.items)`, scanning only top-level file items.
- Structs annotated with `#[account_type]` inside the `#[lez_program] mod { ... }` body were silently skipped, producing `"accounts": []` in the IDL even when account types were present.
- Fix: build a combined item slice from file top-level items + the module body items before calling `collect_account_types`, in all three code paths.

## Test plan

- [ ] Generate IDL for a program that defines `#[account_type]` structs inside the `#[lez_program]` module — verify `accounts` array is populated
- [ ] Generate IDL for a program that defines `#[account_type]` structs at the file top level — verify it still works
- [ ] Run existing test suite: `cargo test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)