### PR TITLE
fix(idl-gen): collect #[account_type] types from path-dependency crates

### DIFF
--- a/spel-cli/src/generate_idl.rs
+++ b/spel-cli/src/generate_idl.rs
@@ -14,6 +14,8 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use toml::Value;
+
 /// Resolve the list of SPEL program source files for IDL generation.
 ///
 /// `arg` is the optional positional argument passed to `generate-idl`:
@@ -63,6 +65,49 @@ pub fn discover_sources(arg: Option<&str>) -> Result<Vec<PathBuf>, String> {
                     .to_string(),
             )
         }
+    }
+}
+
+/// Return the crate-root directories of all `path = "..."` entries in the
+/// `[dependencies]` table of the `Cargo.toml` nearest to `source_path`.
+///
+/// Only runtime dependencies are considered.  `[dev-dependencies]` and
+/// `[build-dependencies]` are deliberately excluded: types defined in those
+/// crates are not part of the program's on-chain interface and must not appear
+/// in the generated IDL.  Registry (`version = "..."`) and git dependencies
+/// are also excluded so that only project-local crates are scanned.
+pub fn find_path_dep_dirs(source_path: &Path) -> Vec<PathBuf> {
+    (|| -> Option<Vec<PathBuf>> {
+        let manifest = find_crate_manifest(source_path)?;
+        let content = fs::read_to_string(&manifest).ok()?;
+        let value: Value = toml::from_str(&content).ok()?;
+        let manifest_dir = manifest.parent()?;
+
+        let mut dirs = Vec::new();
+        if let Some(table) = value.get("dependencies").and_then(|v| v.as_table()) {
+            for (_name, dep) in table {
+                if let Some(rel) = dep.get("path").and_then(|v| v.as_str()) {
+                    let dep_dir = manifest_dir.join(rel);
+                    if dep_dir.is_dir() {
+                        dirs.push(dep_dir);
+                    }
+                }
+            }
+        }
+        Some(dirs)
+    })()
+    .unwrap_or_default()
+}
+
+/// Walk up from `start` to find the nearest `Cargo.toml`.
+fn find_crate_manifest(start: &Path) -> Option<PathBuf> {
+    let mut dir: &Path = if start.is_file() { start.parent()? } else { start };
+    loop {
+        let candidate = dir.join("Cargo.toml");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+        dir = dir.parent()?;
     }
 }
 
@@ -290,5 +335,404 @@ mod tests {
         assert!(idl.instructions[0].accounts[0].writable);
         assert!(idl.instructions[0].accounts[0].pda.is_some());
         assert!(idl.instructions[0].accounts[1].signer);
+    }
+
+    // ── find_path_dep_dirs ─────────────────────────────────────────────────
+
+    #[test]
+    fn find_path_dep_dirs_returns_local_path_deps() {
+        let tmp = TempDir::new("find-path-deps");
+
+        tmp.write("core/Cargo.toml", "[package]\nname = \"token_core\"\nversion = \"0.1.0\"\nedition = \"2021\"\n");
+        tmp.write("core/src/lib.rs", "");
+
+        tmp.write(
+            "methods/guest/Cargo.toml",
+            "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\ntoken_core = { path = \"../../core\" }\n",
+        );
+        let program = tmp.write("methods/guest/src/bin/token.rs", "");
+
+        let dirs = find_path_dep_dirs(&program);
+        assert_eq!(dirs.len(), 1);
+        assert!(dirs[0].ends_with("core"), "expected core dir, got {:?}", dirs[0]);
+    }
+
+    #[test]
+    fn find_path_dep_dirs_ignores_registry_and_git_deps() {
+        let tmp = TempDir::new("find-path-deps-filter");
+
+        tmp.write("core/Cargo.toml", "[package]\nname = \"token_core\"\nversion = \"0.1.0\"\nedition = \"2021\"\n");
+        tmp.write("core/src/lib.rs", "");
+
+        tmp.write(
+            "methods/guest/Cargo.toml",
+            "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\n\
+             token_core = { path = \"../../core\" }\n\
+             serde = { version = \"1.0\" }\n\
+             nssa_core = { git = \"https://example.com/repo.git\", tag = \"v1.0\" }\n",
+        );
+        let program = tmp.write("methods/guest/src/bin/token.rs", "");
+
+        let dirs = find_path_dep_dirs(&program);
+        // Only the path dep (core) should be returned, not serde or nssa_core
+        assert_eq!(dirs.len(), 1);
+        assert!(dirs[0].ends_with("core"));
+    }
+
+    #[test]
+    fn find_path_dep_dirs_ignores_dev_and_build_deps() {
+        let tmp = TempDir::new("find-path-deps-dev-build");
+
+        tmp.write("core/Cargo.toml", "[package]\nname = \"token_core\"\nversion = \"0.1.0\"\nedition = \"2021\"\n");
+        tmp.write("core/src/lib.rs", "");
+        tmp.write("test_helpers/Cargo.toml", "[package]\nname = \"test_helpers\"\nversion = \"0.1.0\"\nedition = \"2021\"\n");
+        tmp.write("test_helpers/src/lib.rs", "");
+        tmp.write("build_support/Cargo.toml", "[package]\nname = \"build_support\"\nversion = \"0.1.0\"\nedition = \"2021\"\n");
+        tmp.write("build_support/src/lib.rs", "");
+
+        tmp.write(
+            "methods/guest/Cargo.toml",
+            "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\n\
+             token_core = { path = \"../../core\" }\n\n\
+             [dev-dependencies]\n\
+             test_helpers = { path = \"../../test_helpers\" }\n\n\
+             [build-dependencies]\n\
+             build_support = { path = \"../../build_support\" }\n",
+        );
+        let program = tmp.write("methods/guest/src/bin/token.rs", "");
+
+        let dirs = find_path_dep_dirs(&program);
+        // Only runtime path dep (core) should be returned
+        assert_eq!(dirs.len(), 1, "expected only core, got: {dirs:?}");
+        assert!(dirs[0].ends_with("core"));
+    }
+
+    // ── account types from path-dep crates ────────────────────────────────
+
+    /// Mirrors the real token program structure:
+    ///   core/src/lib.rs          — TokenDefinition, TokenHolding, TokenMetadata (#[account_type])
+    ///   methods/guest/Cargo.toml — depends on core via path = "../../core"
+    ///   methods/guest/src/bin/token.rs — #[lez_program], no #[account_type] here
+    #[test]
+    fn account_types_from_path_dep_lib_appear_in_idl() {
+        use spel_framework_core::idl_gen::generate_idl_from_file_with_deps;
+
+        let tmp = TempDir::new("path-dep-lib");
+
+        tmp.write(
+            "core/Cargo.toml",
+            "[package]\nname = \"token_core\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        );
+        tmp.write(
+            "core/src/lib.rs",
+            r#"
+use nssa_core::account::AccountId;
+
+#[account_type]
+pub enum TokenDefinition {
+    Fungible {
+        name: String,
+        total_supply: u128,
+        metadata_id: Option<AccountId>,
+    },
+    NonFungible {
+        name: String,
+        printable_supply: u128,
+        metadata_id: AccountId,
+    },
+}
+
+#[account_type]
+pub enum TokenHolding {
+    Fungible {
+        definition_id: AccountId,
+        balance: u128,
+    },
+    NftMaster {
+        definition_id: AccountId,
+        print_balance: u128,
+    },
+    NftPrintedCopy {
+        definition_id: AccountId,
+        owned: bool,
+    },
+}
+
+#[account_type]
+pub struct TokenMetadata {
+    pub definition_id: AccountId,
+    pub uri: String,
+    pub primary_sale_date: u64,
+}
+"#,
+        );
+
+        tmp.write(
+            "methods/guest/Cargo.toml",
+            "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\ntoken_core = { path = \"../../core\" }\n",
+        );
+        let program = tmp.write(
+            "methods/guest/src/bin/token.rs",
+            r#"
+#[lez_program(instruction = "token_core::Instruction")]
+pub mod token {
+    use super::*;
+
+    #[instruction]
+    pub fn transfer(
+        sender: AccountWithMetadata,
+        recipient: AccountWithMetadata,
+        amount_to_transfer: u128,
+    ) -> SpelResult { todo!() }
+
+    #[instruction]
+    pub fn initialize_account(
+        definition_account: AccountWithMetadata,
+        account_to_initialize: AccountWithMetadata,
+    ) -> SpelResult { todo!() }
+
+    #[instruction]
+    pub fn mint(
+        definition_account: AccountWithMetadata,
+        user_holding_account: AccountWithMetadata,
+        amount_to_mint: u128,
+    ) -> SpelResult { todo!() }
+
+    #[instruction]
+    pub fn burn(
+        definition_account: AccountWithMetadata,
+        user_holding_account: AccountWithMetadata,
+        amount_to_burn: u128,
+    ) -> SpelResult { todo!() }
+}
+"#,
+        );
+
+        let dep_dirs = find_path_dep_dirs(&program);
+        assert_eq!(dep_dirs.len(), 1);
+
+        let idl = generate_idl_from_file_with_deps(&program, &dep_dirs).unwrap();
+
+        assert_eq!(idl.name, "token");
+        assert_eq!(idl.instructions.len(), 4);
+
+        let account_names: Vec<&str> = idl.accounts.iter().map(|a| a.name.as_str()).collect();
+        assert!(
+            account_names.contains(&"TokenDefinition"),
+            "TokenDefinition missing; got {:?}",
+            account_names
+        );
+        assert!(
+            account_names.contains(&"TokenHolding"),
+            "TokenHolding missing; got {:?}",
+            account_names
+        );
+        assert!(
+            account_names.contains(&"TokenMetadata"),
+            "TokenMetadata missing; got {:?}",
+            account_names
+        );
+    }
+
+    /// Account types split across sub-modules of a path-dep crate are also found.
+    /// lib.rs declares `pub mod types;` and the types live in types.rs.
+    #[test]
+    fn account_types_in_submodule_of_path_dep_appear_in_idl() {
+        use spel_framework_core::idl_gen::generate_idl_from_file_with_deps;
+
+        let tmp = TempDir::new("path-dep-submodule");
+
+        tmp.write(
+            "core/Cargo.toml",
+            "[package]\nname = \"token_core\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        );
+        // lib.rs re-exports from a sub-module; account types live in types.rs
+        tmp.write("core/src/lib.rs", "pub mod types;\n");
+        tmp.write(
+            "core/src/types.rs",
+            r#"
+use nssa_core::account::AccountId;
+
+#[account_type]
+pub enum TokenHolding {
+    Fungible {
+        definition_id: AccountId,
+        balance: u128,
+    },
+}
+
+#[account_type]
+pub struct TokenMetadata {
+    pub uri: String,
+}
+"#,
+        );
+
+        tmp.write(
+            "methods/guest/Cargo.toml",
+            "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\ntoken_core = { path = \"../../core\" }\n",
+        );
+        let program = tmp.write(
+            "methods/guest/src/bin/token.rs",
+            r#"
+#[lez_program]
+pub mod token {
+    #[instruction]
+    pub fn transfer(
+        sender: AccountWithMetadata,
+        recipient: AccountWithMetadata,
+        amount: u128,
+    ) -> SpelResult { todo!() }
+}
+"#,
+        );
+
+        let dep_dirs = find_path_dep_dirs(&program);
+        let idl = generate_idl_from_file_with_deps(&program, &dep_dirs).unwrap();
+
+        let account_names: Vec<&str> = idl.accounts.iter().map(|a| a.name.as_str()).collect();
+        assert!(
+            account_names.contains(&"TokenHolding"),
+            "TokenHolding in sub-module not found; got {:?}",
+            account_names
+        );
+        assert!(
+            account_names.contains(&"TokenMetadata"),
+            "TokenMetadata in sub-module not found; got {:?}",
+            account_names
+        );
+    }
+
+    /// Account type inside a file-backed module that is itself declared inside an
+    /// inline module: `mod outer { mod inner; }` in lib.rs, where `inner` resolves
+    /// to `outer/inner.rs`.  Verifies that base_dir is advanced when recursing into
+    /// inline module bodies.
+    #[test]
+    fn account_type_in_nested_file_module_appears_in_idl() {
+        use spel_framework_core::idl_gen::generate_idl_from_file_with_deps;
+
+        let tmp = TempDir::new("nested-file-mod");
+
+        tmp.write(
+            "core/Cargo.toml",
+            "[package]\nname = \"token_core\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        );
+        // lib.rs has an inline `mod outer` whose body declares an external `mod inner`
+        tmp.write("core/src/lib.rs", "pub mod outer {\n    pub mod inner;\n}\n");
+        // inner.rs lives at core/src/outer/inner.rs
+        tmp.write(
+            "core/src/outer/inner.rs",
+            "#[account_type]\npub struct VaultAccount { pub balance: u128 }\n",
+        );
+
+        tmp.write(
+            "methods/guest/Cargo.toml",
+            "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\ntoken_core = { path = \"../../core\" }\n",
+        );
+        let program = tmp.write(
+            "methods/guest/src/bin/token.rs",
+            "#[lez_program]\npub mod token {\n  \
+             #[instruction]\n  \
+             pub fn deposit(acc: AccountWithMetadata) -> SpelResult { todo!() }\n}\n",
+        );
+
+        let dep_dirs = find_path_dep_dirs(&program);
+        let idl = generate_idl_from_file_with_deps(&program, &dep_dirs).unwrap();
+
+        let account_names: Vec<&str> = idl.accounts.iter().map(|a| a.name.as_str()).collect();
+        assert!(
+            account_names.contains(&"VaultAccount"),
+            "VaultAccount in outer/inner.rs not found; got {:?}",
+            account_names
+        );
+    }
+
+    /// A `mod` declaration with a `#[path = "..."]` override is resolved to the
+    /// explicitly given file rather than the default `<mod>.rs` / `<mod>/mod.rs`.
+    #[test]
+    fn account_type_behind_path_attribute_appears_in_idl() {
+        use spel_framework_core::idl_gen::generate_idl_from_file_with_deps;
+
+        let tmp = TempDir::new("path-attr-mod");
+
+        tmp.write(
+            "core/Cargo.toml",
+            "[package]\nname = \"token_core\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        );
+        // lib.rs uses #[path] to point at a non-standard file name.
+        tmp.write(
+            "core/src/lib.rs",
+            "#[path = \"account_types.rs\"]\npub mod types;\n",
+        );
+        tmp.write(
+            "core/src/account_types.rs",
+            "#[account_type]\npub struct StakeAccount { pub amount: u64 }\n",
+        );
+
+        tmp.write(
+            "methods/guest/Cargo.toml",
+            "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\ntoken_core = { path = \"../../core\" }\n",
+        );
+        let program = tmp.write(
+            "methods/guest/src/bin/token.rs",
+            "#[lez_program]\npub mod token {\n  \
+             #[instruction]\n  \
+             pub fn stake(acc: AccountWithMetadata) -> SpelResult { todo!() }\n}\n",
+        );
+
+        let dep_dirs = find_path_dep_dirs(&program);
+        let idl = generate_idl_from_file_with_deps(&program, &dep_dirs).unwrap();
+
+        let account_names: Vec<&str> = idl.accounts.iter().map(|a| a.name.as_str()).collect();
+        assert!(
+            account_names.contains(&"StakeAccount"),
+            "StakeAccount behind #[path] not found; got {:?}",
+            account_names
+        );
+    }
+
+    /// Without dep dirs, #[account_type] types from external crates are absent.
+    /// This is the regression guard — the old behaviour that the fix addresses.
+    #[test]
+    fn without_dep_dirs_external_account_types_are_missing() {
+        use spel_framework_core::idl_gen::generate_idl_from_file_with_deps;
+
+        let tmp = TempDir::new("path-dep-no-scan");
+
+        tmp.write(
+            "core/Cargo.toml",
+            "[package]\nname = \"token_core\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        );
+        tmp.write(
+            "core/src/lib.rs",
+            "#[account_type]\npub struct TokenHolding { pub balance: u128 }\n",
+        );
+
+        tmp.write(
+            "methods/guest/Cargo.toml",
+            "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\ntoken_core = { path = \"../../core\" }\n",
+        );
+        let program = tmp.write(
+            "methods/guest/src/bin/token.rs",
+            "#[lez_program]\npub mod token {\n  \
+             #[instruction]\n  \
+             pub fn transfer(acc: AccountWithMetadata) -> SpelResult { todo!() }\n}\n",
+        );
+
+        // Passing no dep dirs replicates the old single-file behaviour
+        let idl = generate_idl_from_file_with_deps(&program, &[]).unwrap();
+        assert!(
+            idl.accounts.is_empty(),
+            "expected no accounts without dep scanning, got {:?}",
+            idl.accounts.iter().map(|a| &a.name).collect::<Vec<_>>()
+        );
     }
 }

--- a/spel-cli/src/lib.rs
+++ b/spel-cli/src/lib.rs
@@ -250,8 +250,8 @@ pub async fn run() {
                 return;
             }
             "generate-idl" => {
-                use spel_framework_core::idl_gen::generate_idl_from_file;
-                use generate_idl::discover_sources;
+                use spel_framework_core::idl_gen::generate_idl_from_file_with_deps;
+                use generate_idl::{discover_sources, find_path_dep_dirs};
 
                 let arg = remaining_args.get(2).map(|s| s.as_str());
                 let sources = discover_sources(arg).unwrap_or_else(|e| {
@@ -260,7 +260,8 @@ pub async fn run() {
                 });
 
                 if sources.len() == 1 {
-                    match generate_idl_from_file(&sources[0]) {
+                    let dep_dirs = find_path_dep_dirs(&sources[0]);
+                    match generate_idl_from_file_with_deps(&sources[0], &dep_dirs) {
                         Ok(idl) => println!("{}", serde_json::to_string_pretty(&idl).unwrap()),
                         Err(e) => {
                             eprintln!("Error: {}", e);
@@ -271,7 +272,8 @@ pub async fn run() {
                     // Multiple programs: write <name>-idl.json for each
                     let mut had_error = false;
                     for source in &sources {
-                        match generate_idl_from_file(source) {
+                        let dep_dirs = find_path_dep_dirs(source);
+                        match generate_idl_from_file_with_deps(source, &dep_dirs) {
                             Ok(idl) => {
                                 let out_name = format!("{}-idl.json", idl.name);
                                 match fs::write(&out_name, serde_json::to_string_pretty(&idl).unwrap()) {

--- a/spel-framework-core/src/idl_gen.rs
+++ b/spel-framework-core/src/idl_gen.rs
@@ -7,8 +7,9 @@
 //! `spel-framework-macros`, but operates at runtime on a file path
 //! rather than at compile time.
 
+use std::collections::HashSet;
 use std::fmt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use syn::{Attribute, FnArg, Ident, ItemFn, Pat, PatType, Type};
 
@@ -60,14 +61,43 @@ impl From<syn::Error> for IdlGenError {
 /// The path is resolved relative to the current working directory,
 /// which is the natural behavior for a CLI tool.
 pub fn generate_idl_from_file(source_path: &Path) -> Result<SpelIdl, IdlGenError> {
+    generate_idl_from_file_with_deps(source_path, &[])
+}
+
+/// Parse a SPEL program source file and return its [`SpelIdl`], also scanning
+/// the library source of each crate directory in `dep_source_dirs` for
+/// `#[account_type]`-annotated types.
+///
+/// Each entry in `dep_source_dirs` should be a Rust crate root (the directory
+/// that contains `src/lib.rs`).  Only local path-dependencies should be passed
+/// here — third-party registry or git crates are intentionally excluded to
+/// avoid pulling in unrelated type definitions.
+pub fn generate_idl_from_file_with_deps(
+    source_path: &Path,
+    dep_source_dirs: &[PathBuf],
+) -> Result<SpelIdl, IdlGenError> {
     let content = std::fs::read_to_string(source_path)?;
-    generate_idl_from_str(&content, &source_path.display().to_string())
+    let extra_items = collect_items_from_crate_dirs(dep_source_dirs);
+    generate_idl_inner(&content, &source_path.display().to_string(), &extra_items)
 }
 
 /// Parse a SPEL program from source text and return its [`SpelIdl`].
 ///
-/// `source_label` is used only in error messages.
+/// `source_label` is used only in error messages. Used exclusively in tests;
+/// production code goes through `generate_idl_from_file_with_deps`.
+#[cfg(test)]
 fn generate_idl_from_str(content: &str, source_label: &str) -> Result<SpelIdl, IdlGenError> {
+    generate_idl_inner(content, source_label, &[])
+}
+
+/// Core IDL generation logic. `extra_items` are synthetic items collected from
+/// dependency crate sources and merged with the program file's own items before
+/// account-type scanning.
+fn generate_idl_inner(
+    content: &str,
+    source_label: &str,
+    extra_items: &[syn::Item],
+) -> Result<SpelIdl, IdlGenError> {
     let path_str = source_label.to_string();
 
     let file = syn::parse_file(content)?;
@@ -186,6 +216,7 @@ fn generate_idl_from_str(content: &str, source_label: &str) -> Result<SpelIdl, I
 
     let mut all_items: Vec<syn::Item> = file.items.clone();
     all_items.extend(items.clone());
+    all_items.extend_from_slice(extra_items);
     let (accounts, types) = collect_account_types(&all_items);
 
     Ok(SpelIdl {
@@ -199,6 +230,124 @@ fn generate_idl_from_str(content: &str, source_label: &str) -> Result<SpelIdl, I
         metadata: None,
         instruction_type: external_instruction,
     })
+}
+
+// ─── Dependency source collection ────────────────────────────────────────
+
+/// Parse the library source of each crate directory and return all `syn::Item`s
+/// found, following `mod` declarations recursively.
+fn collect_items_from_crate_dirs(dirs: &[PathBuf]) -> Vec<syn::Item> {
+    let mut items = Vec::new();
+    let mut visited: HashSet<PathBuf> = HashSet::new();
+    for dir in dirs {
+        let lib_rs = dir.join("src").join("lib.rs");
+        if lib_rs.exists() {
+            collect_items_from_source_file(&lib_rs, &mut items, &mut visited);
+        }
+    }
+    items
+}
+
+/// Parse a single Rust source file and append its items to `out`, following
+/// external `mod` declarations to their corresponding files.
+fn collect_items_from_source_file(
+    path: &Path,
+    out: &mut Vec<syn::Item>,
+    visited: &mut HashSet<PathBuf>,
+) {
+    let canonical = match path.canonicalize() {
+        Ok(p) => p,
+        Err(_) => path.to_path_buf(),
+    };
+    if !visited.insert(canonical) {
+        return; // already processed
+    }
+
+    let content = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+    let file = match syn::parse_file(&content) {
+        Ok(f) => f,
+        Err(_) => return,
+    };
+
+    // Sub-module files for `lib.rs` / `mod.rs` live alongside the file;
+    // for `foo.rs` they live in a `foo/` directory next to the file.
+    let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    let sub_base = if file_name == "lib.rs" || file_name == "mod.rs" {
+        path.parent().map(|p| p.to_path_buf())
+    } else {
+        let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+        path.parent().map(|p| p.join(stem))
+    };
+
+    collect_items_recursive(&file.items, sub_base.as_deref(), out, visited);
+}
+
+/// Resolve the on-disk path for an external `mod` declaration.
+///
+/// Resolution order:
+/// 1. `#[path = "..."]` attribute on the mod item — resolved relative to `base_dir`.
+/// 2. `<base_dir>/<mod_name>.rs`
+/// 3. `<base_dir>/<mod_name>/mod.rs`
+///
+/// Returns `None` if no candidate file exists.
+fn mod_file_path(m: &syn::ItemMod, base_dir: &Path) -> Option<PathBuf> {
+    // Check for explicit #[path = "..."] override first.
+    for attr in &m.attrs {
+        if attr.path().is_ident("path") {
+            if let Ok(syn::MetaNameValue {
+                value: syn::Expr::Lit(syn::ExprLit { lit: syn::Lit::Str(s), .. }),
+                ..
+            }) = attr.meta.require_name_value()
+            {
+                let p = base_dir.join(s.value());
+                if p.exists() {
+                    return Some(p);
+                }
+            }
+        }
+    }
+
+    // Standard two-candidate resolution.
+    let mod_name = m.ident.to_string();
+    let flat = base_dir.join(format!("{mod_name}.rs"));
+    if flat.exists() {
+        return Some(flat);
+    }
+    let nested = base_dir.join(&mod_name).join("mod.rs");
+    if nested.exists() {
+        return Some(nested);
+    }
+    None
+}
+
+fn collect_items_recursive(
+    items: &[syn::Item],
+    base_dir: Option<&Path>,
+    out: &mut Vec<syn::Item>,
+    visited: &mut HashSet<PathBuf>,
+) {
+    for item in items {
+        match item {
+            syn::Item::Mod(m) => {
+                if let Some((_, inner)) = &m.content {
+                    // Inline module — recurse into its body with an updated base_dir
+                    // so that any file-backed `mod` declarations inside it resolve
+                    // relative to `base_dir/<mod_name>/` rather than `base_dir/`.
+                    let inner_base = base_dir.map(|d| d.join(m.ident.to_string()));
+                    collect_items_recursive(inner, inner_base.as_deref(), out, visited);
+                } else if let Some(dir) = base_dir {
+                    // External module file — locate and parse it.
+                    if let Some(p) = mod_file_path(m, dir) {
+                        collect_items_from_source_file(&p, out, visited);
+                    }
+                }
+            }
+            _ => out.push(item.clone()),
+        }
+    }
 }
 
 // ─── Internal parsing types ───────────────────────────────────────────────


### PR DESCRIPTION
The IDL generator only scanned a single source file, so #[account_type] structs and enums defined in local dependency crates (e.g. TokenHolding in token_core) were silently absent from the generated IDL.

Add generate_idl_from_file_with_deps() to spel-framework-core, which accepts additional crate-root directories to scan alongside the program file. Items are collected from each dep's src/lib.rs, following mod declarations recursively, then merged into all_items before collect_account_types runs — so both the direct annotation scan (Pass 1) and the BFS helper-type resolution (Pass 2) see the external types.

Add find_path_dep_dirs() to spel-cli, which walks up from the program source file to locate the nearest Cargo.toml and extracts every path = "..." dependency from it. Registry (version) and git dependencies are deliberately excluded — only project-local crates are scanned to avoid pulling in unrelated type definitions from third-party libraries. The CLI generate-idl handler now calls both functions in sequence.


