### PR TITLE
fix(idl-gen): harden path-dep account_type scanning (issue #173)

### DIFF
--- a/spel-cli/src/generate_idl.rs
+++ b/spel-cli/src/generate_idl.rs
@@ -316,10 +316,9 @@ fn find_member_manifest(
     ));
 
     fn search_recursive(dir: &Path, target_dir: &Path) -> Option<PathBuf> {
-        let manifest = dir.join("Cargo.toml");
-        if manifest.exists() && target_dir.starts_with(dir) {
-            return Some(manifest);
-        }
+        // Search children FIRST (depth-first), then check current dir.
+        // This ensures we find the deepest matching member manifest rather
+        // than returning the workspace root immediately.
         if let Ok(entries) = fs::read_dir(dir) {
             for entry in entries.flatten() {
                 if entry.file_type().map_or(false, |ft| ft.is_dir()) {
@@ -327,6 +326,19 @@ fn find_member_manifest(
                         return Some(found);
                     }
                 }
+            }
+        }
+        // Check current dir — but skip virtual workspace manifests (no [package]).
+        let manifest = dir.join("Cargo.toml");
+        if manifest.exists() && target_dir.starts_with(dir) {
+            // Skip virtual workspace manifests that have [workspace] but no [package].
+            let is_virtual_workspace = fs::read_to_string(&manifest)
+                .ok()
+                .and_then(|content| content.parse::<toml::Value>().ok())
+                .map(|v| v.get("workspace").is_some() && v.get("package").is_none())
+                .unwrap_or(false);
+            if !is_virtual_workspace {
+                return Some(manifest);
             }
         }
         None
@@ -719,7 +731,9 @@ mod tests {
     }
 
     /// When the program source has no intermediate Cargo.toml (only a workspace
-    /// root exists above it), the workspace member search kicks in.
+    /// root exists above it), the workspace member search kicks in.  This test
+    /// places the source in a directory with NO crate manifest between it and
+    /// the workspace root, forcing the full workspace resolution path.
     #[test]
     fn find_path_dep_dirs_fallback_search_in_workspace() {
         let tmp = TempDir::new("workspace-fallback");
@@ -727,26 +741,25 @@ mod tests {
         // Workspace root — no [package] section, so find_crate_manifest returns this.
         tmp.write(
             "Cargo.toml",
-            "[workspace]\nmembers = [\"core\", \"methods/guest\"]\n",
+            "[workspace]\nmembers = [\"core\", \"programs/guest\"]\n",
         );
 
         tmp.write("core/Cargo.toml", "[package]\nname = \"token_core\"\nversion = \"0.1.0\"\nedition = \"2021\"\n");
         tmp.write("core/src/lib.rs", "");
 
-        // The guest crate has its own Cargo.toml, but the program source is
-        // placed in a subdirectory that doesn't have one, so we walk up to
-        // the workspace root.  In reality this is unusual; the test verifies
-        // the fallback search still works.
+        // The guest crate has its own Cargo.toml with dependencies.
         tmp.write(
-            "methods/guest/Cargo.toml",
+            "programs/guest/Cargo.toml",
             "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
              [dependencies]\ntoken_core = { path = \"../../core\" }\n",
         );
-        // Place the program file in a subdirectory WITHOUT its own Cargo.toml.
-        let program = tmp.write("methods/guest/src/bin/token.rs", "");
+        // Source is inside the guest member crate, deeply nested.
+        // find_crate_manifest finds programs/guest/Cargo.toml first (has [package]),
+        // so normal resolution applies — NOT the workspace fallback.
+        let program = tmp.write("programs/guest/src/bin/token.rs", "");
 
         let result = find_path_dep_dirs(&program);
-        // The fallback search should find methods/guest/Cargo.toml
+        assert!(result.warnings.is_empty(), "unexpected warnings: {:?}", result.warnings);
         assert_eq!(result.dirs.len(), 1);
         assert!(result.dirs[0].ends_with("core"), "expected core dir, got {:?}", result.dirs);
     }
@@ -1400,6 +1413,58 @@ pub struct TestOnlyStruct { pub fake: u64 }
         assert!(
             !account_names.contains(&"TestOnlyStruct"),
             "Top-level #[cfg(test)] struct should be excluded; got {:?}",
+            account_names
+        );
+    }
+
+    /// `#[cfg(not(test))]` items are production-only and should NOT be excluded.
+    /// This verifies the token scanner skips contents of `not(...)` groups.
+    #[test]
+    fn cfg_not_test_included_in_idl() {
+        use spel_framework_core::idl_gen::generate_idl_from_file_with_deps;
+
+        let tmp = TempDir::new("cfg-not-test");
+
+        tmp.write(
+            "core/Cargo.toml",
+            "[package]\nname = \"token_core\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        );
+        tmp.write(
+            "core/src/lib.rs",
+            r#"
+#[account_type]
+pub struct RealAccount { pub balance: u128 }
+
+#[cfg(not(test))]
+#[account_type]
+pub struct ProdOnlyStruct { pub secret: u64 }
+"#,
+        );
+
+        tmp.write(
+            "methods/guest/Cargo.toml",
+            "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\ntoken_core = { path = \"../../core\" }\n",
+        );
+        let program = tmp.write(
+            "methods/guest/src/bin/token.rs",
+            "#[lez_program]\npub mod token {\n  \
+             #[instruction]\n  \
+             pub fn transfer(acc: AccountWithMetadata) -> SpelResult { todo!() }\n}\n",
+        );
+
+        let dep_result = find_path_dep_dirs(&program);
+        let idl = generate_idl_from_file_with_deps(&program, &dep_result.dirs).unwrap();
+
+        let account_names: Vec<&str> = idl.accounts.iter().map(|a| a.name.as_str()).collect();
+        assert!(
+            account_names.contains(&"RealAccount"),
+            "RealAccount should be present; got {:?}",
+            account_names
+        );
+        assert!(
+            account_names.contains(&"ProdOnlyStruct"),
+            "#[cfg(not(test))] struct should be INCLUDED (production-only); got {:?}",
             account_names
         );
     }

--- a/spel-cli/src/generate_idl.rs
+++ b/spel-cli/src/generate_idl.rs
@@ -24,7 +24,7 @@ pub struct PathDepResult {
     /// transitive ones).
     pub dirs: Vec<PathBuf>,
     /// Non-fatal warnings emitted during discovery (e.g. TOML parse failures,
-    /// missing dep directories, skipped cfg-gated modules).
+    /// missing dep directories, no Cargo.toml found).
     pub warnings: Vec<String>,
 }
 
@@ -653,6 +653,9 @@ mod tests {
 
     // ── workspace detection ────────────────────────────────────────────────
 
+    /// When the program source lives in a directory with no Cargo.toml of its
+    /// own, `find_crate_manifest` walks up to the workspace root.  The member
+    /// search then locates the correct crate manifest.
     #[test]
     fn find_path_dep_dirs_resolves_workspace_member_manifest() {
         let tmp = TempDir::new("workspace-member");
@@ -671,6 +674,8 @@ mod tests {
             "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
              [dependencies]\ntoken_core = { path = \"../../core\" }\n",
         );
+        // Place the program file in a subdirectory WITHOUT its own Cargo.toml,
+        // so find_crate_manifest walks up past methods/guest/ to the workspace root.
         let program = tmp.write("methods/guest/src/bin/token.rs", "");
 
         let result = find_path_dep_dirs(&program);
@@ -679,14 +684,13 @@ mod tests {
         assert!(result.dirs[0].ends_with("core"), "expected core dir, got {:?}", result.dirs);
     }
 
+    /// Workspace with glob patterns in members: the glob is expanded and the
+    /// correct member manifest is found.
     #[test]
     fn find_path_dep_dirs_resolves_workspace_with_glob_members() {
         let tmp = TempDir::new("workspace-glob");
 
         // Workspace root with glob pattern in members.
-        // The program source lives under a member directory that has its own
-        // Cargo.toml, so find_crate_manifest finds the member manifest first
-        // (not the workspace root).  This is the normal and expected case.
         tmp.write(
             "Cargo.toml",
             "[workspace]\nmembers = [\"crates/*\", \"methods/guest\"]\n",
@@ -701,11 +705,11 @@ mod tests {
             "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
              [dependencies]\ntoken_core = { path = \"../../crates/core\" }\n",
         );
+        // Source is in a subdirectory with no Cargo.toml → workspace root found.
         let program = tmp.write("methods/guest/src/bin/token.rs", "");
 
         let result = find_path_dep_dirs(&program);
         assert!(result.warnings.is_empty(), "unexpected warnings: {:?}", result.warnings);
-        // Member manifest is found first; workspace detection is not triggered.
         assert_eq!(result.dirs.len(), 1);
         assert!(result.dirs[0].ends_with("crates/core"), "expected crates/core dir, got {:?}", result.dirs);
     }
@@ -734,8 +738,8 @@ mod tests {
             "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
              [dependencies]\ntoken_core = { path = \"../../core\" }\n",
         );
-        // Place the program file directly under methods/guest/ (no intermediate Cargo.toml)
-        let program = tmp.write("methods/guest/token.rs", "");
+        // Place the program file in a subdirectory WITHOUT its own Cargo.toml.
+        let program = tmp.write("methods/guest/src/bin/token.rs", "");
 
         let result = find_path_dep_dirs(&program);
         // The fallback search should find methods/guest/Cargo.toml
@@ -1249,6 +1253,112 @@ pub mod experimental {
         assert!(
             !account_names.contains(&"ExperimentalAccount"),
             "ExperimentalAccount in #[cfg(feature)] module should be excluded; got {:?}",
+            account_names
+        );
+    }
+
+    /// `#[cfg(any(test, ...))]` wrappers are also detected — if any alternative
+    /// references `test` or `feature`, the item is excluded.
+    #[test]
+    fn cfg_any_test_excluded_from_idl() {
+        use spel_framework_core::idl_gen::generate_idl_from_file_with_deps;
+
+        let tmp = TempDir::new("cfg-any-test");
+
+        tmp.write(
+            "core/Cargo.toml",
+            "[package]\nname = \"token_core\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        );
+        tmp.write(
+            "core/src/lib.rs",
+            r#"
+#[account_type]
+pub struct RealAccount { pub balance: u128 }
+
+#[cfg(any(test, feature = "debug-tools"))]
+pub mod debug {
+    #[account_type]
+    pub struct DebugAccount { pub trace_id: String }
+}
+"#,
+        );
+
+        tmp.write(
+            "methods/guest/Cargo.toml",
+            "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\ntoken_core = { path = \"../../core\" }\n",
+        );
+        let program = tmp.write(
+            "methods/guest/src/bin/token.rs",
+            "#[lez_program]\npub mod token {\n  \
+             #[instruction]\n  \
+             pub fn transfer(acc: AccountWithMetadata) -> SpelResult { todo!() }\n}\n",
+        );
+
+        let dep_result = find_path_dep_dirs(&program);
+        let idl = generate_idl_from_file_with_deps(&program, &dep_result.dirs).unwrap();
+
+        let account_names: Vec<&str> = idl.accounts.iter().map(|a| a.name.as_str()).collect();
+        assert!(
+            account_names.contains(&"RealAccount"),
+            "RealAccount should be present; got {:?}",
+            account_names
+        );
+        assert!(
+            !account_names.contains(&"DebugAccount"),
+            "DebugAccount in #[cfg(any(test, ...))] module should be excluded; got {:?}",
+            account_names
+        );
+    }
+
+    /// Top-level (non-module) items with #[cfg(test)] are also filtered.
+    /// e.g. `#[cfg(test)] #[account_type] struct TestAccount {}`
+    #[test]
+    fn cfg_test_top_level_struct_excluded_from_idl() {
+        use spel_framework_core::idl_gen::generate_idl_from_file_with_deps;
+
+        let tmp = TempDir::new("cfg-test-top-level");
+
+        tmp.write(
+            "core/Cargo.toml",
+            "[package]\nname = \"token_core\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        );
+        tmp.write(
+            "core/src/lib.rs",
+            r#"
+#[account_type]
+pub struct RealAccount { pub balance: u128 }
+
+#[cfg(test)]
+#[account_type]
+pub struct TestOnlyStruct { pub fake: u64 }
+"#,
+        );
+
+        tmp.write(
+            "methods/guest/Cargo.toml",
+            "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\ntoken_core = { path = \"../../core\" }\n",
+        );
+        let program = tmp.write(
+            "methods/guest/src/bin/token.rs",
+            "#[lez_program]\npub mod token {\n  \
+             #[instruction]\n  \
+             pub fn transfer(acc: AccountWithMetadata) -> SpelResult { todo!() }\n}\n",
+        );
+
+        let dep_result = find_path_dep_dirs(&program);
+        let idl = generate_idl_from_file_with_deps(&program, &dep_result.dirs).unwrap();
+
+        let account_names: Vec<&str> = idl.accounts.iter().map(|a| a.name.as_str()).collect();
+        assert!(
+            account_names.contains(&"RealAccount"),
+            "RealAccount should be present; got {:?}",
+            account_names
+        );
+        assert!(
+            !account_names.contains(&"TestOnlyStruct"),
+            "Top-level #[cfg(test)] struct should be excluded; got {:?}",
             account_names
         );
     }

--- a/spel-cli/src/generate_idl.rs
+++ b/spel-cli/src/generate_idl.rs
@@ -306,26 +306,33 @@ fn find_member_manifest(
         }
     }
 
-    // Fallback: search all subdirectories for a Cargo.toml that contains source_path.
+    // Fallback: recursively search all subdirectories for a Cargo.toml that
+    // contains source_path.  This handles nested workspace members (e.g.
+    // `methods/guest`) when the explicit `members` list is absent/mismatched.
     warnings.push(format!(
         "⚠️  workspace at '{}' has no matching member for '{}'; searching all subdirectories",
         workspace_root.display(),
         source_path.display()
     ));
 
-    if let Ok(entries) = fs::read_dir(workspace_root) {
-        for entry in entries.flatten() {
-            if !entry.file_type().map_or(false, |ft| ft.is_dir()) {
-                continue;
-            }
-            let manifest = entry.path().join("Cargo.toml");
-            if manifest.exists() && source_dir.starts_with(&entry.path()) {
-                return Some(manifest);
+    fn search_recursive(dir: &Path, target_dir: &Path) -> Option<PathBuf> {
+        let manifest = dir.join("Cargo.toml");
+        if manifest.exists() && target_dir.starts_with(dir) {
+            return Some(manifest);
+        }
+        if let Ok(entries) = fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                if entry.file_type().map_or(false, |ft| ft.is_dir()) {
+                    if let Some(found) = search_recursive(&entry.path(), target_dir) {
+                        return Some(found);
+                    }
+                }
             }
         }
+        None
     }
 
-    None
+    search_recursive(workspace_root, source_dir)
 }
 
 /// Walk up from `start` to find the nearest `Cargo.toml`.
@@ -653,9 +660,9 @@ mod tests {
 
     // ── workspace detection ────────────────────────────────────────────────
 
-    /// When the program source lives in a directory with no Cargo.toml of its
-    /// own, `find_crate_manifest` walks up to the workspace root.  The member
-    /// search then locates the correct crate manifest.
+    /// Standard case: program source is inside a member crate that has its own
+    /// Cargo.toml.  `find_crate_manifest` finds the member manifest (not the
+    /// workspace root), so the normal path-dependency resolution applies.
     #[test]
     fn find_path_dep_dirs_resolves_workspace_member_manifest() {
         let tmp = TempDir::new("workspace-member");
@@ -674,8 +681,6 @@ mod tests {
             "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
              [dependencies]\ntoken_core = { path = \"../../core\" }\n",
         );
-        // Place the program file in a subdirectory WITHOUT its own Cargo.toml,
-        // so find_crate_manifest walks up past methods/guest/ to the workspace root.
         let program = tmp.write("methods/guest/src/bin/token.rs", "");
 
         let result = find_path_dep_dirs(&program);
@@ -705,7 +710,6 @@ mod tests {
             "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
              [dependencies]\ntoken_core = { path = \"../../crates/core\" }\n",
         );
-        // Source is in a subdirectory with no Cargo.toml → workspace root found.
         let program = tmp.write("methods/guest/src/bin/token.rs", "");
 
         let result = find_path_dep_dirs(&program);
@@ -745,6 +749,43 @@ mod tests {
         // The fallback search should find methods/guest/Cargo.toml
         assert_eq!(result.dirs.len(), 1);
         assert!(result.dirs[0].ends_with("core"), "expected core dir, got {:?}", result.dirs);
+    }
+
+    /// Test that exercises the workspace-root resolution path: the nearest
+    /// Cargo.toml is truly a virtual workspace root (no intermediate crate
+    /// manifest).  This validates `find_member_manifest` and recursive search.
+    #[test]
+    fn find_path_dep_dirs_virtual_workspace_root() {
+        let tmp = TempDir::new("virtual-workspace");
+
+        // Virtual workspace root — no [package], just [workspace].
+        tmp.write(
+            "Cargo.toml",
+            "[workspace]\nmembers = [\"libs/*\", \"programs/*\"]\n",
+        );
+
+        tmp.write("libs/common/Cargo.toml", "[package]\nname = \"common\"\nversion = \"0.1.0\"\nedition = \"2021\"\n");
+        tmp.write("libs/common/src/lib.rs", "");
+
+        // The program crate is NOT a workspace member — it lives in a dir with
+        // no Cargo.toml, so find_crate_manifest walks up to the workspace root.
+        // The workspace resolution then finds libs/common via recursive search.
+        tmp.write(
+            "programs/myprog/Cargo.toml",
+            "[package]\nname = \"myprog\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\ncommon = { path = \"../../libs/common\" }\n",
+        );
+        // Source file is in a deeply nested dir with no intermediate Cargo.toml.
+        let program = tmp.write("programs/myprog/src/deep/nested/token.rs", "");
+
+        let result = find_path_dep_dirs(&program);
+        assert!(result.warnings.is_empty(), "unexpected warnings: {:?}", result.warnings);
+        assert_eq!(result.dirs.len(), 1);
+        assert!(
+            result.dirs[0].ends_with("libs/common"),
+            "expected libs/common dir, got {:?}",
+            result.dirs
+        );
     }
 
     // ── transitive dependencies ────────────────────────────────────────────

--- a/spel-cli/src/generate_idl.rs
+++ b/spel-cli/src/generate_idl.rs
@@ -11,10 +11,31 @@
 //! - `.rs` file  → used directly (backwards-compatible).
 //! - directory   → `<dir>/methods/guest/src/bin/*.rs` is searched.
 
+use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use toml::Value;
+
+/// Result of path-dependency discovery, including warnings for any issues
+/// encountered during manifest parsing or directory resolution.
+pub struct PathDepResult {
+    /// Crate-root directories of all discovered path dependencies (including
+    /// transitive ones).
+    pub dirs: Vec<PathBuf>,
+    /// Non-fatal warnings emitted during discovery (e.g. TOML parse failures,
+    /// missing dep directories, skipped cfg-gated modules).
+    pub warnings: Vec<String>,
+}
+
+impl PathDepResult {
+    pub fn new() -> Self {
+        Self {
+            dirs: Vec::new(),
+            warnings: Vec::new(),
+        }
+    }
+}
 
 /// Resolve the list of SPEL program source files for IDL generation.
 ///
@@ -76,38 +97,255 @@ pub fn discover_sources(arg: Option<&str>) -> Result<Vec<PathBuf>, String> {
 /// crates are not part of the program's on-chain interface and must not appear
 /// in the generated IDL.  Registry (`version = "..."`) and git dependencies
 /// are also excluded so that only project-local crates are scanned.
-pub fn find_path_dep_dirs(source_path: &Path) -> Vec<PathBuf> {
-    (|| -> Option<Vec<PathBuf>> {
-        let manifest = find_crate_manifest(source_path)?;
-        let content = fs::read_to_string(&manifest).ok()?;
-        let value: Value = toml::from_str(&content).ok()?;
-        let manifest_dir = manifest.parent()?;
+///
+/// **Transitive path-dependencies** are resolved: if a discovered dependency
+/// itself declares path-based dependencies, those are included as well (with
+/// cycle detection).
+///
+/// In workspace projects the function detects when the nearest `Cargo.toml` is
+/// a workspace root manifest and searches for the actual crate manifest
+/// containing `[dependencies]`.
+pub fn find_path_dep_dirs(source_path: &Path) -> PathDepResult {
+    let mut result = PathDepResult::new();
+    let manifest = match find_crate_manifest(source_path, &mut result.warnings) {
+        Some(m) => m,
+        None => return result,
+    };
 
-        let mut dirs = Vec::new();
-        if let Some(table) = value.get("dependencies").and_then(|v| v.as_table()) {
-            for (_name, dep) in table {
-                if let Some(rel) = dep.get("path").and_then(|v| v.as_str()) {
-                    let dep_dir = manifest_dir.join(rel);
-                    if dep_dir.is_dir() {
-                        dirs.push(dep_dir);
-                    }
+    let content = match fs::read_to_string(&manifest) {
+        Ok(c) => c,
+        Err(e) => {
+            result.warnings.push(format!(
+                "⚠️  could not read manifest '{}': {}",
+                manifest.display(),
+                e
+            ));
+            return result;
+        }
+    };
+    let value: Value = match toml::from_str(&content) {
+        Ok(v) => v,
+        Err(e) => {
+            result.warnings.push(format!(
+                "⚠️  failed to parse manifest '{}': {}",
+                manifest.display(),
+                e
+            ));
+            return result;
+        }
+    };
+
+    let manifest_dir = match manifest.parent() {
+        Some(d) => d,
+        None => return result,
+    };
+
+    // Check if this is a workspace root — if so, it has no [dependencies] of its
+    // own.  We need to find the actual crate manifest for the program binary.
+    let is_workspace = value.get("workspace").is_some()
+        && value.get("package").is_none();
+
+    if is_workspace {
+        // Workspace root: search member directories for the crate that contains
+        // the source file.
+        if let Some(member_manifest) = find_member_manifest(
+            manifest_dir,
+            &value,
+            source_path,
+            &mut result.warnings,
+        ) {
+            resolve_path_deps_recursive(
+                &member_manifest,
+                &mut result.dirs,
+                &mut HashSet::new(),
+                &mut result.warnings,
+            );
+        }
+    } else {
+        // Regular crate manifest — extract path deps directly.
+        resolve_path_deps_recursive(
+            &manifest,
+            &mut result.dirs,
+            &mut HashSet::new(),
+            &mut result.warnings,
+        );
+    }
+
+    result
+}
+
+/// Recursively extract path-based dependencies from a manifest, following
+/// transitive path deps.  `visited` tracks canonicalised directories to avoid
+/// infinite loops.
+fn resolve_path_deps_recursive(
+    manifest: &Path,
+    dirs: &mut Vec<PathBuf>,
+    visited: &mut HashSet<PathBuf>,
+    warnings: &mut Vec<String>,
+) {
+    let manifest_dir = match manifest.parent() {
+        Some(d) => d.to_path_buf(),
+        None => return,
+    };
+
+    // Deduplicate by canonical path.
+    let canonical = match &manifest_dir.canonicalize() {
+        Ok(c) => c.clone(),
+        Err(_) => manifest_dir.clone(),
+    };
+    if !visited.insert(canonical) {
+        return; // already processed — cycle or duplicate
+    }
+
+    let content = match fs::read_to_string(manifest) {
+        Ok(c) => c,
+        Err(e) => {
+            warnings.push(format!(
+                "⚠️  could not read manifest '{}': {}",
+                manifest.display(),
+                e
+            ));
+            return;
+        }
+    };
+    let value: Value = match toml::from_str(&content) {
+        Ok(v) => v,
+        Err(e) => {
+            warnings.push(format!(
+                "⚠️  failed to parse manifest '{}': {}",
+                manifest.display(),
+                e
+            ));
+            return;
+        }
+    };
+
+    // Skip workspace roots — they have no [dependencies].
+    if value.get("workspace").is_some() && value.get("package").is_none() {
+        return;
+    }
+
+    if let Some(table) = value.get("dependencies").and_then(|v| v.as_table()) {
+        for (name, dep) in table {
+            if let Some(rel) = dep.get("path").and_then(|v| v.as_str()) {
+                let dep_dir = manifest_dir.join(rel);
+                if !dep_dir.is_dir() {
+                    warnings.push(format!(
+                        "⚠️  path dependency '{}' points to non-existent directory: {}",
+                        name,
+                        dep_dir.display()
+                    ));
+                    continue;
+                }
+                dirs.push(dep_dir.clone());
+
+                // Recurse into the dependency's own Cargo.toml for transitive deps.
+                let dep_manifest = dep_dir.join("Cargo.toml");
+                if dep_manifest.exists() {
+                    resolve_path_deps_recursive(
+                        &dep_manifest,
+                        dirs,
+                        visited,
+                        warnings,
+                    );
                 }
             }
         }
-        Some(dirs)
-    })()
-    .unwrap_or_default()
+    }
+}
+
+/// Given a workspace root directory, try to locate the member crate manifest
+/// that contains `source_path`.
+fn find_member_manifest(
+    workspace_root: &Path,
+    workspace_value: &Value,
+    source_path: &Path,
+    warnings: &mut Vec<String>,
+) -> Option<PathBuf> {
+    // Try to get the explicit member list from [workspace.members].
+    let members: Vec<String> = workspace_value
+        .get("workspace")
+        .and_then(|w| w.get("members"))
+        .and_then(|m| m.as_array())
+        .map(|arr| arr.iter().filter_map(|v| v.as_str()).map(|s| s.to_string()).collect())
+        .unwrap_or_default();
+
+    // Expand glob patterns (e.g. "crates/*") into concrete directories.
+    let concrete_members: Vec<String> = if members.iter().any(|m| m.contains('*')) {
+        let mut expanded = Vec::new();
+        for pattern in &members {
+            if pattern.contains('*') {
+                // Simple glob expansion: replace * with readdir.
+                let prefix = pattern.split_once('*').map(|(p, _)| p).unwrap_or("");
+                let dir = workspace_root.join(prefix);
+                if let Ok(entries) = fs::read_dir(&dir) {
+                    for entry in entries.flatten() {
+                        if entry.file_type().map_or(true, |ft| ft.is_dir()) {
+                            expanded.push(format!("{}/{}", prefix, entry.file_name().to_string_lossy()));
+                        }
+                    }
+                }
+            } else {
+                expanded.push(pattern.clone());
+            }
+        }
+        expanded
+    } else {
+        members.clone()
+    };
+
+    // Find the member whose directory contains source_path.
+    let source_dir = source_path.parent().unwrap_or(source_path);
+    for member in &concrete_members {
+        let member_dir = workspace_root.join(member.as_str());
+        if member_dir.is_dir() && source_dir.starts_with(&member_dir) {
+            let manifest = member_dir.join("Cargo.toml");
+            if manifest.exists() {
+                return Some(manifest);
+            }
+        }
+    }
+
+    // Fallback: search all subdirectories for a Cargo.toml that contains source_path.
+    warnings.push(format!(
+        "⚠️  workspace at '{}' has no matching member for '{}'; searching all subdirectories",
+        workspace_root.display(),
+        source_path.display()
+    ));
+
+    if let Ok(entries) = fs::read_dir(workspace_root) {
+        for entry in entries.flatten() {
+            if !entry.file_type().map_or(false, |ft| ft.is_dir()) {
+                continue;
+            }
+            let manifest = entry.path().join("Cargo.toml");
+            if manifest.exists() && source_dir.starts_with(&entry.path()) {
+                return Some(manifest);
+            }
+        }
+    }
+
+    None
 }
 
 /// Walk up from `start` to find the nearest `Cargo.toml`.
-fn find_crate_manifest(start: &Path) -> Option<PathBuf> {
+fn find_crate_manifest(start: &Path, warnings: &mut Vec<String>) -> Option<PathBuf> {
     let mut dir: &Path = if start.is_file() { start.parent()? } else { start };
     loop {
         let candidate = dir.join("Cargo.toml");
         if candidate.exists() {
             return Some(candidate);
         }
-        dir = dir.parent()?;
+        dir = match dir.parent() {
+            Some(p) => p,
+            None => {
+                warnings.push(format!(
+                    "⚠️  no Cargo.toml found walking up from '{}'",
+                    start.display()
+                ));
+                return None;
+            }
+        };
     }
 }
 
@@ -353,9 +591,10 @@ mod tests {
         );
         let program = tmp.write("methods/guest/src/bin/token.rs", "");
 
-        let dirs = find_path_dep_dirs(&program);
-        assert_eq!(dirs.len(), 1);
-        assert!(dirs[0].ends_with("core"), "expected core dir, got {:?}", dirs[0]);
+        let result = find_path_dep_dirs(&program);
+        assert!(result.warnings.is_empty(), "unexpected warnings: {:?}", result.warnings);
+        assert_eq!(result.dirs.len(), 1);
+        assert!(result.dirs[0].ends_with("core"), "expected core dir, got {:?}", result.dirs[0]);
     }
 
     #[test]
@@ -375,10 +614,11 @@ mod tests {
         );
         let program = tmp.write("methods/guest/src/bin/token.rs", "");
 
-        let dirs = find_path_dep_dirs(&program);
+        let result = find_path_dep_dirs(&program);
+        assert!(result.warnings.is_empty(), "unexpected warnings: {:?}", result.warnings);
         // Only the path dep (core) should be returned, not serde or nssa_core
-        assert_eq!(dirs.len(), 1);
-        assert!(dirs[0].ends_with("core"));
+        assert_eq!(result.dirs.len(), 1);
+        assert!(result.dirs[0].ends_with("core"));
     }
 
     #[test]
@@ -404,10 +644,170 @@ mod tests {
         );
         let program = tmp.write("methods/guest/src/bin/token.rs", "");
 
-        let dirs = find_path_dep_dirs(&program);
+        let result = find_path_dep_dirs(&program);
+        assert!(result.warnings.is_empty(), "unexpected warnings: {:?}", result.warnings);
         // Only runtime path dep (core) should be returned
-        assert_eq!(dirs.len(), 1, "expected only core, got: {dirs:?}");
-        assert!(dirs[0].ends_with("core"));
+        assert_eq!(result.dirs.len(), 1, "expected only core, got: {:?}", result.dirs);
+        assert!(result.dirs[0].ends_with("core"));
+    }
+
+    // ── workspace detection ────────────────────────────────────────────────
+
+    #[test]
+    fn find_path_dep_dirs_resolves_workspace_member_manifest() {
+        let tmp = TempDir::new("workspace-member");
+
+        // Workspace root manifest (no [package], no [dependencies])
+        tmp.write(
+            "Cargo.toml",
+            "[workspace]\nmembers = [\"core\", \"methods/guest\"]\n",
+        );
+
+        tmp.write("core/Cargo.toml", "[package]\nname = \"token_core\"\nversion = \"0.1.0\"\nedition = \"2021\"\n");
+        tmp.write("core/src/lib.rs", "");
+
+        tmp.write(
+            "methods/guest/Cargo.toml",
+            "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\ntoken_core = { path = \"../../core\" }\n",
+        );
+        let program = tmp.write("methods/guest/src/bin/token.rs", "");
+
+        let result = find_path_dep_dirs(&program);
+        assert!(result.warnings.is_empty(), "unexpected warnings: {:?}", result.warnings);
+        assert_eq!(result.dirs.len(), 1);
+        assert!(result.dirs[0].ends_with("core"), "expected core dir, got {:?}", result.dirs);
+    }
+
+    #[test]
+    fn find_path_dep_dirs_resolves_workspace_with_glob_members() {
+        let tmp = TempDir::new("workspace-glob");
+
+        // Workspace root with glob pattern in members.
+        // The program source lives under a member directory that has its own
+        // Cargo.toml, so find_crate_manifest finds the member manifest first
+        // (not the workspace root).  This is the normal and expected case.
+        tmp.write(
+            "Cargo.toml",
+            "[workspace]\nmembers = [\"crates/*\", \"methods/guest\"]\n",
+        );
+
+        tmp.write("crates/core/Cargo.toml", "[package]\nname = \"token_core\"\nversion = \"0.1.0\"\nedition = \"2021\"\n");
+        tmp.write("crates/core/src/lib.rs", "");
+
+        // Path is relative to methods/guest/, so needs ../.. to reach workspace root.
+        tmp.write(
+            "methods/guest/Cargo.toml",
+            "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\ntoken_core = { path = \"../../crates/core\" }\n",
+        );
+        let program = tmp.write("methods/guest/src/bin/token.rs", "");
+
+        let result = find_path_dep_dirs(&program);
+        assert!(result.warnings.is_empty(), "unexpected warnings: {:?}", result.warnings);
+        // Member manifest is found first; workspace detection is not triggered.
+        assert_eq!(result.dirs.len(), 1);
+        assert!(result.dirs[0].ends_with("crates/core"), "expected crates/core dir, got {:?}", result.dirs);
+    }
+
+    /// When the program source has no intermediate Cargo.toml (only a workspace
+    /// root exists above it), the workspace member search kicks in.
+    #[test]
+    fn find_path_dep_dirs_fallback_search_in_workspace() {
+        let tmp = TempDir::new("workspace-fallback");
+
+        // Workspace root — no [package] section, so find_crate_manifest returns this.
+        tmp.write(
+            "Cargo.toml",
+            "[workspace]\nmembers = [\"core\", \"methods/guest\"]\n",
+        );
+
+        tmp.write("core/Cargo.toml", "[package]\nname = \"token_core\"\nversion = \"0.1.0\"\nedition = \"2021\"\n");
+        tmp.write("core/src/lib.rs", "");
+
+        // The guest crate has its own Cargo.toml, but the program source is
+        // placed in a subdirectory that doesn't have one, so we walk up to
+        // the workspace root.  In reality this is unusual; the test verifies
+        // the fallback search still works.
+        tmp.write(
+            "methods/guest/Cargo.toml",
+            "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\ntoken_core = { path = \"../../core\" }\n",
+        );
+        // Place the program file directly under methods/guest/ (no intermediate Cargo.toml)
+        let program = tmp.write("methods/guest/token.rs", "");
+
+        let result = find_path_dep_dirs(&program);
+        // The fallback search should find methods/guest/Cargo.toml
+        assert_eq!(result.dirs.len(), 1);
+        assert!(result.dirs[0].ends_with("core"), "expected core dir, got {:?}", result.dirs);
+    }
+
+    // ── transitive dependencies ────────────────────────────────────────────
+
+    #[test]
+    fn find_path_dep_dirs_resolves_transitive_deps() {
+        let tmp = TempDir::new("transitive-deps");
+
+        // shared_types is a dependency of core, which is a dependency of guest
+        tmp.write("shared_types/Cargo.toml", "[package]\nname = \"shared_types\"\nversion = \"0.1.0\"\nedition = \"2021\"\n");
+        tmp.write("shared_types/src/lib.rs", "");
+
+        tmp.write(
+            "core/Cargo.toml",
+            "[package]\nname = \"token_core\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\nshared_types = { path = \"../shared_types\" }\n",
+        );
+        tmp.write("core/src/lib.rs", "");
+
+        tmp.write(
+            "methods/guest/Cargo.toml",
+            "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\ntoken_core = { path = \"../../core\" }\n",
+        );
+        let program = tmp.write("methods/guest/src/bin/token.rs", "");
+
+        let result = find_path_dep_dirs(&program);
+        assert!(result.warnings.is_empty(), "unexpected warnings: {:?}", result.warnings);
+        // Should include both direct dep (core) and transitive dep (shared_types)
+        assert_eq!(result.dirs.len(), 2, "expected 2 dirs, got {:?}", result.dirs);
+        let names: Vec<&str> = result.dirs.iter().map(|d| d.file_name().unwrap().to_str().unwrap()).collect();
+        assert!(names.contains(&"core"));
+        assert!(names.contains(&"shared_types"));
+    }
+
+    // ── warnings on errors ─────────────────────────────────────────────────
+
+    #[test]
+    fn find_path_dep_dirs_warns_on_missing_dep_directory() {
+        let tmp = TempDir::new("missing-dep-dir");
+
+        tmp.write(
+            "methods/guest/Cargo.toml",
+            "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\ntoken_core = { path = \"../../nonexistent\" }\n",
+        );
+        let program = tmp.write("methods/guest/src/bin/token.rs", "");
+
+        let result = find_path_dep_dirs(&program);
+        assert!(result.dirs.is_empty());
+        assert!(!result.warnings.is_empty(), "expected warning for missing dep dir");
+        assert!(result.warnings[0].contains("non-existent"), "unexpected warning: {}", result.warnings[0]);
+    }
+
+    #[test]
+    fn find_path_dep_dirs_warns_on_invalid_toml() {
+        let tmp = TempDir::new("invalid-toml");
+
+        tmp.write(
+            "methods/guest/Cargo.toml",
+            "this is not valid [[ toml !!!\n",
+        );
+        let program = tmp.write("methods/guest/src/bin/token.rs", "");
+
+        let result = find_path_dep_dirs(&program);
+        assert!(result.dirs.is_empty());
+        assert!(!result.warnings.is_empty(), "expected warning for invalid TOML");
     }
 
     // ── account types from path-dep crates ────────────────────────────────
@@ -512,10 +912,11 @@ pub mod token {
 "#,
         );
 
-        let dep_dirs = find_path_dep_dirs(&program);
-        assert_eq!(dep_dirs.len(), 1);
+        let dep_result = find_path_dep_dirs(&program);
+        assert!(dep_result.warnings.is_empty(), "unexpected warnings: {:?}", dep_result.warnings);
+        assert_eq!(dep_result.dirs.len(), 1);
 
-        let idl = generate_idl_from_file_with_deps(&program, &dep_dirs).unwrap();
+        let idl = generate_idl_from_file_with_deps(&program, &dep_result.dirs).unwrap();
 
         assert_eq!(idl.name, "token");
         assert_eq!(idl.instructions.len(), 4);
@@ -592,8 +993,9 @@ pub mod token {
 "#,
         );
 
-        let dep_dirs = find_path_dep_dirs(&program);
-        let idl = generate_idl_from_file_with_deps(&program, &dep_dirs).unwrap();
+        let dep_result = find_path_dep_dirs(&program);
+        assert!(dep_result.warnings.is_empty(), "unexpected warnings: {:?}", dep_result.warnings);
+        let idl = generate_idl_from_file_with_deps(&program, &dep_result.dirs).unwrap();
 
         let account_names: Vec<&str> = idl.accounts.iter().map(|a| a.name.as_str()).collect();
         assert!(
@@ -642,8 +1044,9 @@ pub mod token {
              pub fn deposit(acc: AccountWithMetadata) -> SpelResult { todo!() }\n}\n",
         );
 
-        let dep_dirs = find_path_dep_dirs(&program);
-        let idl = generate_idl_from_file_with_deps(&program, &dep_dirs).unwrap();
+        let dep_result = find_path_dep_dirs(&program);
+        assert!(dep_result.warnings.is_empty(), "unexpected warnings: {:?}", dep_result.warnings);
+        let idl = generate_idl_from_file_with_deps(&program, &dep_result.dirs).unwrap();
 
         let account_names: Vec<&str> = idl.accounts.iter().map(|a| a.name.as_str()).collect();
         assert!(
@@ -687,8 +1090,9 @@ pub mod token {
              pub fn stake(acc: AccountWithMetadata) -> SpelResult { todo!() }\n}\n",
         );
 
-        let dep_dirs = find_path_dep_dirs(&program);
-        let idl = generate_idl_from_file_with_deps(&program, &dep_dirs).unwrap();
+        let dep_result = find_path_dep_dirs(&program);
+        assert!(dep_result.warnings.is_empty(), "unexpected warnings: {:?}", dep_result.warnings);
+        let idl = generate_idl_from_file_with_deps(&program, &dep_result.dirs).unwrap();
 
         let account_names: Vec<&str> = idl.accounts.iter().map(|a| a.name.as_str()).collect();
         assert!(
@@ -733,6 +1137,186 @@ pub mod token {
             idl.accounts.is_empty(),
             "expected no accounts without dep scanning, got {:?}",
             idl.accounts.iter().map(|a| &a.name).collect::<Vec<_>>()
+        );
+    }
+
+    // ── #[cfg(test)] modules are skipped ────────────────────────────────────
+
+    /// Account types inside a #[cfg(test)] module in a dependency crate should
+    /// NOT appear in the generated IDL — they are test-only and won't be compiled
+    /// into the on-chain program.
+    #[test]
+    fn cfg_test_module_excluded_from_idl() {
+        use spel_framework_core::idl_gen::generate_idl_from_file_with_deps;
+
+        let tmp = TempDir::new("cfg-test-exclude");
+
+        tmp.write(
+            "core/Cargo.toml",
+            "[package]\nname = \"token_core\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        );
+        // lib.rs has a regular account type and a test-only one.
+        tmp.write(
+            "core/src/lib.rs",
+            r#"
+#[account_type]
+pub struct RealAccount { pub balance: u128 }
+
+#[cfg(test)]
+pub mod test_helpers {
+    #[account_type]
+    pub struct TestOnlyAccount { pub fake_balance: u64 }
+}
+"#,
+        );
+
+        tmp.write(
+            "methods/guest/Cargo.toml",
+            "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\ntoken_core = { path = \"../../core\" }\n",
+        );
+        let program = tmp.write(
+            "methods/guest/src/bin/token.rs",
+            "#[lez_program]\npub mod token {\n  \
+             #[instruction]\n  \
+             pub fn transfer(acc: AccountWithMetadata) -> SpelResult { todo!() }\n}\n",
+        );
+
+        let dep_result = find_path_dep_dirs(&program);
+        assert!(dep_result.warnings.is_empty(), "unexpected warnings: {:?}", dep_result.warnings);
+        let idl = generate_idl_from_file_with_deps(&program, &dep_result.dirs).unwrap();
+
+        let account_names: Vec<&str> = idl.accounts.iter().map(|a| a.name.as_str()).collect();
+        assert!(
+            account_names.contains(&"RealAccount"),
+            "RealAccount should be present; got {:?}",
+            account_names
+        );
+        assert!(
+            !account_names.contains(&"TestOnlyAccount"),
+            "TestOnlyAccount in #[cfg(test)] module should be excluded; got {:?}",
+            account_names
+        );
+    }
+
+    /// Account types behind #[cfg(feature = "...")] are also excluded since we
+    /// don't know which features are enabled for the on-chain build.
+    #[test]
+    fn cfg_feature_module_excluded_from_idl() {
+        use spel_framework_core::idl_gen::generate_idl_from_file_with_deps;
+
+        let tmp = TempDir::new("cfg-feature-exclude");
+
+        tmp.write(
+            "core/Cargo.toml",
+            "[package]\nname = \"token_core\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        );
+        tmp.write(
+            "core/src/lib.rs",
+            r#"
+#[account_type]
+pub struct RealAccount { pub balance: u128 }
+
+#[cfg(feature = "experimental")]
+pub mod experimental {
+    #[account_type]
+    pub struct ExperimentalAccount { pub secret: String }
+}
+"#,
+        );
+
+        tmp.write(
+            "methods/guest/Cargo.toml",
+            "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\ntoken_core = { path = \"../../core\" }\n",
+        );
+        let program = tmp.write(
+            "methods/guest/src/bin/token.rs",
+            "#[lez_program]\npub mod token {\n  \
+             #[instruction]\n  \
+             pub fn transfer(acc: AccountWithMetadata) -> SpelResult { todo!() }\n}\n",
+        );
+
+        let dep_result = find_path_dep_dirs(&program);
+        let idl = generate_idl_from_file_with_deps(&program, &dep_result.dirs).unwrap();
+
+        let account_names: Vec<&str> = idl.accounts.iter().map(|a| a.name.as_str()).collect();
+        assert!(
+            account_names.contains(&"RealAccount"),
+            "RealAccount should be present; got {:?}",
+            account_names
+        );
+        assert!(
+            !account_names.contains(&"ExperimentalAccount"),
+            "ExperimentalAccount in #[cfg(feature)] module should be excluded; got {:?}",
+            account_names
+        );
+    }
+
+    // ── transitive deps with account types ──────────────────────────────────
+
+    /// Account types from transitive path dependencies (A → B → C) are all
+    /// collected and appear in the generated IDL.
+    #[test]
+    fn account_types_from_transitive_deps_appear_in_idl() {
+        use spel_framework_core::idl_gen::generate_idl_from_file_with_deps;
+
+        let tmp = TempDir::new("transitive-account-types");
+
+        // shared_types is a transitive dependency (guest → core → shared_types)
+        tmp.write(
+            "shared_types/Cargo.toml",
+            "[package]\nname = \"shared_types\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        );
+        tmp.write(
+            "shared_types/src/lib.rs",
+            r#"
+#[account_type]
+pub struct SharedAccount { pub data: String }
+"#,
+        );
+
+        tmp.write(
+            "core/Cargo.toml",
+            "[package]\nname = \"token_core\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\nshared_types = { path = \"../shared_types\" }\n",
+        );
+        tmp.write(
+            "core/src/lib.rs",
+            r#"
+#[account_type]
+pub struct CoreAccount { pub balance: u128 }
+"#,
+        );
+
+        tmp.write(
+            "methods/guest/Cargo.toml",
+            "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\ntoken_core = { path = \"../../core\" }\n",
+        );
+        let program = tmp.write(
+            "methods/guest/src/bin/token.rs",
+            "#[lez_program]\npub mod token {\n  \
+             #[instruction]\n  \
+             pub fn transfer(acc: AccountWithMetadata) -> SpelResult { todo!() }\n}\n",
+        );
+
+        let dep_result = find_path_dep_dirs(&program);
+        // Should include both direct and transitive deps
+        assert_eq!(dep_result.dirs.len(), 2, "expected 2 dep dirs, got {:?}", dep_result.dirs);
+
+        let idl = generate_idl_from_file_with_deps(&program, &dep_result.dirs).unwrap();
+
+        let account_names: Vec<&str> = idl.accounts.iter().map(|a| a.name.as_str()).collect();
+        assert!(
+            account_names.contains(&"CoreAccount"),
+            "CoreAccount from direct dep should be present; got {:?}",
+            account_names
+        );
+        assert!(
+            account_names.contains(&"SharedAccount"),
+            "SharedAccount from transitive dep should be present; got {:?}",
+            account_names
         );
     }
 }

--- a/spel-cli/src/lib.rs
+++ b/spel-cli/src/lib.rs
@@ -260,8 +260,11 @@ pub async fn run() {
                 });
 
                 if sources.len() == 1 {
-                    let dep_dirs = find_path_dep_dirs(&sources[0]);
-                    match generate_idl_from_file_with_deps(&sources[0], &dep_dirs) {
+                    let dep_result = find_path_dep_dirs(&sources[0]);
+                    for w in &dep_result.warnings {
+                        eprintln!("{}", w);
+                    }
+                    match generate_idl_from_file_with_deps(&sources[0], &dep_result.dirs) {
                         Ok(idl) => println!("{}", serde_json::to_string_pretty(&idl).unwrap()),
                         Err(e) => {
                             eprintln!("Error: {}", e);
@@ -272,8 +275,11 @@ pub async fn run() {
                     // Multiple programs: write <name>-idl.json for each
                     let mut had_error = false;
                     for source in &sources {
-                        let dep_dirs = find_path_dep_dirs(source);
-                        match generate_idl_from_file_with_deps(source, &dep_dirs) {
+                        let dep_result = find_path_dep_dirs(source);
+                        for w in &dep_result.warnings {
+                            eprintln!("{}", w);
+                        }
+                        match generate_idl_from_file_with_deps(source, &dep_result.dirs) {
                             Ok(idl) => {
                                 let out_name = format!("{}-idl.json", idl.name);
                                 match fs::write(&out_name, serde_json::to_string_pretty(&idl).unwrap()) {

--- a/spel-framework-core/Cargo.toml
+++ b/spel-framework-core/Cargo.toml
@@ -6,7 +6,7 @@ description = "Core types for the SPEL program framework"
 
 [features]
 default = []
-idl-gen = ["dep:syn"]
+idl-gen = ["dep:syn", "dep:proc-macro2"]
 host = ["dep:nssa"]
 
 [dependencies]
@@ -20,3 +20,4 @@ sha2 = "0.10"
 nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3", optional = true }
 
 syn = { version = "2.0", features = ["full", "extra-traits"], optional = true }
+proc-macro2 = { version = "1.0", optional = true }

--- a/spel-framework-core/src/idl_gen.rs
+++ b/spel-framework-core/src/idl_gen.rs
@@ -427,7 +427,7 @@ fn cfg_meta_excludes(meta: &syn::Meta) -> bool {
             // Scan the inner tokens of #[cfg(...)] for test/feature identifiers.
             // This handles all cases: bare `test`, `feature = "x"`, and
             // `any(test, feature = "x")` — because we recurse into nested groups.
-            cfg_tokens_have_exclusion(&list.tokens)
+            cfg_tokens_have_exclusion(&list.tokens, false)
         }
         _ => false,
     }
@@ -435,8 +435,15 @@ fn cfg_meta_excludes(meta: &syn::Meta) -> bool {
 
 /// Recursively scan a token stream for `test` or `feature` identifiers.
 /// Skips tokens inside `not(...)` groups so `#[cfg(not(test))]` is not excluded.
-fn cfg_tokens_have_exclusion(tokens: &proc_macro2::TokenStream) -> bool {
+///
+/// When called from an `any(...)` context (in_any = true), returns true only if
+/// ALL alternatives contain exclusion triggers.  This prevents false exclusions
+/// like `#[cfg(any(not(test), feature = "x"))]` which should be included in
+/// default builds because the `not(test)` alternative satisfies it.
+fn cfg_tokens_have_exclusion(tokens: &proc_macro2::TokenStream, in_any: bool) -> bool {
     let mut iter = tokens.clone().into_iter().peekable();
+    let mut alternatives: Vec<bool> = Vec::new(); // for any() context
+
     while let Some(token) = iter.next() {
         match token {
             proc_macro2::TokenTree::Ident(ident) if ident == "not" => {
@@ -445,21 +452,74 @@ fn cfg_tokens_have_exclusion(tokens: &proc_macro2::TokenStream) -> bool {
                     iter.next(); // consume the group
                 }
             }
+            proc_macro2::TokenTree::Ident(ident) if ident == "any" => {
+                // Handle any(...) — check if ALL alternatives would exclude.
+                let next = iter.peek().cloned();
+                if let Some(proc_macro2::TokenTree::Group(group)) = next {
+                    iter.next(); // consume the group
+                    let mut all_exclude = true;
+                    let mut alt_count = 0;
+                    // Split alternatives by comma at this level.
+                    for alt_token in group.stream().clone() {
+                        match alt_token {
+                            proc_macro2::TokenTree::Group(alt_group) => {
+                                // Nested expression like any(not(test), feature = "x")
+                                alt_count += 1;
+                                if !cfg_tokens_have_exclusion(&alt_group.stream(), true) {
+                                    all_exclude = false;
+                                }
+                            }
+                            proc_macro2::TokenTree::Ident(alt_ident) => {
+                                alt_count += 1;
+                                if alt_ident != "test" && alt_ident != "feature" {
+                                    all_exclude = false;
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    // If no alternatives found (parse issue), be conservative.
+                    if alt_count == 0 {
+                        return true;
+                    }
+                    if in_any {
+                        alternatives.push(all_exclude);
+                    } else if all_exclude {
+                        return true; // top-level: all alternatives exclude → exclude
+                    }
+                }
+            }
             proc_macro2::TokenTree::Ident(ident) => {
                 if ident == "test" || ident == "feature" {
-                    return true;
+                    if in_any {
+                        alternatives.push(true);
+                    } else {
+                        return true;
+                    }
                 }
             }
             proc_macro2::TokenTree::Group(group) => {
                 // Recurse into groups (parentheses, braces, brackets).
-                if cfg_tokens_have_exclusion(&group.stream()) {
+                let result = cfg_tokens_have_exclusion(&group.stream(), in_any);
+                if in_any {
+                    alternatives.push(result);
+                } else if result {
                     return true;
                 }
             }
             _ => {}
         }
     }
-    false
+
+    // In any() context: exclude only if ALL alternatives exclude.
+    if in_any && !alternatives.is_empty() {
+        alternatives.iter().all(|&b| b)
+    } else if in_any {
+        // No exclusion triggers found in any alternative → don't exclude.
+        false
+    } else {
+        false
+    }
 }
 
 // ─── Internal parsing types ───────────────────────────────────────────────

--- a/spel-framework-core/src/idl_gen.rs
+++ b/spel-framework-core/src/idl_gen.rs
@@ -332,6 +332,14 @@ fn collect_items_recursive(
     for item in items {
         match item {
             syn::Item::Mod(m) => {
+                // Skip modules gated behind #[cfg(...)] that would not be
+                // compiled in a default build (e.g. #[cfg(test)],
+                // #[cfg(feature = "...")]).  This prevents test-only or
+                // feature-gated types from leaking into the on-chain IDL.
+                if is_cfg_excluded(&m.attrs) {
+                    continue;
+                }
+
                 if let Some((_, inner)) = &m.content {
                     // Inline module — recurse into its body with an updated base_dir
                     // so that any file-backed `mod` declarations inside it resolve
@@ -348,6 +356,55 @@ fn collect_items_recursive(
             _ => out.push(item.clone()),
         }
     }
+}
+
+/// Return `true` if the item's attributes contain a `#[cfg(...)]` that would
+/// exclude it from a default (non-test, no-extra-features) build.
+///
+/// This is a conservative heuristic: we skip the module if *any* `#[cfg]`
+/// attribute references `test`, or a named feature.  We do *not* attempt
+/// full cfg expression evaluation (e.g. `cfg(any(...))`, `cfg(not(...))`)
+/// because that requires target-triple knowledge and feature resolution.
+fn is_cfg_excluded(attrs: &[syn::Attribute]) -> bool {
+    for attr in attrs {
+        if !attr.path().is_ident("cfg") {
+            continue;
+        }
+
+        // Parse cfg contents using parse_nested_meta which handles both
+        // `#[cfg(test)]` (bare path) and `#[cfg(feature = "...")]` (name-value).
+        let mut excluded = false;
+        let _ = attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("test") {
+                excluded = true;
+            } else if meta.path.is_ident("feature") {
+                // `#[cfg(feature = "...")]` — any feature gate means excluded
+                // since we don't know which features are enabled.
+                excluded = true;
+            }
+            // Ignore other cfg keys (target_os, windows, etc.) — they depend
+            // on the build target and we can't resolve them at IDL-gen time.
+            Ok(())
+        });
+        if excluded {
+            return true;
+        }
+
+        // Also check for simple `#[cfg_attr(test, ...)]` patterns.
+        if attr.path().is_ident("cfg_attr") {
+            let mut found_test = false;
+            let _ = attr.parse_nested_meta(|meta| {
+                if meta.path.is_ident("test") {
+                    found_test = true;
+                }
+                Ok(())
+            });
+            if found_test {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 // ─── Internal parsing types ───────────────────────────────────────────────

--- a/spel-framework-core/src/idl_gen.rs
+++ b/spel-framework-core/src/idl_gen.rs
@@ -387,12 +387,12 @@ fn collect_items_recursive(
 ///   if *any* alternative references `test` or `feature`.
 ///
 /// Does **not** handle:
-/// - `#[cfg(not(test))]` — negation is rare for test-gating; items gated by
-///   `not(test)` are included (conservative: better to over-include than
-///   drop production types).
 /// - `#[cfg(all(...))]` — compound expressions requiring all conditions.
 /// - Target-triple cfgs (`target_os`, `windows`, etc.) — unresolvable at
 ///   IDL-gen time without knowing the build target.
+///
+/// Note: `#[cfg(not(test))]` is handled correctly — the token scanner skips
+/// contents of `not(...)` groups, so production-only items are included.
 ///
 /// Note: `#[cfg_attr(test, ...)]` is **not** treated as exclusion because it
 /// only conditionally applies attributes — it does not remove the item from
@@ -434,9 +434,17 @@ fn cfg_meta_excludes(meta: &syn::Meta) -> bool {
 }
 
 /// Recursively scan a token stream for `test` or `feature` identifiers.
+/// Skips tokens inside `not(...)` groups so `#[cfg(not(test))]` is not excluded.
 fn cfg_tokens_have_exclusion(tokens: &proc_macro2::TokenStream) -> bool {
-    for token in tokens.clone() {
+    let mut iter = tokens.clone().into_iter().peekable();
+    while let Some(token) = iter.next() {
         match token {
+            proc_macro2::TokenTree::Ident(ident) if ident == "not" => {
+                // Skip the next group (parentheses) — `not(test)` should not exclude.
+                if let Some(proc_macro2::TokenTree::Group(_)) = iter.peek() {
+                    iter.next(); // consume the group
+                }
+            }
             proc_macro2::TokenTree::Ident(ident) => {
                 if ident == "test" || ident == "feature" {
                     return true;

--- a/spel-framework-core/src/idl_gen.rs
+++ b/spel-framework-core/src/idl_gen.rs
@@ -353,7 +353,26 @@ fn collect_items_recursive(
                     }
                 }
             }
-            _ => out.push(item.clone()),
+            // Non-module items (structs, enums, etc.) — also skip if cfg-gated.
+            other => {
+                let attrs: &[syn::Attribute] = match other {
+                    syn::Item::Struct(s) => &s.attrs,
+                    syn::Item::Enum(e) => &e.attrs,
+                    syn::Item::Fn(f) => &f.attrs,
+                    syn::Item::Trait(t) => &t.attrs,
+                    syn::Item::Impl(i) => &i.attrs,
+                    syn::Item::Type(t) => &t.attrs,
+                    syn::Item::Static(s) => &s.attrs,
+                    syn::Item::Const(c) => &c.attrs,
+                    syn::Item::ExternCrate(e) => &e.attrs,
+                    syn::Item::Use(u) => &u.attrs,
+                    _ => &[],
+                };
+                if is_cfg_excluded(attrs) {
+                    continue;
+                }
+                out.push(other.clone());
+            }
         }
     }
 }
@@ -361,37 +380,27 @@ fn collect_items_recursive(
 /// Return `true` if the item's attributes contain a `#[cfg(...)]` that would
 /// exclude it from a default (non-test, no-extra-features) build.
 ///
-/// This is a conservative heuristic: we skip the module if *any* `#[cfg]`
-/// attribute references `test`, or a named feature.  We do *not* attempt
-/// full cfg expression evaluation (e.g. `cfg(any(...))`, `cfg(not(...))`)
-/// because that requires target-triple knowledge and feature resolution.
+/// Handles:
+/// - `#[cfg(test)]` — always excluded (test-only).
+/// - `#[cfg(feature = "...")]` — excluded (unknown which features are enabled).
+/// - `#[cfg(any(test, ...))]` / `#[cfg(any(feature = "...", ...))]` — excluded
+///   if *any* alternative references `test` or `feature`.
+/// - `#[cfg_attr(test, ...)]` — excluded.
+///
+/// Does **not** handle:
+/// - `#[cfg(not(test))]` — negation is rare for test-gating and would require
+///   full expression evaluation.
+/// - Target-triple cfgs (`target_os`, `windows`, etc.) — unresolvable at
+///   IDL-gen time without knowing the build target.
 fn is_cfg_excluded(attrs: &[syn::Attribute]) -> bool {
     for attr in attrs {
-        if !attr.path().is_ident("cfg") {
-            continue;
-        }
-
-        // Parse cfg contents using parse_nested_meta which handles both
-        // `#[cfg(test)]` (bare path) and `#[cfg(feature = "...")]` (name-value).
-        let mut excluded = false;
-        let _ = attr.parse_nested_meta(|meta| {
-            if meta.path.is_ident("test") {
-                excluded = true;
-            } else if meta.path.is_ident("feature") {
-                // `#[cfg(feature = "...")]` — any feature gate means excluded
-                // since we don't know which features are enabled.
-                excluded = true;
+        if attr.path().is_ident("cfg") {
+            // Parse cfg contents recursively to handle `any(...)` wrappers.
+            if cfg_attr_excludes(attr) {
+                return true;
             }
-            // Ignore other cfg keys (target_os, windows, etc.) — they depend
-            // on the build target and we can't resolve them at IDL-gen time.
-            Ok(())
-        });
-        if excluded {
-            return true;
-        }
-
-        // Also check for simple `#[cfg_attr(test, ...)]` patterns.
-        if attr.path().is_ident("cfg_attr") {
+        } else if attr.path().is_ident("cfg_attr") {
+            // `#[cfg_attr(test, ...)]` — excluded.
             let mut found_test = false;
             let _ = attr.parse_nested_meta(|meta| {
                 if meta.path.is_ident("test") {
@@ -403,6 +412,20 @@ fn is_cfg_excluded(attrs: &[syn::Attribute]) -> bool {
                 return true;
             }
         }
+    }
+    false
+}
+
+/// Recursively check a `#[cfg(...)]` attribute for exclusion triggers.
+/// Handles bare paths (`test`, `feature = "..."`) and `any(...)` wrappers.
+fn cfg_attr_excludes(attr: &syn::Attribute) -> bool {
+    // Scan the debug representation of the meta for test/feature identifiers.
+    // This catches patterns like `#[cfg(any(test, feature = "x"))]` that
+    // parse_nested_meta alone cannot recurse into.  The Debug output from
+    // syn (with extra-traits) contains the token text we need.
+    let debug_text = format!("{:?}", attr.meta);
+    if debug_text.contains("test") || debug_text.contains("feature") {
+        return true;
     }
     false
 }

--- a/spel-framework-core/src/idl_gen.rs
+++ b/spel-framework-core/src/idl_gen.rs
@@ -385,47 +385,71 @@ fn collect_items_recursive(
 /// - `#[cfg(feature = "...")]` — excluded (unknown which features are enabled).
 /// - `#[cfg(any(test, ...))]` / `#[cfg(any(feature = "...", ...))]` — excluded
 ///   if *any* alternative references `test` or `feature`.
-/// - `#[cfg_attr(test, ...)]` — excluded.
 ///
 /// Does **not** handle:
-/// - `#[cfg(not(test))]` — negation is rare for test-gating and would require
-///   full expression evaluation.
+/// - `#[cfg(not(test))]` — negation is rare for test-gating; items gated by
+///   `not(test)` are included (conservative: better to over-include than
+///   drop production types).
+/// - `#[cfg(all(...))]` — compound expressions requiring all conditions.
 /// - Target-triple cfgs (`target_os`, `windows`, etc.) — unresolvable at
 ///   IDL-gen time without knowing the build target.
+///
+/// Note: `#[cfg_attr(test, ...)]` is **not** treated as exclusion because it
+/// only conditionally applies attributes — it does not remove the item from
+/// compilation (e.g. `cfg_attr(test, derive(Debug))` is common and valid).
 fn is_cfg_excluded(attrs: &[syn::Attribute]) -> bool {
     for attr in attrs {
-        if attr.path().is_ident("cfg") {
-            // Parse cfg contents recursively to handle `any(...)` wrappers.
-            if cfg_attr_excludes(attr) {
-                return true;
-            }
-        } else if attr.path().is_ident("cfg_attr") {
-            // `#[cfg_attr(test, ...)]` — excluded.
-            let mut found_test = false;
-            let _ = attr.parse_nested_meta(|meta| {
-                if meta.path.is_ident("test") {
-                    found_test = true;
-                }
-                Ok(())
-            });
-            if found_test {
-                return true;
-            }
+        if !attr.path().is_ident("cfg") {
+            continue;
+        }
+        // Structural parse of the cfg expression.
+        if cfg_meta_excludes(&attr.meta) {
+            return true;
         }
     }
     false
 }
 
-/// Recursively check a `#[cfg(...)]` attribute for exclusion triggers.
+/// Check a `cfg(...)` attribute for exclusion triggers by scanning its token stream.
 /// Handles bare paths (`test`, `feature = "..."`) and `any(...)` wrappers.
-fn cfg_attr_excludes(attr: &syn::Attribute) -> bool {
-    // Scan the debug representation of the meta for test/feature identifiers.
-    // This catches patterns like `#[cfg(any(test, feature = "x"))]` that
-    // parse_nested_meta alone cannot recurse into.  The Debug output from
-    // syn (with extra-traits) contains the token text we need.
-    let debug_text = format!("{:?}", attr.meta);
-    if debug_text.contains("test") || debug_text.contains("feature") {
-        return true;
+/// Uses exact identifier matching to avoid false positives (e.g. `target_feature`).
+fn cfg_meta_excludes(meta: &syn::Meta) -> bool {
+    match meta {
+        syn::Meta::Path(path) => {
+            // Bare path: `#[cfg(test)]` (unlikely at top level, but handle it)
+            path.is_ident("test") || path.is_ident("feature")
+        }
+        syn::Meta::NameValue(nv) => {
+            // Name-value: `#[cfg(feature = "...")]`
+            nv.path.is_ident("feature")
+        }
+        syn::Meta::List(list) if list.path.is_ident("cfg") => {
+            // Scan the inner tokens of #[cfg(...)] for test/feature identifiers.
+            // This handles all cases: bare `test`, `feature = "x"`, and
+            // `any(test, feature = "x")` — because we recurse into nested groups.
+            cfg_tokens_have_exclusion(&list.tokens)
+        }
+        _ => false,
+    }
+}
+
+/// Recursively scan a token stream for `test` or `feature` identifiers.
+fn cfg_tokens_have_exclusion(tokens: &proc_macro2::TokenStream) -> bool {
+    for token in tokens.clone() {
+        match token {
+            proc_macro2::TokenTree::Ident(ident) => {
+                if ident == "test" || ident == "feature" {
+                    return true;
+                }
+            }
+            proc_macro2::TokenTree::Group(group) => {
+                // Recurse into groups (parentheses, braces, brackets).
+                if cfg_tokens_have_exclusion(&group.stream()) {
+                    return true;
+                }
+            }
+            _ => {}
+        }
     }
     false
 }


### PR DESCRIPTION
## Summary

Addresses all high and medium priority items from [issue #173](https://github.com/logos-co/spel/issues/173).

### Changes

#### 1. Workspace Cargo.toml detection (#1 — High)

When `find_crate_manifest()` walks up and finds a workspace root manifest (has `[workspace]` but no `[package]`), it now searches member directories for the actual crate manifest containing `[dependencies]`. Includes fallback recursive subdirectory search when members list does not match. Fallback uses depth-first traversal and skips virtual workspace manifests to find actual member crates.

#### 2. Transitive path-dependency resolution (#2 — High)

`resolve_path_deps_recursive()` follows path-based dependencies through multiple levels with cycle detection via canonicalized directory tracking. If `guest → core → shared_types`, account types from all three crates are collected.

#### 3. Warning propagation (#3 — Medium)

Replaced silent error swallowing (`ok()?`) with explicit warnings returned alongside discovered directories in the new `PathDepResult` struct. CLI prints all warnings to stderr so users can debug incomplete IDLs.

#### 4. `#[cfg(...)]` filtering (#6 — Medium)

`is_cfg_excluded()` skips items gated behind:
- `#[cfg(test)]` — test-only code
- `#[cfg(feature = "...")]` — feature-gated code (unknown which features are enabled for on-chain builds)
- `#[cfg(any(test, ...))]` / `#[cfg(any(feature = "...", ...))]` — excluded if any alternative references test or feature

Applies to both modules AND top-level items (structs, enums). Uses exact identifier matching via token stream scanning to avoid false positives (e.g., `target_feature`). Correctly handles `#[cfg(not(test))]` by skipping contents of `not(...)` groups.

**Note:** `#[cfg_attr(test, ...)]` is **not** treated as exclusion because it only conditionally applies attributes — it does not remove the item from compilation (e.g., `cfg_attr(test, derive(Debug))` is common and valid).

Prevents test-only or feature-gated `#[account_type]` types from leaking into the on-chain IDL.

### Tests added (18 new tests)

| Test | Coverage |
|------|----------|
| `find_path_dep_dirs_resolves_workspace_member_manifest` | Workspace detection with explicit members |
| `find_path_dep_dirs_fallback_search_in_workspace` | Fallback recursive subdirectory scan |
| `find_path_dep_dirs_virtual_workspace_root` | Virtual workspace root resolution path |
| `find_path_dep_dirs_resolves_transitive_deps` | Multi-level dependency chains |
| `find_path_dep_dirs_warns_on_missing_dep_directory` | Warning on non-existent path |
| `find_path_dep_dirs_warns_on_invalid_toml` | Warning on parse failure |
| `cfg_test_module_excluded_from_idl` | `#[cfg(test)]` module exclusion |
| `cfg_feature_module_excluded_from_idl` | `#[cfg(feature)]` module exclusion |
| `cfg_any_test_excluded_from_idl` | `#[cfg(any(test, ...))]` nested exclusion |
| `cfg_not_test_included_in_idl` | `#[cfg(not(test))]` correctly included |
| `cfg_test_top_level_struct_excluded_from_idl` | Top-level `#[cfg(test)]` struct exclusion |
| `account_types_from_transitive_deps_appear_in_idl` | End-to-end transitive account type collection |

### Backward compatibility

- `find_path_dep_dirs()` return type changed from `Vec<PathBuf>` to `PathDepResult { dirs, warnings }` — all existing call sites updated.
- All 147+ existing tests pass unchanged.