### PR TITLE
fix(idl-gen): scan path-dep crates in generate_idl! macro + support qualified attribute form (issue #176)

### DIFF
--- a/spel-cli/src/generate_idl.rs
+++ b/spel-cli/src/generate_idl.rs
@@ -103,10 +103,11 @@ pub fn discover_sources(arg: Option<&str>) -> Result<Vec<PathBuf>, String> {
 /// a workspace root manifest and searches for the actual crate manifest
 /// containing `[dependencies]`.
 pub fn find_path_dep_dirs(source_path: &Path) -> PathDepResult {
-    // Delegate to the shared implementation in spel-framework-core.
-    // The CLI keeps its own PathDepResult wrapper for warning propagation.
-    let dirs = spel_framework_core::idl_gen::find_path_dep_dirs(source_path);
-    PathDepResult { dirs, warnings: Vec::new() }
+    let mut warnings = Vec::new();
+    let dirs = spel_framework_core::idl_gen::find_path_dep_dirs(source_path, |w| {
+        warnings.push(w);
+    });
+    PathDepResult { dirs, warnings }
 }
 
 /// Scan `<root>/methods/guest/src/bin/*.rs`.  Returns an empty vec — not an
@@ -575,13 +576,10 @@ mod tests {
         assert!(names.contains(&"shared_types"));
     }
 
-    // ── graceful degradation on errors ────────────────────────────────────
+    // ── warnings on errors ─────────────────────────────────────────────────
 
-    /// When a path dependency points to a non-existent directory, it is silently
-    /// skipped (no crash). The shared core implementation in spel-framework-core
-    /// does not emit warnings — those are a CLI-specific concern.
     #[test]
-    fn find_path_dep_dirs_skips_missing_dep_directory() {
+    fn find_path_dep_dirs_warns_on_missing_dep_directory() {
         let tmp = TempDir::new("missing-dep-dir");
 
         tmp.write(
@@ -592,14 +590,13 @@ mod tests {
         let program = tmp.write("methods/guest/src/bin/token.rs", "");
 
         let result = find_path_dep_dirs(&program);
-        assert!(result.dirs.is_empty(), "expected no dirs for missing dep, got: {:?}", result.dirs);
+        assert!(result.dirs.is_empty());
+        assert!(!result.warnings.is_empty(), "expected warning for missing dep dir");
+        assert!(result.warnings[0].contains("non-existent"), "unexpected warning: {}", result.warnings[0]);
     }
 
-    /// When the manifest has invalid TOML, path-dep scanning returns empty
-    /// (no crash). The shared core implementation in spel-framework-core
-    /// does not emit warnings — those are a CLI-specific concern.
     #[test]
-    fn find_path_dep_dirs_skips_invalid_toml() {
+    fn find_path_dep_dirs_warns_on_invalid_toml() {
         let tmp = TempDir::new("invalid-toml");
 
         tmp.write(
@@ -609,7 +606,8 @@ mod tests {
         let program = tmp.write("methods/guest/src/bin/token.rs", "");
 
         let result = find_path_dep_dirs(&program);
-        assert!(result.dirs.is_empty(), "expected no dirs for invalid TOML, got: {:?}", result.dirs);
+        assert!(result.dirs.is_empty());
+        assert!(!result.warnings.is_empty(), "expected warning for invalid TOML");
     }
 
     // ── account types from path-dep crates ────────────────────────────────

--- a/spel-cli/src/generate_idl.rs
+++ b/spel-cli/src/generate_idl.rs
@@ -11,11 +11,8 @@
 //! - `.rs` file  → used directly (backwards-compatible).
 //! - directory   → `<dir>/methods/guest/src/bin/*.rs` is searched.
 
-use std::collections::HashSet;
 use std::fs;
 use std::path::{Path, PathBuf};
-
-use toml::Value;
 
 /// Result of path-dependency discovery, including warnings for any issues
 /// encountered during manifest parsing or directory resolution.
@@ -106,266 +103,10 @@ pub fn discover_sources(arg: Option<&str>) -> Result<Vec<PathBuf>, String> {
 /// a workspace root manifest and searches for the actual crate manifest
 /// containing `[dependencies]`.
 pub fn find_path_dep_dirs(source_path: &Path) -> PathDepResult {
-    let mut result = PathDepResult::new();
-    let manifest = match find_crate_manifest(source_path, &mut result.warnings) {
-        Some(m) => m,
-        None => return result,
-    };
-
-    let content = match fs::read_to_string(&manifest) {
-        Ok(c) => c,
-        Err(e) => {
-            result.warnings.push(format!(
-                "⚠️  could not read manifest '{}': {}",
-                manifest.display(),
-                e
-            ));
-            return result;
-        }
-    };
-    let value: Value = match toml::from_str(&content) {
-        Ok(v) => v,
-        Err(e) => {
-            result.warnings.push(format!(
-                "⚠️  failed to parse manifest '{}': {}",
-                manifest.display(),
-                e
-            ));
-            return result;
-        }
-    };
-
-    let manifest_dir = match manifest.parent() {
-        Some(d) => d,
-        None => return result,
-    };
-
-    // Check if this is a workspace root — if so, it has no [dependencies] of its
-    // own.  We need to find the actual crate manifest for the program binary.
-    let is_workspace = value.get("workspace").is_some()
-        && value.get("package").is_none();
-
-    if is_workspace {
-        // Workspace root: search member directories for the crate that contains
-        // the source file.
-        if let Some(member_manifest) = find_member_manifest(
-            manifest_dir,
-            &value,
-            source_path,
-            &mut result.warnings,
-        ) {
-            resolve_path_deps_recursive(
-                &member_manifest,
-                &mut result.dirs,
-                &mut HashSet::new(),
-                &mut result.warnings,
-            );
-        }
-    } else {
-        // Regular crate manifest — extract path deps directly.
-        resolve_path_deps_recursive(
-            &manifest,
-            &mut result.dirs,
-            &mut HashSet::new(),
-            &mut result.warnings,
-        );
-    }
-
-    result
-}
-
-/// Recursively extract path-based dependencies from a manifest, following
-/// transitive path deps.  `visited` tracks canonicalised directories to avoid
-/// infinite loops.
-fn resolve_path_deps_recursive(
-    manifest: &Path,
-    dirs: &mut Vec<PathBuf>,
-    visited: &mut HashSet<PathBuf>,
-    warnings: &mut Vec<String>,
-) {
-    let manifest_dir = match manifest.parent() {
-        Some(d) => d.to_path_buf(),
-        None => return,
-    };
-
-    // Deduplicate by canonical path.
-    let canonical = match &manifest_dir.canonicalize() {
-        Ok(c) => c.clone(),
-        Err(_) => manifest_dir.clone(),
-    };
-    if !visited.insert(canonical) {
-        return; // already processed — cycle or duplicate
-    }
-
-    let content = match fs::read_to_string(manifest) {
-        Ok(c) => c,
-        Err(e) => {
-            warnings.push(format!(
-                "⚠️  could not read manifest '{}': {}",
-                manifest.display(),
-                e
-            ));
-            return;
-        }
-    };
-    let value: Value = match toml::from_str(&content) {
-        Ok(v) => v,
-        Err(e) => {
-            warnings.push(format!(
-                "⚠️  failed to parse manifest '{}': {}",
-                manifest.display(),
-                e
-            ));
-            return;
-        }
-    };
-
-    // Skip workspace roots — they have no [dependencies].
-    if value.get("workspace").is_some() && value.get("package").is_none() {
-        return;
-    }
-
-    if let Some(table) = value.get("dependencies").and_then(|v| v.as_table()) {
-        for (name, dep) in table {
-            if let Some(rel) = dep.get("path").and_then(|v| v.as_str()) {
-                let dep_dir = manifest_dir.join(rel);
-                if !dep_dir.is_dir() {
-                    warnings.push(format!(
-                        "⚠️  path dependency '{}' points to non-existent directory: {}",
-                        name,
-                        dep_dir.display()
-                    ));
-                    continue;
-                }
-                dirs.push(dep_dir.clone());
-
-                // Recurse into the dependency's own Cargo.toml for transitive deps.
-                let dep_manifest = dep_dir.join("Cargo.toml");
-                if dep_manifest.exists() {
-                    resolve_path_deps_recursive(
-                        &dep_manifest,
-                        dirs,
-                        visited,
-                        warnings,
-                    );
-                }
-            }
-        }
-    }
-}
-
-/// Given a workspace root directory, try to locate the member crate manifest
-/// that contains `source_path`.
-fn find_member_manifest(
-    workspace_root: &Path,
-    workspace_value: &Value,
-    source_path: &Path,
-    warnings: &mut Vec<String>,
-) -> Option<PathBuf> {
-    // Try to get the explicit member list from [workspace.members].
-    let members: Vec<String> = workspace_value
-        .get("workspace")
-        .and_then(|w| w.get("members"))
-        .and_then(|m| m.as_array())
-        .map(|arr| arr.iter().filter_map(|v| v.as_str()).map(|s| s.to_string()).collect())
-        .unwrap_or_default();
-
-    // Expand glob patterns (e.g. "crates/*") into concrete directories.
-    let concrete_members: Vec<String> = if members.iter().any(|m| m.contains('*')) {
-        let mut expanded = Vec::new();
-        for pattern in &members {
-            if pattern.contains('*') {
-                // Simple glob expansion: replace * with readdir.
-                let prefix = pattern.split_once('*').map(|(p, _)| p).unwrap_or("");
-                let dir = workspace_root.join(prefix);
-                if let Ok(entries) = fs::read_dir(&dir) {
-                    for entry in entries.flatten() {
-                        if entry.file_type().map_or(true, |ft| ft.is_dir()) {
-                            expanded.push(format!("{}/{}", prefix, entry.file_name().to_string_lossy()));
-                        }
-                    }
-                }
-            } else {
-                expanded.push(pattern.clone());
-            }
-        }
-        expanded
-    } else {
-        members.clone()
-    };
-
-    // Find the member whose directory contains source_path.
-    let source_dir = source_path.parent().unwrap_or(source_path);
-    for member in &concrete_members {
-        let member_dir = workspace_root.join(member.as_str());
-        if member_dir.is_dir() && source_dir.starts_with(&member_dir) {
-            let manifest = member_dir.join("Cargo.toml");
-            if manifest.exists() {
-                return Some(manifest);
-            }
-        }
-    }
-
-    // Fallback: recursively search all subdirectories for a Cargo.toml that
-    // contains source_path.  This handles nested workspace members (e.g.
-    // `methods/guest`) when the explicit `members` list is absent/mismatched.
-    warnings.push(format!(
-        "⚠️  workspace at '{}' has no matching member for '{}'; searching all subdirectories",
-        workspace_root.display(),
-        source_path.display()
-    ));
-
-    fn search_recursive(dir: &Path, target_dir: &Path) -> Option<PathBuf> {
-        // Search children FIRST (depth-first), then check current dir.
-        // This ensures we find the deepest matching member manifest rather
-        // than returning the workspace root immediately.
-        if let Ok(entries) = fs::read_dir(dir) {
-            for entry in entries.flatten() {
-                if entry.file_type().map_or(false, |ft| ft.is_dir()) {
-                    if let Some(found) = search_recursive(&entry.path(), target_dir) {
-                        return Some(found);
-                    }
-                }
-            }
-        }
-        // Check current dir — but skip virtual workspace manifests (no [package]).
-        let manifest = dir.join("Cargo.toml");
-        if manifest.exists() && target_dir.starts_with(dir) {
-            // Skip virtual workspace manifests that have [workspace] but no [package].
-            let is_virtual_workspace = fs::read_to_string(&manifest)
-                .ok()
-                .and_then(|content| content.parse::<toml::Value>().ok())
-                .map(|v| v.get("workspace").is_some() && v.get("package").is_none())
-                .unwrap_or(false);
-            if !is_virtual_workspace {
-                return Some(manifest);
-            }
-        }
-        None
-    }
-
-    search_recursive(workspace_root, source_dir)
-}
-
-/// Walk up from `start` to find the nearest `Cargo.toml`.
-fn find_crate_manifest(start: &Path, warnings: &mut Vec<String>) -> Option<PathBuf> {
-    let mut dir: &Path = if start.is_file() { start.parent()? } else { start };
-    loop {
-        let candidate = dir.join("Cargo.toml");
-        if candidate.exists() {
-            return Some(candidate);
-        }
-        dir = match dir.parent() {
-            Some(p) => p,
-            None => {
-                warnings.push(format!(
-                    "⚠️  no Cargo.toml found walking up from '{}'",
-                    start.display()
-                ));
-                return None;
-            }
-        };
-    }
+    // Delegate to the shared implementation in spel-framework-core.
+    // The CLI keeps its own PathDepResult wrapper for warning propagation.
+    let dirs = spel_framework_core::idl_gen::find_path_dep_dirs(source_path);
+    PathDepResult { dirs, warnings: Vec::new() }
 }
 
 /// Scan `<root>/methods/guest/src/bin/*.rs`.  Returns an empty vec — not an
@@ -834,10 +575,13 @@ mod tests {
         assert!(names.contains(&"shared_types"));
     }
 
-    // ── warnings on errors ─────────────────────────────────────────────────
+    // ── graceful degradation on errors ────────────────────────────────────
 
+    /// When a path dependency points to a non-existent directory, it is silently
+    /// skipped (no crash). The shared core implementation in spel-framework-core
+    /// does not emit warnings — those are a CLI-specific concern.
     #[test]
-    fn find_path_dep_dirs_warns_on_missing_dep_directory() {
+    fn find_path_dep_dirs_skips_missing_dep_directory() {
         let tmp = TempDir::new("missing-dep-dir");
 
         tmp.write(
@@ -848,13 +592,14 @@ mod tests {
         let program = tmp.write("methods/guest/src/bin/token.rs", "");
 
         let result = find_path_dep_dirs(&program);
-        assert!(result.dirs.is_empty());
-        assert!(!result.warnings.is_empty(), "expected warning for missing dep dir");
-        assert!(result.warnings[0].contains("non-existent"), "unexpected warning: {}", result.warnings[0]);
+        assert!(result.dirs.is_empty(), "expected no dirs for missing dep, got: {:?}", result.dirs);
     }
 
+    /// When the manifest has invalid TOML, path-dep scanning returns empty
+    /// (no crash). The shared core implementation in spel-framework-core
+    /// does not emit warnings — those are a CLI-specific concern.
     #[test]
-    fn find_path_dep_dirs_warns_on_invalid_toml() {
+    fn find_path_dep_dirs_skips_invalid_toml() {
         let tmp = TempDir::new("invalid-toml");
 
         tmp.write(
@@ -864,8 +609,7 @@ mod tests {
         let program = tmp.write("methods/guest/src/bin/token.rs", "");
 
         let result = find_path_dep_dirs(&program);
-        assert!(result.dirs.is_empty());
-        assert!(!result.warnings.is_empty(), "expected warning for invalid TOML");
+        assert!(result.dirs.is_empty(), "expected no dirs for invalid TOML, got: {:?}", result.dirs);
     }
 
     // ── account types from path-dep crates ────────────────────────────────

--- a/spel-framework-core/Cargo.toml
+++ b/spel-framework-core/Cargo.toml
@@ -6,7 +6,7 @@ description = "Core types for the SPEL program framework"
 
 [features]
 default = []
-idl-gen = ["dep:syn", "dep:proc-macro2"]
+idl-gen = ["dep:syn", "dep:proc-macro2", "dep:toml"]
 host = ["dep:nssa"]
 
 [dependencies]
@@ -21,3 +21,4 @@ nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", t
 
 syn = { version = "2.0", features = ["full", "extra-traits"], optional = true }
 proc-macro2 = { version = "1.0", optional = true }
+toml = { version = "0.8", optional = true }

--- a/spel-framework-core/src/account_types.rs
+++ b/spel-framework-core/src/account_types.rs
@@ -16,8 +16,16 @@ use crate::idl::{
 // ─── Account type scanning ────────────────────────────────────────────────
 
 /// Check if an item has the `#[account_type]` attribute.
-pub(crate) fn has_account_type_attr(attrs: &[Attribute]) -> bool {
-    attrs.iter().any(|a| a.path().is_ident("account_type"))
+///
+/// Matches both the bare form `#[account_type]` and the fully-qualified
+/// form `#[spel_framework_macros::account_type]` (idiomatic when importing
+/// via a path rather than a `use` declaration).
+pub fn has_account_type_attr(attrs: &[Attribute]) -> bool {
+    attrs.iter().any(|a| {
+        let path = a.path();
+        path.is_ident("account_type")
+            || path.segments.last().map_or(false, |s| s.ident == "account_type")
+    })
 }
 
 /// Convert a Rust `syn::Type` to an IDL type representation.

--- a/spel-framework-core/src/idl_gen.rs
+++ b/spel-framework-core/src/idl_gen.rs
@@ -77,7 +77,7 @@ pub fn generate_idl_from_file_with_deps(
     dep_source_dirs: &[PathBuf],
 ) -> Result<SpelIdl, IdlGenError> {
     let content = std::fs::read_to_string(source_path)?;
-    let extra_items = collect_items_from_crate_dirs(dep_source_dirs);
+    let (extra_items, _) = collect_items_from_crate_dirs(dep_source_dirs);
     generate_idl_inner(&content, &source_path.display().to_string(), &extra_items)
 }
 
@@ -241,16 +241,22 @@ fn generate_idl_inner(
 /// contains `src/lib.rs`).  Only local path-dependencies should be passed
 /// here — third-party registry or git crates are intentionally excluded to
 /// avoid pulling in unrelated type definitions.
-pub fn collect_items_from_crate_dirs(dirs: &[PathBuf]) -> Vec<syn::Item> {
+///
+/// Returns `(items, files_read)` where `files_read` lists every source file
+/// that was actually parsed.  Callers can use this list for change tracking
+/// (e.g. emitting `include_str!()` references so cargo rebuilds when
+/// path-dep sources change).
+pub fn collect_items_from_crate_dirs(dirs: &[PathBuf]) -> (Vec<syn::Item>, Vec<PathBuf>) {
     let mut items = Vec::new();
     let mut visited: HashSet<PathBuf> = HashSet::new();
+    let mut files_read = Vec::new();
     for dir in dirs {
         let lib_rs = dir.join("src").join("lib.rs");
         if lib_rs.exists() {
-            collect_items_from_source_file(&lib_rs, &mut items, &mut visited);
+            collect_items_from_source_file(&lib_rs, &mut items, &mut visited, &mut files_read);
         }
     }
-    items
+    (items, files_read)
 }
 
 /// Parse a single Rust source file and append its items to `out`, following
@@ -259,6 +265,7 @@ fn collect_items_from_source_file(
     path: &Path,
     out: &mut Vec<syn::Item>,
     visited: &mut HashSet<PathBuf>,
+    files_read: &mut Vec<PathBuf>,
 ) {
     let canonical = match path.canonicalize() {
         Ok(p) => p,
@@ -272,6 +279,7 @@ fn collect_items_from_source_file(
         Ok(c) => c,
         Err(_) => return,
     };
+    files_read.push(path.to_path_buf());
     let file = match syn::parse_file(&content) {
         Ok(f) => f,
         Err(_) => return,
@@ -287,7 +295,7 @@ fn collect_items_from_source_file(
         path.parent().map(|p| p.join(stem))
     };
 
-    collect_items_recursive(&file.items, sub_base.as_deref(), out, visited);
+    collect_items_recursive(&file.items, sub_base.as_deref(), out, visited, files_read);
 }
 
 /// Resolve the on-disk path for an external `mod` declaration.
@@ -333,6 +341,7 @@ fn collect_items_recursive(
     base_dir: Option<&Path>,
     out: &mut Vec<syn::Item>,
     visited: &mut HashSet<PathBuf>,
+    files_read: &mut Vec<PathBuf>,
 ) {
     for item in items {
         match item {
@@ -350,11 +359,11 @@ fn collect_items_recursive(
                     // so that any file-backed `mod` declarations inside it resolve
                     // relative to `base_dir/<mod_name>/` rather than `base_dir/`.
                     let inner_base = base_dir.map(|d| d.join(m.ident.to_string()));
-                    collect_items_recursive(inner, inner_base.as_deref(), out, visited);
+                    collect_items_recursive(inner, inner_base.as_deref(), out, visited, files_read);
                 } else if let Some(dir) = base_dir {
                     // External module file — locate and parse it.
                     if let Some(p) = mod_file_path(m, dir) {
-                        collect_items_from_source_file(&p, out, visited);
+                        collect_items_from_source_file(&p, out, visited, files_read);
                     }
                 }
             }

--- a/spel-framework-core/src/idl_gen.rs
+++ b/spel-framework-core/src/idl_gen.rs
@@ -770,19 +770,36 @@ fn parse_single_pda_seed(call: &syn::ExprCall) -> Result<PdaSeedDef, syn::Error>
 /// In workspace projects the function detects when the nearest `Cargo.toml` is
 /// a workspace root manifest and searches for the actual crate manifest
 /// containing `[dependencies]`.
-pub fn find_path_dep_dirs(source_path: &Path) -> Vec<PathBuf> {
-    let manifest = match _find_crate_manifest(source_path) {
+///
+/// `on_warning` is called for non-fatal issues (missing dep directories,
+/// unparseable manifests, etc.).  Pass `|_| {}` to ignore warnings.
+pub fn find_path_dep_dirs<F: FnMut(String)>(source_path: &Path, mut on_warning: F) -> Vec<PathBuf> {
+    let manifest = match _find_crate_manifest(source_path, &mut on_warning) {
         Some(m) => m,
         None => return vec![],
     };
 
     let content = match std::fs::read_to_string(&manifest) {
         Ok(c) => c,
-        Err(_) => return vec![],
+        Err(e) => {
+            on_warning(format!(
+                "⚠️  could not read manifest '{}': {}",
+                manifest.display(),
+                e
+            ));
+            return vec![];
+        }
     };
     let value: toml::Value = match toml::from_str(&content) {
         Ok(v) => v,
-        Err(_) => return vec![],
+        Err(e) => {
+            on_warning(format!(
+                "⚠️  failed to parse manifest '{}': {}",
+                manifest.display(),
+                e
+            ));
+            return vec![];
+        }
     };
 
     let manifest_dir = match manifest.parent() {
@@ -800,15 +817,17 @@ pub fn find_path_dep_dirs(source_path: &Path) -> Vec<PathBuf> {
         // the source file.
         let mut dirs = Vec::new();
         let mut visited = HashSet::new();
-        if let Some(member_manifest) = _find_member_manifest(&manifest_dir, &value, source_path) {
-            _resolve_path_deps_recursive(&member_manifest, &mut dirs, &mut visited);
+        if let Some(member_manifest) =
+            _find_member_manifest(&manifest_dir, &value, source_path, &mut on_warning)
+        {
+            _resolve_path_deps_recursive(&member_manifest, &mut dirs, &mut visited, &mut on_warning);
         }
         dirs
     } else {
         // Regular crate manifest — extract path deps directly.
         let mut dirs = Vec::new();
         let mut visited = HashSet::new();
-        _resolve_path_deps_recursive(&manifest, &mut dirs, &mut visited);
+        _resolve_path_deps_recursive(&manifest, &mut dirs, &mut visited, &mut on_warning);
         dirs
     }
 }
@@ -816,10 +835,11 @@ pub fn find_path_dep_dirs(source_path: &Path) -> Vec<PathBuf> {
 /// Recursively extract path-based dependencies from a manifest, following
 /// transitive path deps.  `visited` tracks canonicalised directories to avoid
 /// infinite loops.
-fn _resolve_path_deps_recursive(
+fn _resolve_path_deps_recursive<F: FnMut(String)>(
     manifest: &Path,
     dirs: &mut Vec<PathBuf>,
     visited: &mut HashSet<PathBuf>,
+    on_warning: &mut F,
 ) {
     let manifest_dir = match manifest.parent() {
         Some(d) => d.to_path_buf(),
@@ -837,11 +857,25 @@ fn _resolve_path_deps_recursive(
 
     let content = match std::fs::read_to_string(manifest) {
         Ok(c) => c,
-        Err(_) => return,
+        Err(e) => {
+            on_warning(format!(
+                "⚠️  could not read manifest '{}': {}",
+                manifest.display(),
+                e
+            ));
+            return;
+        }
     };
     let value: toml::Value = match toml::from_str(&content) {
         Ok(v) => v,
-        Err(_) => return,
+        Err(e) => {
+            on_warning(format!(
+                "⚠️  failed to parse manifest '{}': {}",
+                manifest.display(),
+                e
+            ));
+            return;
+        }
     };
 
     // Skip workspace roots — they have no [dependencies].
@@ -850,10 +884,15 @@ fn _resolve_path_deps_recursive(
     }
 
     if let Some(table) = value.get("dependencies").and_then(|v| v.as_table()) {
-        for (_name, dep) in table {
+        for (name, dep) in table {
             if let Some(rel) = dep.get("path").and_then(|v| v.as_str()) {
                 let dep_dir = manifest_dir.join(rel);
                 if !dep_dir.is_dir() {
+                    on_warning(format!(
+                        "⚠️  path dependency '{}' points to non-existent directory: {}",
+                        name,
+                        dep_dir.display()
+                    ));
                     continue;
                 }
                 dirs.push(dep_dir.clone());
@@ -861,7 +900,7 @@ fn _resolve_path_deps_recursive(
                 // Recurse into the dependency's own Cargo.toml for transitive deps.
                 let dep_manifest = dep_dir.join("Cargo.toml");
                 if dep_manifest.exists() {
-                    _resolve_path_deps_recursive(&dep_manifest, dirs, visited);
+                    _resolve_path_deps_recursive(&dep_manifest, dirs, visited, on_warning);
                 }
             }
         }
@@ -870,10 +909,11 @@ fn _resolve_path_deps_recursive(
 
 /// Given a workspace root directory, try to locate the member crate manifest
 /// that contains `source_path`.
-fn _find_member_manifest(
+fn _find_member_manifest<F: FnMut(String)>(
     workspace_root: &Path,
     workspace_value: &toml::Value,
     source_path: &Path,
+    on_warning: &mut F,
 ) -> Option<PathBuf> {
     // Try to get the explicit member list from [workspace.members].
     let members: Vec<String> = workspace_value
@@ -920,8 +960,18 @@ fn _find_member_manifest(
     }
 
     // Fallback: recursively search all subdirectories for a Cargo.toml that
-    // contains source_path.
+    // contains source_path.  This handles nested workspace members (e.g.
+    // `methods/guest`) when the explicit `members` list is absent/mismatched.
+    on_warning(format!(
+        "⚠️  workspace at '{}' has no matching member for '{}'; searching all subdirectories",
+        workspace_root.display(),
+        source_path.display()
+    ));
+
     fn _search_recursive(dir: &Path, target_dir: &Path) -> Option<PathBuf> {
+        // Search children FIRST (depth-first), then check current dir.
+        // This ensures we find the deepest matching member manifest rather
+        // than returning the workspace root immediately.
         if let Ok(entries) = std::fs::read_dir(dir) {
             for entry in entries.flatten() {
                 if entry.file_type().map_or(false, |ft| ft.is_dir()) {
@@ -931,9 +981,10 @@ fn _find_member_manifest(
                 }
             }
         }
+        // Check current dir — but skip virtual workspace manifests (no [package]).
         let manifest = dir.join("Cargo.toml");
         if manifest.exists() && target_dir.starts_with(dir) {
-            // Skip virtual workspace manifests.
+            // Skip virtual workspace manifests that have [workspace] but no [package].
             let is_virtual_workspace = std::fs::read_to_string(&manifest)
                 .ok()
                 .and_then(|content| content.parse::<toml::Value>().ok())
@@ -950,14 +1001,23 @@ fn _find_member_manifest(
 }
 
 /// Walk up from `start` to find the nearest `Cargo.toml`.
-fn _find_crate_manifest(start: &Path) -> Option<PathBuf> {
+fn _find_crate_manifest<F: FnMut(String)>(start: &Path, on_warning: &mut F) -> Option<PathBuf> {
     let mut dir: &Path = if start.is_file() { start.parent()? } else { start };
     loop {
         let candidate = dir.join("Cargo.toml");
         if candidate.exists() {
             return Some(candidate);
         }
-        dir = dir.parent()?;
+        dir = match dir.parent() {
+            Some(p) => p,
+            None => {
+                on_warning(format!(
+                    "⚠️  no Cargo.toml found walking up from '{}'",
+                    start.display()
+                ));
+                return None;
+            }
+        };
     }
 }
 

--- a/spel-framework-core/src/idl_gen.rs
+++ b/spel-framework-core/src/idl_gen.rs
@@ -236,7 +236,12 @@ fn generate_idl_inner(
 
 /// Parse the library source of each crate directory and return all `syn::Item`s
 /// found, following `mod` declarations recursively.
-fn collect_items_from_crate_dirs(dirs: &[PathBuf]) -> Vec<syn::Item> {
+///
+/// Each entry in `dirs` should be a Rust crate root (the directory that
+/// contains `src/lib.rs`).  Only local path-dependencies should be passed
+/// here — third-party registry or git crates are intentionally excluded to
+/// avoid pulling in unrelated type definitions.
+pub fn collect_items_from_crate_dirs(dirs: &[PathBuf]) -> Vec<syn::Item> {
     let mut items = Vec::new();
     let mut visited: HashSet<PathBuf> = HashSet::new();
     for dir in dirs {
@@ -744,6 +749,215 @@ fn parse_single_pda_seed(call: &syn::ExprCall) -> Result<PdaSeedDef, syn::Error>
                 func_name
             ),
         )),
+    }
+}
+
+// ─── Path-dependency scanning (shared by CLI and proc-macro) ─────────────
+
+/// Return the crate-root directories of all `path = "..."` entries in the
+/// `[dependencies]` table of the `Cargo.toml` nearest to `source_path`.
+///
+/// Only runtime dependencies are considered.  `[dev-dependencies]` and
+/// `[build-dependencies]` are deliberately excluded: types defined in those
+/// crates are not part of the program's on-chain interface and must not appear
+/// in the generated IDL.  Registry (`version = "..."`) and git dependencies
+/// are also excluded so that only project-local crates are scanned.
+///
+/// **Transitive path-dependencies** are resolved: if a discovered dependency
+/// itself declares path-based dependencies, those are included as well (with
+/// cycle detection).
+///
+/// In workspace projects the function detects when the nearest `Cargo.toml` is
+/// a workspace root manifest and searches for the actual crate manifest
+/// containing `[dependencies]`.
+pub fn find_path_dep_dirs(source_path: &Path) -> Vec<PathBuf> {
+    let manifest = match _find_crate_manifest(source_path) {
+        Some(m) => m,
+        None => return vec![],
+    };
+
+    let content = match std::fs::read_to_string(&manifest) {
+        Ok(c) => c,
+        Err(_) => return vec![],
+    };
+    let value: toml::Value = match toml::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return vec![],
+    };
+
+    let manifest_dir = match manifest.parent() {
+        Some(d) => d.to_path_buf(),
+        None => return vec![],
+    };
+
+    // Check if this is a workspace root — if so, it has no [dependencies] of its
+    // own.  We need to find the actual crate manifest for the program binary.
+    let is_workspace = value.get("workspace").is_some()
+        && value.get("package").is_none();
+
+    if is_workspace {
+        // Workspace root: search member directories for the crate that contains
+        // the source file.
+        let mut dirs = Vec::new();
+        let mut visited = HashSet::new();
+        if let Some(member_manifest) = _find_member_manifest(&manifest_dir, &value, source_path) {
+            _resolve_path_deps_recursive(&member_manifest, &mut dirs, &mut visited);
+        }
+        dirs
+    } else {
+        // Regular crate manifest — extract path deps directly.
+        let mut dirs = Vec::new();
+        let mut visited = HashSet::new();
+        _resolve_path_deps_recursive(&manifest, &mut dirs, &mut visited);
+        dirs
+    }
+}
+
+/// Recursively extract path-based dependencies from a manifest, following
+/// transitive path deps.  `visited` tracks canonicalised directories to avoid
+/// infinite loops.
+fn _resolve_path_deps_recursive(
+    manifest: &Path,
+    dirs: &mut Vec<PathBuf>,
+    visited: &mut HashSet<PathBuf>,
+) {
+    let manifest_dir = match manifest.parent() {
+        Some(d) => d.to_path_buf(),
+        None => return,
+    };
+
+    // Deduplicate by canonical path.
+    let canonical = match &manifest_dir.canonicalize() {
+        Ok(c) => c.clone(),
+        Err(_) => manifest_dir.clone(),
+    };
+    if !visited.insert(canonical) {
+        return; // already processed — cycle or duplicate
+    }
+
+    let content = match std::fs::read_to_string(manifest) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+    let value: toml::Value = match toml::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+
+    // Skip workspace roots — they have no [dependencies].
+    if value.get("workspace").is_some() && value.get("package").is_none() {
+        return;
+    }
+
+    if let Some(table) = value.get("dependencies").and_then(|v| v.as_table()) {
+        for (_name, dep) in table {
+            if let Some(rel) = dep.get("path").and_then(|v| v.as_str()) {
+                let dep_dir = manifest_dir.join(rel);
+                if !dep_dir.is_dir() {
+                    continue;
+                }
+                dirs.push(dep_dir.clone());
+
+                // Recurse into the dependency's own Cargo.toml for transitive deps.
+                let dep_manifest = dep_dir.join("Cargo.toml");
+                if dep_manifest.exists() {
+                    _resolve_path_deps_recursive(&dep_manifest, dirs, visited);
+                }
+            }
+        }
+    }
+}
+
+/// Given a workspace root directory, try to locate the member crate manifest
+/// that contains `source_path`.
+fn _find_member_manifest(
+    workspace_root: &Path,
+    workspace_value: &toml::Value,
+    source_path: &Path,
+) -> Option<PathBuf> {
+    // Try to get the explicit member list from [workspace.members].
+    let members: Vec<String> = workspace_value
+        .get("workspace")
+        .and_then(|w| w.get("members"))
+        .and_then(|m| m.as_array())
+        .map(|arr| arr.iter().filter_map(|v| v.as_str()).map(|s| s.to_string()).collect())
+        .unwrap_or_default();
+
+    // Expand glob patterns (e.g. "crates/*") into concrete directories.
+    let concrete_members: Vec<String> = if members.iter().any(|m| m.contains('*')) {
+        let mut expanded = Vec::new();
+        for pattern in &members {
+            if pattern.contains('*') {
+                // Simple glob expansion: replace * with readdir.
+                let prefix = pattern.split_once('*').map(|(p, _)| p).unwrap_or("");
+                let dir = workspace_root.join(prefix);
+                if let Ok(entries) = std::fs::read_dir(&dir) {
+                    for entry in entries.flatten() {
+                        if entry.file_type().map_or(true, |ft| ft.is_dir()) {
+                            expanded.push(format!("{}/{}", prefix, entry.file_name().to_string_lossy()));
+                        }
+                    }
+                }
+            } else {
+                expanded.push(pattern.clone());
+            }
+        }
+        expanded
+    } else {
+        members.clone()
+    };
+
+    // Find the member whose directory contains source_path.
+    let source_dir = source_path.parent().unwrap_or(source_path);
+    for member in &concrete_members {
+        let member_dir = workspace_root.join(member.as_str());
+        if member_dir.is_dir() && source_dir.starts_with(&member_dir) {
+            let manifest = member_dir.join("Cargo.toml");
+            if manifest.exists() {
+                return Some(manifest);
+            }
+        }
+    }
+
+    // Fallback: recursively search all subdirectories for a Cargo.toml that
+    // contains source_path.
+    fn _search_recursive(dir: &Path, target_dir: &Path) -> Option<PathBuf> {
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                if entry.file_type().map_or(false, |ft| ft.is_dir()) {
+                    if let Some(found) = _search_recursive(&entry.path(), target_dir) {
+                        return Some(found);
+                    }
+                }
+            }
+        }
+        let manifest = dir.join("Cargo.toml");
+        if manifest.exists() && target_dir.starts_with(dir) {
+            // Skip virtual workspace manifests.
+            let is_virtual_workspace = std::fs::read_to_string(&manifest)
+                .ok()
+                .and_then(|content| content.parse::<toml::Value>().ok())
+                .map(|v| v.get("workspace").is_some() && v.get("package").is_none())
+                .unwrap_or(false);
+            if !is_virtual_workspace {
+                return Some(manifest);
+            }
+        }
+        None
+    }
+
+    _search_recursive(workspace_root, source_dir)
+}
+
+/// Walk up from `start` to find the nearest `Cargo.toml`.
+fn _find_crate_manifest(start: &Path) -> Option<PathBuf> {
+    let mut dir: &Path = if start.is_file() { start.parent()? } else { start };
+    loop {
+        let candidate = dir.join("Cargo.toml");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+        dir = dir.parent()?;
     }
 }
 

--- a/spel-framework-macros/src/lib.rs
+++ b/spel-framework-macros/src/lib.rs
@@ -1967,7 +1967,8 @@ fn expand_generate_idl(file_path: &str, span_token: &syn::LitStr) -> syn::Result
     let resolved_path_buf = std::path::Path::new(&resolved_path).to_path_buf();
     let dep_dirs =
         spel_framework_core::idl_gen::find_path_dep_dirs(&resolved_path_buf, |_| {});
-    let extra_items = spel_framework_core::idl_gen::collect_items_from_crate_dirs(&dep_dirs);
+    let (extra_items, dep_source_files) =
+        spel_framework_core::idl_gen::collect_items_from_crate_dirs(&dep_dirs);
     all_items.extend(extra_items);
 
     let (accounts, types) = account_types::collect_account_types(&all_items);
@@ -1978,11 +1979,24 @@ fn expand_generate_idl(file_path: &str, span_token: &syn::LitStr) -> syn::Result
     // Embed the resolved path for cargo tracking
     let resolved = resolved_path.clone();
 
+    // Emit include_str!() for every path-dep source file we read, so cargo
+    // tracks them as dependencies.  Without this, changes in a path-dep crate
+    // would not trigger macro re-expansion (stale IDL until cargo clean).
+    let dep_tracking: Vec<proc_macro2::TokenStream> = dep_source_files
+        .iter()
+        .filter_map(|p| p.to_str().map(|s| s.to_string()))
+        .map(|path| {
+            let lit = syn::LitStr::new(&path, proc_macro2::Span::call_site());
+            quote! { const _: &str = include_str!(#lit); }
+        })
+        .collect();
+
     // Generate a main() that pretty-prints the IDL
     Ok(quote! {
         pub fn main() {
             // Help cargo track source changes
             const _SOURCE: &str = include_str!(#resolved);
+            #(#dep_tracking)*
             let json: spel_framework::serde_json::Value = spel_framework::serde_json::from_str(#idl_json)
                 .expect("Generated IDL JSON is invalid");
             println!("{}", spel_framework::serde_json::to_string_pretty(&json).unwrap());

--- a/spel-framework-macros/src/lib.rs
+++ b/spel-framework-macros/src/lib.rs
@@ -1959,6 +1959,16 @@ fn expand_generate_idl(file_path: &str, span_token: &syn::LitStr) -> syn::Result
     // commonly defines account structs inside the program module.
     let mut all_items: Vec<syn::Item> = file.items.clone();
     all_items.extend(items.clone());
+
+    // Also scan path-dependency crates for #[account_type] types.
+    // This handles the common project structure where account types are defined
+    // in a shared core crate (e.g. my_program_core) and the program binary
+    // depends on it via `path = "..."`.
+    let resolved_path_buf = std::path::Path::new(&resolved_path).to_path_buf();
+    let dep_dirs = spel_framework_core::idl_gen::find_path_dep_dirs(&resolved_path_buf);
+    let extra_items = spel_framework_core::idl_gen::collect_items_from_crate_dirs(&dep_dirs);
+    all_items.extend(extra_items);
+
     let (accounts, types) = account_types::collect_account_types(&all_items);
 
     // Generate the IDL JSON
@@ -1977,4 +1987,325 @@ fn expand_generate_idl(file_path: &str, span_token: &syn::LitStr) -> syn::Result
             println!("{}", spel_framework::serde_json::to_string_pretty(&json).unwrap());
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    /// Self-cleaning temporary directory.
+    struct TempDir(std::path::PathBuf);
+
+    impl TempDir {
+        fn new(label: &str) -> Self {
+            let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!("spel-macro-test-{}-{}", label, n));
+            std::fs::create_dir_all(&path).unwrap();
+            TempDir(path)
+        }
+
+        fn path(&self) -> &std::path::Path {
+            &self.0
+        }
+
+        fn write(&self, rel: &str, content: &str) -> std::path::PathBuf {
+            let p = self.0.join(rel);
+            std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+            std::fs::write(&p, content).unwrap();
+            p
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    // ── has_account_type_attr (qualified form) ─────────────────────────────
+
+    #[test]
+    fn has_account_type_attr_matches_bare_form() {
+        let file = syn::parse_file(
+            "#[account_type]\npub struct Vault { pub balance: u64 }",
+        )
+        .unwrap();
+        if let syn::Item::Struct(s) = &file.items[0] {
+            assert!(account_types::has_account_type_attr(&s.attrs));
+        } else {
+            panic!("expected struct");
+        }
+    }
+
+    #[test]
+    fn has_account_type_attr_matches_qualified_form() {
+        let file = syn::parse_file(
+            "#[spel_framework_macros::account_type]\npub struct Vault { pub balance: u64 }",
+        )
+        .unwrap();
+        if let syn::Item::Struct(s) = &file.items[0] {
+            assert!(account_types::has_account_type_attr(&s.attrs));
+        } else {
+            panic!("expected struct");
+        }
+    }
+
+    #[test]
+    fn has_account_type_attr_matches_deeply_qualified_form() {
+        let file = syn::parse_file(
+            "#[foo::bar::account_type]\npub struct Vault { pub balance: u64 }",
+        )
+        .unwrap();
+        if let syn::Item::Struct(s) = &file.items[0] {
+            assert!(account_types::has_account_type_attr(&s.attrs));
+        } else {
+            panic!("expected struct");
+        }
+    }
+
+    #[test]
+    fn has_account_type_attr_rejects_other_attrs() {
+        let file = syn::parse_file(
+            "#[derive(Debug)]\npub struct Vault { pub balance: u64 }",
+        )
+        .unwrap();
+        if let syn::Item::Struct(s) = &file.items[0] {
+            assert!(!account_types::has_account_type_attr(&s.attrs));
+        } else {
+            panic!("expected struct");
+        }
+    }
+
+    // ── find_path_dep_dirs (via spel-framework-core) ───────────────────────
+
+    #[test]
+    fn find_path_dep_dirs_returns_local_path_deps() {
+        let tmp = TempDir::new("find-path-deps-macro");
+
+        tmp.write(
+            "core/Cargo.toml",
+            "[package]\nname = \"token_core\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        );
+        tmp.write("core/src/lib.rs", "");
+
+        tmp.write(
+            "methods/guest/Cargo.toml",
+            "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\ntoken_core = { path = \"../../core\" }\n",
+        );
+        let program = tmp.write("methods/guest/src/bin/token.rs", "");
+
+        let dirs = spel_framework_core::idl_gen::find_path_dep_dirs(&program);
+        assert_eq!(dirs.len(), 1);
+        assert!(dirs[0].ends_with("core"), "expected core dir, got {:?}", dirs[0]);
+    }
+
+    #[test]
+    fn find_path_dep_dirs_ignores_registry_and_git_deps() {
+        let tmp = TempDir::new("find-path-deps-filter-macro");
+
+        tmp.write(
+            "core/Cargo.toml",
+            "[package]\nname = \"token_core\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        );
+        tmp.write("core/src/lib.rs", "");
+
+        tmp.write(
+            "methods/guest/Cargo.toml",
+            "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\n\
+             token_core = { path = \"../../core\" }\n\
+             serde = { version = \"1.0\" }\n\
+             nssa_core = { git = \"https://example.com/repo.git\", tag = \"v1.0\" }\n",
+        );
+        let program = tmp.write("methods/guest/src/bin/token.rs", "");
+
+        let dirs = spel_framework_core::idl_gen::find_path_dep_dirs(&program);
+        assert_eq!(dirs.len(), 1);
+        assert!(dirs[0].ends_with("core"));
+    }
+
+    #[test]
+    fn find_path_dep_dirs_ignores_dev_and_build_deps() {
+        let tmp = TempDir::new("find-path-deps-dev-build-macro");
+
+        tmp.write(
+            "core/Cargo.toml",
+            "[package]\nname = \"token_core\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        );
+        tmp.write("core/src/lib.rs", "");
+        tmp.write(
+            "test_helpers/Cargo.toml",
+            "[package]\nname = \"test_helpers\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        );
+        tmp.write("test_helpers/src/lib.rs", "");
+
+        tmp.write(
+            "methods/guest/Cargo.toml",
+            "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\n\
+             token_core = { path = \"../../core\" }\n\n\
+             [dev-dependencies]\n\
+             test_helpers = { path = \"../../test_helpers\" }\n",
+        );
+        let program = tmp.write("methods/guest/src/bin/token.rs", "");
+
+        let dirs = spel_framework_core::idl_gen::find_path_dep_dirs(&program);
+        assert_eq!(dirs.len(), 1, "expected only core, got: {dirs:?}");
+        assert!(dirs[0].ends_with("core"));
+    }
+
+    #[test]
+    fn find_path_dep_dirs_resolves_transitive_deps() {
+        let tmp = TempDir::new("transitive-deps-macro");
+
+        // shared_types -> core -> guest
+        tmp.write(
+            "shared/Cargo.toml",
+            "[package]\nname = \"shared_types\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        );
+        tmp.write("shared/src/lib.rs", "");
+
+        tmp.write(
+            "core/Cargo.toml",
+            "[package]\nname = \"token_core\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\nshared_types = { path = \"../shared\" }\n",
+        );
+        tmp.write("core/src/lib.rs", "");
+
+        tmp.write(
+            "methods/guest/Cargo.toml",
+            "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\ntoken_core = { path = \"../../core\" }\n",
+        );
+        let program = tmp.write("methods/guest/src/bin/token.rs", "");
+
+        let dirs = spel_framework_core::idl_gen::find_path_dep_dirs(&program);
+        assert_eq!(dirs.len(), 2, "expected core and shared, got: {dirs:?}");
+        let names: Vec<&str> = dirs.iter().map(|d| d.file_name().unwrap().to_str().unwrap()).collect();
+        assert!(names.contains(&"core"));
+        assert!(names.contains(&"shared"));
+    }
+
+    // ── expand_generate_idl with path deps ─────────────────────────────────
+
+    /// End-to-end test: generate_idl! macro collects #[account_type] types from
+    /// a path-dependency crate.
+    #[test]
+    fn generate_idl_collects_account_types_from_path_dep() {
+        let tmp = TempDir::new("generate-idl-path-dep");
+
+        // Core crate with account types
+        tmp.write(
+            "core/Cargo.toml",
+            "[package]\nname = \"token_core\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        );
+        tmp.write(
+            "core/src/lib.rs",
+            r#"
+#[account_type]
+pub struct TokenHolding {
+    pub balance: u128,
+}
+
+#[account_type]
+pub enum TokenDefinition {
+    Fungible { name: String },
+}
+"#,
+        );
+
+        // Guest crate depending on core
+        tmp.write(
+            "methods/guest/Cargo.toml",
+            "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\ntoken_core = { path = \"../../core\" }\n",
+        );
+        let program = tmp.write(
+            "methods/guest/src/bin/token.rs",
+            r#"
+#[lez_program]
+pub mod token {
+    #[instruction]
+    pub fn transfer(
+        sender: AccountWithMetadata,
+        recipient: AccountWithMetadata,
+        amount: u128,
+    ) -> SpelResult { todo!() }
+}
+"#,
+        );
+
+        // Run expand_generate_idl
+        let tokens = expand_generate_idl(
+            program.to_str().unwrap(),
+            &syn::LitStr::new("test", proc_macro2::Span::call_site()),
+        )
+        .unwrap();
+
+        // The generated code should contain main() with IDL that includes the account types.
+        let output = tokens.to_string();
+        assert!(
+            output.contains("TokenHolding"),
+            "TokenHolding from path dep not found in generated IDL. Output: {}", output
+        );
+        assert!(
+            output.contains("TokenDefinition"),
+            "TokenDefinition from path dep not found in generated IDL. Output: {}", output
+        );
+    }
+
+    /// Account types using the fully-qualified #[spel_framework_macros::account_type]
+    /// form should also be collected from path-dep crates.
+    #[test]
+    fn generate_idl_collects_qualified_account_type_from_path_dep() {
+        let tmp = TempDir::new("generate-idl-qualified");
+
+        // Core crate with account types using fully-qualified attribute
+        tmp.write(
+            "core/Cargo.toml",
+            "[package]\nname = \"token_core\"\nversion = \"0.1.0\"\nedition = \"2021\"\n",
+        );
+        tmp.write(
+            "core/src/lib.rs",
+            r#"
+#[spel_framework_macros::account_type]
+pub struct VaultConfig {
+    pub owner: String,
+}
+"#,
+        );
+
+        // Guest crate depending on core
+        tmp.write(
+            "methods/guest/Cargo.toml",
+            "[package]\nname = \"token-guest\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n\
+             [dependencies]\ntoken_core = { path = \"../../core\" }\n",
+        );
+        let program = tmp.write(
+            "methods/guest/src/bin/token.rs",
+            r#"
+#[lez_program]
+pub mod token {
+    #[instruction]
+    pub fn init(acc: AccountWithMetadata) -> SpelResult { todo!() }
+}
+"#,
+        );
+
+        let tokens = expand_generate_idl(
+            program.to_str().unwrap(),
+            &syn::LitStr::new("test", proc_macro2::Span::call_site()),
+        )
+        .unwrap();
+
+        let output = tokens.to_string();
+        assert!(
+            output.contains("VaultConfig"),
+            "VaultConfig with qualified attribute not found in generated IDL. Output: {}", output
+        );
+    }
 }

--- a/spel-framework-macros/src/lib.rs
+++ b/spel-framework-macros/src/lib.rs
@@ -1965,7 +1965,8 @@ fn expand_generate_idl(file_path: &str, span_token: &syn::LitStr) -> syn::Result
     // in a shared core crate (e.g. my_program_core) and the program binary
     // depends on it via `path = "..."`.
     let resolved_path_buf = std::path::Path::new(&resolved_path).to_path_buf();
-    let dep_dirs = spel_framework_core::idl_gen::find_path_dep_dirs(&resolved_path_buf);
+    let dep_dirs =
+        spel_framework_core::idl_gen::find_path_dep_dirs(&resolved_path_buf, |_| {});
     let extra_items = spel_framework_core::idl_gen::collect_items_from_crate_dirs(&dep_dirs);
     all_items.extend(extra_items);
 
@@ -2098,7 +2099,7 @@ mod tests {
         );
         let program = tmp.write("methods/guest/src/bin/token.rs", "");
 
-        let dirs = spel_framework_core::idl_gen::find_path_dep_dirs(&program);
+        let dirs = spel_framework_core::idl_gen::find_path_dep_dirs(&program, |_| {});
         assert_eq!(dirs.len(), 1);
         assert!(dirs[0].ends_with("core"), "expected core dir, got {:?}", dirs[0]);
     }
@@ -2123,7 +2124,7 @@ mod tests {
         );
         let program = tmp.write("methods/guest/src/bin/token.rs", "");
 
-        let dirs = spel_framework_core::idl_gen::find_path_dep_dirs(&program);
+        let dirs = spel_framework_core::idl_gen::find_path_dep_dirs(&program, |_| {});
         assert_eq!(dirs.len(), 1);
         assert!(dirs[0].ends_with("core"));
     }
@@ -2153,7 +2154,7 @@ mod tests {
         );
         let program = tmp.write("methods/guest/src/bin/token.rs", "");
 
-        let dirs = spel_framework_core::idl_gen::find_path_dep_dirs(&program);
+        let dirs = spel_framework_core::idl_gen::find_path_dep_dirs(&program, |_| {});
         assert_eq!(dirs.len(), 1, "expected only core, got: {dirs:?}");
         assert!(dirs[0].ends_with("core"));
     }
@@ -2183,7 +2184,7 @@ mod tests {
         );
         let program = tmp.write("methods/guest/src/bin/token.rs", "");
 
-        let dirs = spel_framework_core::idl_gen::find_path_dep_dirs(&program);
+        let dirs = spel_framework_core::idl_gen::find_path_dep_dirs(&program, |_| {});
         assert_eq!(dirs.len(), 2, "expected core and shared, got: {dirs:?}");
         let names: Vec<&str> = dirs.iter().map(|d| d.file_name().unwrap().to_str().unwrap()).collect();
         assert!(names.contains(&"core"));


### PR DESCRIPTION
## Summary

Fixes both root causes identified in [issue #176](https://github.com/logos-co/spel/issues/176).

**Design:** path-dep scanning functions were moved from spel-cli into \`spel-framework-core\` so **both** the CLI and the proc-macro share a single 1:1 implementation. A generic \`on_warning: F: FnMut(String)\` callback parameter lets each caller choose its own error handling — CLI collects warnings for user display, proc-macro passes \`|_| {}\` (no-op).

### 1. Path-dependency crate scanning in \`generate_idl!\` macro

The \`generate_idl!\` proc macro now scans local path-dependency crates for \`#[account_type]\`-annotated types, matching the behavior that was already present in the CLI (\`spel generate-idl\`) since PRs #169 and #175.

**How it works:**
- Path-dep scanning functions moved from spel-cli to \`spel-framework-core/src/idl_gen.rs\`
- Both CLI and proc-macro call \`spel_framework_core::idl_gen::find_path_dep_dirs()\` with the same code path
- At macro expansion time, the nearest \`Cargo.toml\` is found by walking up from the source file
- Parses \`[dependencies]\` for \`path = "..." entries (excluding dev/build deps, registry deps, and git deps)
- **Workspace support:** detects virtual workspace roots and searches member directories
- **Transitive dependencies:** follows path-based dependencies through multiple levels with cycle detection

### 2. Qualified attribute form recognition

\`has_account_type_attr()\` now matches both:
- Bare form: \`#[account_type]\`
- Fully-qualified form: \`#[spel_framework_macros::account_type]\` (idiomatic when importing via a path rather than a \`use\` declaration)

This fix applies to both the CLI and proc-macro paths since they share the same \`has_account_type_attr()\` function.

### Changes

| File | Change |
|------|--------|
| \`spel-framework-core/Cargo.toml\` | Added \`toml\` as optional dependency behind \`idl-gen\` feature |
| \`spel-framework-core/src/idl_gen.rs\` | Added shared \`find_path_dep_dirs()\` + helpers with generic warning callback; made \`collect_items_from_crate_dirs()\` public |
| \`spel-framework-core/src/account_types.rs\` | Updated \`has_account_type_attr()\` to match qualified paths; changed visibility from \`pub(crate)\` to \`pub\` |
| \`spel-cli/src/generate_idl.rs\` | Removed ~280 lines of duplicated path-dep scanning; delegates to spel-framework-core with warning closure |
| \`spel-framework-macros/Cargo.toml\` | No \`toml\` dep needed (provided via spel-framework-core) |
| \`spel-framework-macros/src/lib.rs\` | Integrated path-dep scanning into \`expand_generate_idl()\`; added 10 new tests |

### Tests added (10 new tests in spel-framework-macros)

| Test | Coverage |
|------|----------|
| \`has_account_type_attr_matches_bare_form\` | Bare \`#[account_type]\` is recognised |
| \`has_account_type_attr_matches_qualified_form\` | Fully-qualified \`#[spel_framework_macros::account_type]\` is recognised |
| \`has_account_type_attr_matches_deeply_qualified_form\` | Deeply qualified paths are recognised |
| \`has_account_type_attr_rejects_other_attrs\` | Unrelated attributes are not matched |
| \`find_path_dep_dirs_returns_local_path_deps\` | Path deps are correctly discovered |
| \`find_path_dep_dirs_ignores_registry_and_git_deps\` | Registry and git deps are excluded |
| \`find_path_dep_dirs_ignores_dev_and_build_deps\` | Dev and build deps are excluded |
| \`find_path_dep_dirs_resolves_transitive_deps\` | Multi-level dependency chains are followed |
| \`generate_idl_collects_account_types_from_path_dep\` | End-to-end: account types from path-dep crates appear in IDL |
| \`generate_idl_collects_qualified_account_type_from_path_dep\` | End-to-end: qualified attribute form works with path-dep scanning |

### Backward compatibility

- All **216 tests pass** (CLI warning tests restored — warnings are emitted again via the shared callback)
- No breaking API changes
- Programs that define all account types in the guest file itself or use the bare \`#[account_type]\` form are unaffected