### PR TITLE
docs: add troubleshooting for ring/riscv32 guest build failure (issue #165)

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,38 @@ spel inspect 0000...0000 \
 | `spel` | Generic IDL-driven CLI with TX submission + project scaffolding |
 | `spel-client-gen` | Code generator — produces typed Rust FFI clients from IDL JSON |
 
+## Troubleshooting
+
+### Guest build fails with `ring` cross-compilation error on riscv32
+
+If your guest build fails with:
+
+```
+riscv32-unknown-elf-gcc: error: unrecognized command-line option '-m64'
+error: failed to run custom build command for `ring v0.17.14`
+```
+
+This is caused by the LEZ workspace enabling `risc0-zkvm` default features (`bonsai`, `client`), which pull in `reqwest → rustls → ring`. The `ring` crate cannot cross-compile for riscv32.
+
+**Root cause:** [logos-blockchain/logos-execution-zone issue #468](https://github.com/logos-blockchain/logos-execution-zone/issues/468)
+
+**Workaround:** fork the LEZ repo, apply this one-line change to `Cargo.toml`, and patch your workspace:
+
+```diff
+- risc0-zkvm = { version = "3.0.5", features = ["std"] }
++ risc0-zkvm = { version = "3.0.5", default-features = false, features = ["std"] }
+```
+
+Then in your workspace `Cargo.toml`:
+
+```toml
+[patch."https://github.com/logos-blockchain/logos-execution-zone.git"]
+nssa_core = { git = "https://github.com/YOUR-USER/logos-execution-zone.git", branch = "fix-risc0-defaults" }
+nssa = { git = "https://github.com/YOUR-USER/logos-execution-zone.git", branch = "fix-risc0-defaults" }
+```
+
+Once the upstream fix is merged, remove the `[patch]` section and update your LEZ dependency tag.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

Adds a troubleshooting section documenting the `ring` cross-compilation failure on riscv32 guest builds.

**Root cause:** The LEZ workspace enables `risc0-zkvm` default features (`bonsai`, `client`), which pull in `reqwest → rustls → ring`. The `ring` crate cannot cross-compile for riscv32 (`-m64` rejected by `riscv32-unknown-elf-gcc`).

**Why spel cannot fix this alone:**
- `nssa_core` uses `risc0-zkvm.workspace = true` which inherits LEZ workspace defaults
- Cargo feature unification is global — spel's own `default-features = false` on risc0-zkvm cannot override the LEZ workspace config
- `[patch]` requires a fork of LEZ with the fix

**Upstream issue filed:** https://github.com/logos-blockchain/logos-execution-zone/issues/468

**Workaround documented in README:** Users must fork LEZ, apply one-line change (`default-features = false` on risc0-zkvm), and patch their workspace. Once the upstream fix is merged, the patch can be removed.

### Verification

Tested locally with `[patch]` pointing to a modified LEZ copy — `ring` disappears from the dependency tree and all 216 tests pass.