### PR TITLE
fix(init): use branch=main for spel-framework default (issue #183)

### DIFF
--- a/spel-cli/src/init.rs
+++ b/spel-cli/src/init.rs
@@ -284,7 +284,7 @@ risc0-zkvm = {{ version = "=3.0.5", features = ["std"] }}
     let spel_ref = match (spel_tag, spel_rev) {
         (Some(t), _) => format!("tag = \"{}\"", t),
         (_, Some(r)) => format!("rev = \"{}\"", r),
-        _ => "tag = \"v0.2.0-rc.3\"".to_string(),
+        _ => "branch = \"main\"".to_string(),
     };
     // methods/guest/Cargo.toml
     write_file(root, "methods/guest/Cargo.toml", &format!(r#"[package]


### PR DESCRIPTION
## Problem

`spel init` scaffolded projects that were **unbuildable** out of the box.

The root cause: the init template referenced `spel-framework` from tag `v0.2.0-rc.3`, which depends on LEZ `v0.2.0-rc1`. But the generated guest code references `nssa_core` from LEZ `v0.2.0-rc3`. This created two incompatible versions of `nssa_core` in the dependency tree:

```
error[E0308]: expected nssa_core::account::data::Data, found nssa_core::account::Data
```

## Fix

Change the default `spel_ref` from `tag = "v0.2.0-rc.3"` to `branch = "main"`. Main branch already has correct rc3 LEZ dependencies everywhere (`spel-framework-core`, `spel-framework`, and the init template all use rc3), so this eliminates the mismatch.

## Verification

```bash
rm -rf testproj && spel init testproj && cd testproj && make build
# ✅ Guest binary built successfully (442KB ELF)
```