### PR TITLE
feat(macros): support #[self_program_id] parameter injection in handlers

### DIFF
--- a/spel-framework-macros/src/lib.rs
+++ b/spel-framework-macros/src/lib.rs
@@ -157,6 +157,9 @@ struct InstructionInfo {
     args: Vec<ArgParam>,
     /// The original function item (with #[instruction] stripped)
     func: ItemFn,
+    /// True if the handler declares a `#[self_program_id]` parameter.
+    /// When set, the macro injects `self_program_id` as the last argument in the call.
+    has_program_id_param: bool,
 }
 
 struct AccountParam {
@@ -471,6 +474,7 @@ fn parse_instruction(func: ItemFn) -> syn::Result<InstructionInfo> {
     let fn_name = func.sig.ident.clone();
     let mut accounts = Vec::new();
     let mut args = Vec::new();
+    let mut has_program_id_param = false;
 
     for input in &func.sig.inputs {
         match input {
@@ -478,7 +482,14 @@ fn parse_instruction(func: ItemFn) -> syn::Result<InstructionInfo> {
                 let param_name = extract_param_name(pat_type)?;
                 let ty = &*pat_type.ty;
 
-                if is_account_type(ty) {
+                if pat_type
+                    .attrs
+                    .iter()
+                    .any(|a| a.path().is_ident("self_program_id"))
+                {
+                    has_program_id_param = true;
+                    // excluded from `args` so it doesn't become an Instruction enum field
+                } else if is_account_type(ty) {
                     let constraints = parse_account_constraints(&pat_type.attrs)?;
                     accounts.push(AccountParam {
                         name: param_name,
@@ -513,6 +524,7 @@ fn parse_instruction(func: ItemFn) -> syn::Result<InstructionInfo> {
         accounts,
         args,
         func,
+        has_program_id_param,
     })
 }
 
@@ -808,6 +820,7 @@ fn generate_match_arms(mod_name: &Ident, instructions: &[InstructionInfo]) -> Ve
                     let name = &a.name;
                     quote! { #name }
                 }))
+                .chain(ix.has_program_id_param.then(|| quote! { self_program_id }))
                 .collect();
 
             // Collect arg seed values to pass to validation
@@ -1063,7 +1076,8 @@ impl<'a> VisitMut for ExecuteTransformer<'a> {
             call.func = syn::parse_quote! { SpelOutput::execute_with_claims };
             call.args.clear();
             call.args.push(syn::parse_quote! { &#accounts_arg });
-            call.args.push(syn::parse_quote! { &#claims_fn(#(#all_seed_args),*) });
+            call.args
+                .push(syn::parse_quote! { &#claims_fn(#(#all_seed_args),*) });
             call.args.push(syn::parse_quote! { #chained_arg });
         }
     }
@@ -1101,7 +1115,9 @@ fn generate_handler_fns(instructions: &[InstructionInfo]) -> Vec<TokenStream2> {
             func.attrs.retain(|a| !a.path().is_ident("instruction"));
             for input in &mut func.sig.inputs {
                 if let FnArg::Typed(pat_type) = input {
-                    pat_type.attrs.retain(|a| !a.path().is_ident("account"));
+                    pat_type.attrs.retain(|a| {
+                        !a.path().is_ident("account") && !a.path().is_ident("self_program_id")
+                    });
                 }
             }
             // Transform SpelOutput::execute(vec![...], calls) → execute_with_claims

--- a/spel-framework/tests/e2e.rs
+++ b/spel-framework/tests/e2e.rs
@@ -58,7 +58,7 @@ fn e2e_idl_generation() {
     // Top-level fields
     assert_eq!(idl.version, "0.1.0");
     assert_eq!(idl.name, "treasury");
-    assert_eq!(idl.instructions.len(), 9);
+    assert_eq!(idl.instructions.len(), 11);
 
     // initialize instruction
     let init = &idl.instructions[0];

--- a/tests/e2e/fixture_program/src/lib.rs
+++ b/tests/e2e/fixture_program/src/lib.rs
@@ -114,6 +114,35 @@ mod treasury {
         Ok(SpelOutput::execute(vec![account, authority], vec![]))
     }
 
+    /// Uses the injected program ID to derive a PDA at runtime.
+    /// Exercises #[self_program_id] together with accounts and no instruction args.
+    #[instruction]
+    pub fn create_self_pda(
+        #[account(init, pda = literal("self_derived"))]
+        derived: AccountWithMetadata,
+        #[account(signer)]
+        authority: AccountWithMetadata,
+        #[self_program_id] program_id: ProgramId,
+    ) -> SpelResult {
+        // Use program_id to recompute the expected PDA — exercises the injected value.
+        let _expected = spel_framework::pda::compute_pda(
+            &program_id,
+            &[&spel_framework::pda::seed_from_str("self_derived")],
+        );
+        Ok(SpelOutput::execute(vec![derived, authority], vec![]))
+    }
+
+    /// Exercises #[self_program_id] with a flexible parameter name and no other args.
+    #[instruction]
+    pub fn echo_program_id(
+        #[account(signer)]
+        authority: AccountWithMetadata,
+        #[self_program_id] pid: ProgramId,
+    ) -> SpelResult {
+        let _ = pid;
+        Ok(SpelOutput::execute(vec![authority], vec![]))
+    }
+
     /// Batch update: one fixed authority + variable-length list of target accounts.
     #[instruction]
     pub fn batch_update(
@@ -146,7 +175,7 @@ mod tests {
         let idl = __program_idl();
         assert_eq!(idl.name, "treasury");
         assert_eq!(idl.version, "0.1.0");
-        assert_eq!(idl.instructions.len(), 9);
+        assert_eq!(idl.instructions.len(), 11);
         assert_eq!(idl.instructions[0].name, "initialize");
     }
 
@@ -155,7 +184,7 @@ mod tests {
         let idl: spel_framework::idl::SpelIdl =
             serde_json::from_str(PROGRAM_IDL_JSON).expect("PROGRAM_IDL_JSON should parse");
         assert_eq!(idl.name, "treasury");
-        assert_eq!(idl.instructions.len(), 9);
+        assert_eq!(idl.instructions.len(), 11);
     }
 
     #[test]
@@ -760,5 +789,97 @@ mod tests {
     // `#[cfg(not(test))]`. It cannot be unit-tested here without a full zkVM harness.
     // The filter logic (pre_states_clone.zip(post_states).filter(...)) is covered by
     // integration/e2e tests that invoke the guest binary end-to-end.
+
+    // ── #[self_program_id] ───────────────────────────────────────────────────
+
+    /// Handler is callable directly with a ProgramId as the last argument.
+    #[test]
+    fn handler_create_self_pda_callable() {
+        let acc = make_account(true);
+        let result = treasury::create_self_pda(acc.clone(), acc.clone(), test_program_id());
+        assert!(result.is_ok());
+    }
+
+    /// Flexible naming: the parameter doesn't have to be called `program_id`.
+    #[test]
+    fn handler_echo_program_id_callable() {
+        let acc = make_account(true);
+        let result = treasury::echo_program_id(acc.clone(), test_program_id());
+        assert!(result.is_ok());
+    }
+
+    /// The #[self_program_id] parameter must NOT appear in the IDL instruction args —
+    /// it is injected by the runtime and must not be serialised as part of the instruction.
+    #[test]
+    fn idl_self_program_id_param_excluded_from_args() {
+        let idl = __program_idl();
+
+        let create_self = idl.instructions.iter()
+            .find(|i| i.name == "create_self_pda")
+            .expect("create_self_pda must be in IDL");
+        assert_eq!(
+            create_self.args.len(), 0,
+            "create_self_pda should have no instruction args (program_id is injected)"
+        );
+
+        let echo = idl.instructions.iter()
+            .find(|i| i.name == "echo_program_id")
+            .expect("echo_program_id must be in IDL");
+        assert_eq!(
+            echo.args.len(), 0,
+            "echo_program_id should have no instruction args"
+        );
+    }
+
+    /// Accounts are still tracked correctly even when a #[self_program_id] param is present.
+    #[test]
+    fn idl_self_program_id_does_not_affect_account_metadata() {
+        let idl = __program_idl();
+
+        let create_self = idl.instructions.iter()
+            .find(|i| i.name == "create_self_pda")
+            .expect("create_self_pda must be in IDL");
+        assert_eq!(create_self.accounts.len(), 2);
+        assert!(create_self.accounts[0].init, "derived should be init");
+        assert!(create_self.accounts[0].pda.is_some(), "derived should have PDA");
+        assert!(create_self.accounts[1].signer, "authority should be signer");
+
+        let echo = idl.instructions.iter()
+            .find(|i| i.name == "echo_program_id")
+            .expect("echo_program_id must be in IDL");
+        assert_eq!(echo.accounts.len(), 1);
+        assert!(echo.accounts[0].signer, "authority should be signer");
+    }
+
+    /// PDA validation is unaffected by the presence of a #[self_program_id] param —
+    /// the macro still generates __validate_* using the program_id from ProgramInput.
+    #[test]
+    fn validate_create_self_pda_accepts_correct_address() {
+        let program_id = test_program_id();
+        let seed = spel_framework::pda::seed_from_str("self_derived");
+        let correct_id = spel_framework::pda::compute_pda(&program_id, &[&seed]);
+
+        let accounts = vec![
+            make_account_with_id(*correct_id.value(), false),
+            make_account_with_id([2u8; 32], true),
+        ];
+        let result = treasury::__validate_create_self_pda(&accounts, &program_id, &empty_ix_data());
+        assert!(result.is_ok(), "correct PDA should pass: {result:?}");
+    }
+
+    #[test]
+    fn validate_create_self_pda_rejects_wrong_address() {
+        let program_id = test_program_id();
+        let accounts = vec![
+            make_account_with_id([0xFFu8; 32], false), // wrong address
+            make_account_with_id([2u8; 32], true),
+        ];
+        let result = treasury::__validate_create_self_pda(&accounts, &program_id, &empty_ix_data());
+        let err = result.expect_err("wrong address should fail");
+        assert!(
+            matches!(err, spel_framework::error::SpelError::PdaMismatch { .. }),
+            "expected PdaMismatch, got: {err:?}"
+        );
+    }
 
 }


### PR DESCRIPTION
Handlers inside #[lez_program] modules can now declare a parameter annotated with #[self_program_id] to receive the program's own ID at runtime. The macro detects the attribute, excludes the parameter from the generated Instruction enum and IDL args, and injects the `self_program_id` value (already available in the generated main()) as the last positional argument in the dispatch match arm.

The attribute name is fixed; the parameter name is flexible. The parameter must appear last in the handler signature due to the positional call-arg construction.