### PR TITLE
fix(scaffold): suppress spurious r0vm ImageID error in make build

### DIFF
--- a/spel-cli/src/init.rs
+++ b/spel-cli/src/init.rs
@@ -110,7 +110,8 @@ help: ## Show this help
 	@echo "  make cli ARGS=\"<command> --arg1 value1\""
 
 build: ## Build the guest binary
-	cargo risczero build --manifest-path methods/guest/Cargo.toml
+	cargo risczero build --manifest-path methods/guest/Cargo.toml \
+		2> >(grep -Ev "Falling back to slow ImageID|No such file or directory \(os error 2\)" >&2)
 	@echo ""
 	@echo "✅ Guest binary built: $(PROGRAM_BIN)"
 	@ls -la $(PROGRAM_BIN) 2>/dev/null || true


### PR DESCRIPTION
## Summary

Fixes #186.

`cargo risczero build` emits two cosmetic stderr lines when `r0vm` is not installed via `rzup`, even though the build succeeds and the ELF is produced correctly:

```
Falling back to slow ImageID computation. Updating to the latest r0vm will speed this up.
  error: No such file or directory (os error 2)
```

New users see these as alarming errors and report the build as broken.

## Fix

The generated `Makefile` already sets `SHELL := /bin/bash`, so bash process substitution is available. The `build:` target now filters exactly these two known-spurious lines from stderr while leaving all real build errors intact:

```makefile
build: ## Build the guest binary
	cargo risczero build --manifest-path methods/guest/Cargo.toml \
		2> >(grep -Ev "Falling back to slow ImageID|No such file or directory \(os error 2\)" >&2)
```

## Test plan
- [ ] `make build` on a fresh `spel init` project no longer shows the spurious error lines
- [ ] Real build errors (e.g. compile failures) still surface normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)