### PR TITLE
feat(rfp-002): add spel-freeze-authority library and sample program

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 members = [
     "spel-admin-authority",
     "spel-admin-authority-sample",
+    "spel-freeze-authority",
+    "spel-freeze-authority-sample",
     "spel-framework",
     "spel-framework-core",
     "spel-framework-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,7 @@
 [workspace]
 members = [
+    "spel-admin-authority",
+    "spel-admin-authority-sample",
     "spel-framework",
     "spel-framework-core",
     "spel-framework-macros",

--- a/spel-admin-authority-sample/Cargo.toml
+++ b/spel-admin-authority-sample/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "spel-admin-authority-sample"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Sample program demonstrating spel-admin-authority usage (RFP-001)"
+
+[dependencies]
+borsh = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
+spel-framework = { path = "../spel-framework" }
+spel-admin-authority = { path = "../spel-admin-authority" }

--- a/spel-admin-authority-sample/src/lib.rs
+++ b/spel-admin-authority-sample/src/lib.rs
@@ -33,24 +33,8 @@ use serde::{Deserialize, Serialize};
 use spel_admin_authority::{AdminError, AdminState};
 use spel_framework::prelude::*;
 
-/// The config PDA account data.
-#[account_type]
-#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
-pub struct AdminConfig {
-    /// The admin authority state.
-    pub admin_state: AdminState,
-    /// A configurable value gated behind admin authority.
-    pub config_value: u64,
-}
-
-impl AdminConfig {
-    pub fn new(admin_key: [u8; 32]) -> Self {
-        Self {
-            admin_state: AdminState::new(admin_key),
-            config_value: 0,
-        }
-    }
-}
+// Re-export AdminConfig from the library
+pub use spel_admin_authority::AdminConfig;
 
 /// Convert AdminError to SpelError for use in instruction handlers.
 fn admin_err(e: AdminError) -> spel_framework::error::SpelError {
@@ -89,9 +73,10 @@ mod admin_authority_sample {
 
     /// Update the config value. Admin-only.
     ///
-    /// Reads the admin state from the config PDA and verifies the signer
-    /// is the current admin before allowing the update.
+    /// The #[require_admin(config)] annotation automatically injects
+    /// the admin authority check before the handler body runs.
     #[instruction]
+    #[require_admin(config)]
     pub fn set_config_value(
         #[account(mut, pda = literal("config"))]
         config: AccountWithMetadata,

--- a/spel-admin-authority-sample/src/lib.rs
+++ b/spel-admin-authority-sample/src/lib.rs
@@ -1,0 +1,272 @@
+//! # Admin Authority Sample Program (RFP-001)
+//!
+//! Demonstrates how to use `spel-admin-authority` in a SPEL program.
+//!
+//! ## Instructions
+//!
+//! - `initialize` — creates the config PDA and sets the admin authority
+//! - `set_config_value` — admin-only: update the config value (gated instruction)
+//! - `transfer_admin` — admin-only: transfer authority to a new key
+//! - `revoke_admin` — admin-only: permanently revoke admin control
+//!
+//! ## Usage pattern
+//!
+//! ```rust,ignore
+//! #[lez_program]
+//! mod my_program {
+//!     #[instruction]
+//!     pub fn initialize(
+//!         #[account(init, pda = literal("config"))]
+//!         config: AccountWithMetadata,
+//!         #[account(signer)]
+//!         admin: AccountWithMetadata,
+//!     ) -> SpelResult {
+//!         // Store AdminState in config PDA
+//!         let state = AdminState::new(*admin.account_id.value());
+//!         // ... write state to config account
+//!     }
+//! }
+//! ```
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+use spel_admin_authority::{AdminError, AdminState};
+use spel_framework::prelude::*;
+
+/// The config PDA account data.
+#[account_type]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AdminConfig {
+    /// The admin authority state.
+    pub admin_state: AdminState,
+    /// A configurable value gated behind admin authority.
+    pub config_value: u64,
+}
+
+impl AdminConfig {
+    pub fn new(admin_key: [u8; 32]) -> Self {
+        Self {
+            admin_state: AdminState::new(admin_key),
+            config_value: 0,
+        }
+    }
+}
+
+/// Convert AdminError to SpelError for use in instruction handlers.
+fn admin_err(e: AdminError) -> spel_framework::error::SpelError {
+    spel_framework::error::SpelError::Unauthorized {
+        message: e.to_string(),
+    }
+}
+
+#[lez_program]
+mod admin_authority_sample {
+    use super::*;
+
+    /// Initialize the config PDA and set the admin authority.
+    ///
+    /// The signer of this transaction becomes the admin authority.
+    /// Re-initialization is rejected automatically by `#[account(init)]`.
+    #[instruction]
+    pub fn initialize(
+        #[account(init, pda = literal("config"))]
+        config: AccountWithMetadata,
+        #[account(signer)]
+        admin: AccountWithMetadata,
+    ) -> SpelResult {
+        let admin_key = *admin.account_id.value();
+        let state = AdminConfig::new(admin_key);
+        let data = borsh::to_vec(&state).expect("AdminConfig serializes");
+
+        let mut post_config = config.account.clone();
+        post_config.data = data.try_into().expect("data fits");
+
+        Ok(SpelOutput::execute(
+            vec![config, admin],
+            vec![],
+        ))
+    }
+
+    /// Update the config value. Admin-only.
+    ///
+    /// Reads the admin state from the config PDA and verifies the signer
+    /// is the current admin before allowing the update.
+    #[instruction]
+    pub fn set_config_value(
+        #[account(mut, pda = literal("config"))]
+        config: AccountWithMetadata,
+        #[account(signer)]
+        admin: AccountWithMetadata,
+        new_value: u64,
+    ) -> SpelResult {
+        let mut state = AdminConfig::try_from_slice(&config.account.data)
+            .map_err(|_| spel_framework::error::SpelError::Unauthorized {
+                message: "Failed to deserialize AdminConfig".to_string(),
+            })?;
+
+        // Assert admin authority
+        let admin_key = *admin.account_id.value();
+        state.admin_state.assert_admin(&admin_key).map_err(admin_err)?;
+
+        // Update value
+        state.config_value = new_value;
+        let data = borsh::to_vec(&state).expect("AdminConfig serializes");
+
+        let mut post_config = config.account.clone();
+        post_config.data = data.try_into().expect("data fits");
+
+        Ok(SpelOutput::execute(vec![config, admin], vec![]))
+    }
+
+    /// Transfer admin authority to a new signer. Admin-only.
+    ///
+    /// After this call, only the new admin can call privileged instructions.
+    #[instruction]
+    pub fn transfer_admin(
+        #[account(mut, pda = literal("config"))]
+        config: AccountWithMetadata,
+        #[account(signer)]
+        admin: AccountWithMetadata,
+        new_admin: [u8; 32],
+    ) -> SpelResult {
+        let mut state = AdminConfig::try_from_slice(&config.account.data)
+            .map_err(|_| spel_framework::error::SpelError::Unauthorized {
+                message: "Failed to deserialize AdminConfig".to_string(),
+            })?;
+
+        let admin_key = *admin.account_id.value();
+        state.admin_state.transfer_admin(&admin_key, new_admin).map_err(admin_err)?;
+
+        let data = borsh::to_vec(&state).expect("AdminConfig serializes");
+        let mut post_config = config.account.clone();
+        post_config.data = data.try_into().expect("data fits");
+
+        Ok(SpelOutput::execute(vec![config, admin], vec![]))
+    }
+
+    /// Permanently revoke admin authority. Admin-only. Irreversible.
+    ///
+    /// After this call, no one can call privileged instructions ever again.
+    #[instruction]
+    pub fn revoke_admin(
+        #[account(mut, pda = literal("config"))]
+        config: AccountWithMetadata,
+        #[account(signer)]
+        admin: AccountWithMetadata,
+    ) -> SpelResult {
+        let mut state = AdminConfig::try_from_slice(&config.account.data)
+            .map_err(|_| spel_framework::error::SpelError::Unauthorized {
+                message: "Failed to deserialize AdminConfig".to_string(),
+            })?;
+
+        let admin_key = *admin.account_id.value();
+        state.admin_state.revoke_admin(&admin_key).map_err(admin_err)?;
+
+        let data = borsh::to_vec(&state).expect("AdminConfig serializes");
+        let mut post_config = config.account.clone();
+        post_config.data = data.try_into().expect("data fits");
+
+        Ok(SpelOutput::execute(vec![config, admin], vec![]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nssa_core::account::{Account, AccountId, AccountWithMetadata};
+
+    fn make_account(id: [u8; 32], authorized: bool) -> AccountWithMetadata {
+        AccountWithMetadata {
+            account_id: AccountId::new(id),
+            account: Account::default(),
+            is_authorized: authorized,
+        }
+    }
+
+    fn make_config_account(state: &AdminConfig) -> AccountWithMetadata {
+        let data = borsh::to_vec(state).unwrap();
+        let mut account = Account::default();
+        account.data = data.try_into().unwrap();
+        AccountWithMetadata {
+            account_id: AccountId::new([0u8; 32]),
+            account,
+            is_authorized: false,
+        }
+    }
+
+    fn admin_key() -> [u8; 32] { [1u8; 32] }
+    fn other_key() -> [u8; 32] { [2u8; 32] }
+    fn new_admin_key() -> [u8; 32] { [3u8; 32] }
+
+    #[test]
+    fn initialize_sets_admin() {
+        let config = make_account([0u8; 32], false);
+        let admin = make_account(admin_key(), true);
+        let result = admin_authority_sample::initialize(config, admin);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn set_config_value_succeeds_for_admin() {
+        let state = AdminConfig::new(admin_key());
+        let config = make_config_account(&state);
+        let admin = make_account(admin_key(), true);
+        let result = admin_authority_sample::set_config_value(config, admin, 42);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn set_config_value_rejected_for_non_admin() {
+        let state = AdminConfig::new(admin_key());
+        let config = make_config_account(&state);
+        let non_admin = make_account(other_key(), true);
+        let result = admin_authority_sample::set_config_value(config, non_admin, 42);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn transfer_admin_works() {
+        let state = AdminConfig::new(admin_key());
+        let config = make_config_account(&state);
+        let admin = make_account(admin_key(), true);
+        let result = admin_authority_sample::transfer_admin(config, admin, new_admin_key());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn transfer_admin_rejected_for_non_admin() {
+        let state = AdminConfig::new(admin_key());
+        let config = make_config_account(&state);
+        let non_admin = make_account(other_key(), true);
+        let result = admin_authority_sample::transfer_admin(config, non_admin, new_admin_key());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn revoke_admin_works() {
+        let state = AdminConfig::new(admin_key());
+        let config = make_config_account(&state);
+        let admin = make_account(admin_key(), true);
+        let result = admin_authority_sample::revoke_admin(config, admin);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn revoke_admin_rejected_for_non_admin() {
+        let state = AdminConfig::new(admin_key());
+        let config = make_config_account(&state);
+        let non_admin = make_account(other_key(), true);
+        let result = admin_authority_sample::revoke_admin(config, non_admin);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn set_config_rejected_after_revocation() {
+        let mut state = AdminConfig::new(admin_key());
+        state.admin_state.revoke_admin(&admin_key()).unwrap();
+        let config = make_config_account(&state);
+        let admin = make_account(admin_key(), true);
+        let result = admin_authority_sample::set_config_value(config, admin, 99);
+        assert!(result.is_err());
+    }
+}

--- a/spel-admin-authority/Cargo.toml
+++ b/spel-admin-authority/Cargo.toml
@@ -9,4 +9,3 @@ description = "Admin authority library for SPEL/LEZ programs (RFP-001)"
 borsh = { version = "1", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
 nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
-spel-framework = { path = "../spel-framework" }

--- a/spel-admin-authority/Cargo.toml
+++ b/spel-admin-authority/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "spel-admin-authority"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Admin authority library for SPEL/LEZ programs (RFP-001)"
+
+[dependencies]
+borsh = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
+spel-framework = { path = "../spel-framework" }

--- a/spel-admin-authority/README.md
+++ b/spel-admin-authority/README.md
@@ -1,0 +1,196 @@
+# spel-admin-authority
+
+Admin authority library for LEZ programs — RFP-001 implementation.
+
+Provides a standardised access control primitive for SPEL programs where
+privileged functions can only be called by a designated admin authority.
+The authority can transfer control to a new key or permanently revoke it.
+
+## Quick Start
+
+Add to your program's `Cargo.toml`:
+
+```toml
+[dependencies]
+spel-admin-authority = { path = "../spel-admin-authority" }
+```
+
+## Usage
+
+### 1. Store AdminConfig in your config PDA
+
+```rust
+use spel_admin_authority::AdminConfig;
+
+// In your initialize instruction:
+let admin_key = *admin.account_id.value();
+let config = AdminConfig::new(admin_key);
+let data = borsh::to_vec(&config).unwrap();
+```
+
+### 2. Gate privileged instructions with #[require_admin]
+
+```rust
+use spel_framework::prelude::*;
+
+#[lez_program]
+mod my_program {
+    #[instruction]
+    pub fn initialize(
+        #[account(init, pda = literal("config"))]
+        config: AccountWithMetadata,
+        #[account(signer)]
+        admin: AccountWithMetadata,
+    ) -> SpelResult {
+        // Store AdminConfig in config PDA
+        Ok(SpelOutput::execute(vec![config, admin], vec![]))
+    }
+
+    /// Admin-only: update config value.
+    /// The #[require_admin] annotation injects the authority check automatically.
+    #[instruction]
+    #[require_admin(config)]
+    pub fn set_value(
+        #[account(mut, pda = literal("config"))]
+        config: AccountWithMetadata,
+        #[account(signer)]
+        admin: AccountWithMetadata,
+        new_value: u64,
+    ) -> SpelResult {
+        // Admin check injected automatically — no boilerplate needed
+        Ok(SpelOutput::execute(vec![config, admin], vec![]))
+    }
+
+    /// Transfer admin authority to a new key.
+    #[instruction]
+    pub fn transfer_admin(
+        #[account(mut, pda = literal("config"))]
+        config: AccountWithMetadata,
+        #[account(signer)]
+        admin: AccountWithMetadata,
+        new_admin: [u8; 32],
+    ) -> SpelResult {
+        let mut state = AdminConfig::try_from_slice(&config.account.data).unwrap();
+        let admin_key = *admin.account_id.value();
+        state.admin_state.transfer_admin(&admin_key, new_admin).unwrap();
+        Ok(SpelOutput::execute(vec![config, admin], vec![]))
+    }
+
+    /// Permanently revoke admin authority — irreversible.
+    #[instruction]
+    pub fn revoke_admin(
+        #[account(mut, pda = literal("config"))]
+        config: AccountWithMetadata,
+        #[account(signer)]
+        admin: AccountWithMetadata,
+    ) -> SpelResult {
+        let mut state = AdminConfig::try_from_slice(&config.account.data).unwrap();
+        let admin_key = *admin.account_id.value();
+        state.admin_state.revoke_admin(&admin_key).unwrap();
+        Ok(SpelOutput::execute(vec![config, admin], vec![]))
+    }
+}
+```
+
+## API
+
+### `AdminState`
+
+Core authority primitive. Store inside your program's config account.
+
+```rust
+pub struct AdminState {
+    pub admin: Option<[u8; 32]>,
+}
+
+impl AdminState {
+    pub fn new(admin_key: [u8; 32]) -> Self;
+    pub fn is_revoked(&self) -> bool;
+    pub fn assert_admin(&self, signer_key: &[u8; 32]) -> Result<(), AdminError>;
+    pub fn transfer_admin(&mut self, signer_key: &[u8; 32], new_admin: [u8; 32]) -> Result<(), AdminError>;
+    pub fn revoke_admin(&mut self, signer_key: &[u8; 32]) -> Result<(), AdminError>;
+}
+```
+
+### `AdminConfig`
+
+Standard config PDA type bundling `AdminState` with a `u64` config value.
+Use this directly or embed `AdminState` in your own config struct.
+
+```rust
+pub struct AdminConfig {
+    pub admin_state: AdminState,
+    pub config_value: u64,
+}
+```
+
+### `#[require_admin(config)]` macro
+
+Add to any `#[instruction]` function to automatically inject an admin
+authority check before the handler body runs. The argument names the
+account parameter that holds the `AdminConfig` PDA.
+
+```rust
+#[instruction]
+#[require_admin(config)]    // ← single annotation, no boilerplate
+pub fn privileged_action(
+    #[account(mut, pda = literal("config"))]
+    config: AccountWithMetadata,
+    #[account(signer)]
+    admin: AccountWithMetadata,
+) -> SpelResult { ... }
+```
+
+The macro expands to verify `AdminConfig::assert_admin()` against the
+signer before the handler body executes. An unauthorized call returns
+`SpelError::Unauthorized` and the transaction is rejected.
+
+## Error Codes
+
+| Error | Meaning |
+|---|---|
+| `AdminError::Unauthorized` | Signer is not the current admin authority |
+| `AdminError::Revoked` | Admin authority has been permanently revoked |
+| `AdminError::AlreadyRevoked` | Cannot revoke — already revoked |
+
+## Authority Lifecycle
+initialize(admin_key)
+│
+▼
+AdminState { admin: Some(key) }
+│
+├── assert_admin(key) ──► Ok — privileged call allowed
+├── assert_admin(other) ─► Err(Unauthorized)
+│
+├── transfer_admin(key, new_key)
+│       └──► AdminState { admin: Some(new_key) }
+│
+└── revoke_admin(key)
+└──► AdminState { admin: None } (permanent)
+│
+└── assert_admin(any) ──► Err(Revoked)
+
+## Atomicity
+
+All mutations in `AdminState` only modify state after all checks pass.
+An unauthorized call returns `Err` before any write — the prior authority
+is preserved on failure. This is enforced structurally, not by convention.
+
+## Tests
+
+```bash
+cargo test -p spel-admin-authority    # 9 unit tests
+cargo test -p spel-admin-authority-sample  # 8 integration tests
+```
+
+## Reference Implementation
+
+See `spel-admin-authority-sample/` for a complete SPEL program demonstrating
+all four instructions: `initialize`, `set_config_value`, `transfer_admin`,
+and `revoke_admin`.
+
+## Related
+
+- [RFP-001 proposal](https://github.com/logos-co/rfp/issues/55)
+- [LP-0013 implementation](https://github.com/bristinWild/logos-execution-zone)
+  — production use of `AdminState` pattern for token mint authority

--- a/spel-admin-authority/src/lib.rs
+++ b/spel-admin-authority/src/lib.rs
@@ -1,0 +1,194 @@
+//! # SPEL Admin Authority Library (RFP-001)
+//!
+//! Provides standardised admin authority for LEZ programs.
+//!
+//! ## Usage
+//!
+//! ```rust,ignore
+//! use spel_admin_authority::{AdminState, AdminError};
+//!
+//! // In initialize instruction:
+//! let mut state = AdminState::initialize(admin_account.account_id.value());
+//!
+//! // Gate a privileged instruction:
+//! state.assert_admin(&signer_account)?;
+//!
+//! // Transfer authority:
+//! state.transfer_admin(new_admin_key)?;
+//!
+//! // Revoke permanently:
+//! state.revoke_admin()?;
+//! ```
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+
+/// The admin authority state stored in a PDA account.
+///
+/// This struct is stored on-chain in the program's config PDA.
+/// Use `#[account_type]` when embedding in your program.
+#[derive(Debug, Clone, PartialEq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct AdminState {
+    /// The current admin authority public key.
+    /// `None` means admin has been permanently revoked.
+    pub admin: Option<[u8; 32]>,
+}
+
+/// Errors returned by admin authority operations.
+#[derive(Debug, Clone, PartialEq)]
+pub enum AdminError {
+    /// The signer is not the current admin authority.
+    Unauthorized,
+    /// Admin authority has been permanently revoked.
+    Revoked,
+    /// Admin authority is already revoked — cannot revoke twice.
+    AlreadyRevoked,
+}
+
+impl std::fmt::Display for AdminError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AdminError::Unauthorized => {
+                write!(f, "Unauthorized: signer is not the admin authority")
+            }
+            AdminError::Revoked => write!(f, "Admin authority has been permanently revoked"),
+            AdminError::AlreadyRevoked => write!(f, "Admin authority is already revoked"),
+        }
+    }
+}
+
+impl AdminState {
+    /// Initialize a new AdminState with the given admin key.
+    pub fn new(admin_key: [u8; 32]) -> Self {
+        Self {
+            admin: Some(admin_key),
+        }
+    }
+
+    /// Check if admin authority has been revoked.
+    pub fn is_revoked(&self) -> bool {
+        self.admin.is_none()
+    }
+
+    /// Assert that the given account is the current admin authority.
+    ///
+    /// Returns `Err(AdminError::Revoked)` if authority has been revoked.
+    /// Returns `Err(AdminError::Unauthorized)` if the signer doesn't match.
+    pub fn assert_admin(&self, signer_key: &[u8; 32]) -> Result<(), AdminError> {
+        match &self.admin {
+            None => Err(AdminError::Revoked),
+            Some(key) => {
+                if key == signer_key {
+                    Ok(())
+                } else {
+                    Err(AdminError::Unauthorized)
+                }
+            }
+        }
+    }
+
+    /// Transfer admin authority to a new key.
+    ///
+    /// Only the current admin can call this.
+    pub fn transfer_admin(
+        &mut self,
+        signer_key: &[u8; 32],
+        new_admin: [u8; 32],
+    ) -> Result<(), AdminError> {
+        self.assert_admin(signer_key)?;
+        self.admin = Some(new_admin);
+        Ok(())
+    }
+
+    /// Permanently revoke admin authority.
+    ///
+    /// Only the current admin can call this. This is irreversible.
+    pub fn revoke_admin(&mut self, signer_key: &[u8; 32]) -> Result<(), AdminError> {
+        self.assert_admin(signer_key)?;
+        self.admin = None;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(byte: u8) -> [u8; 32] {
+        [byte; 32]
+    }
+
+    #[test]
+    fn new_sets_admin() {
+        let state = AdminState::new(key(1));
+        assert_eq!(state.admin, Some(key(1)));
+        assert!(!state.is_revoked());
+    }
+
+    #[test]
+    fn assert_admin_accepts_correct_signer() {
+        let state = AdminState::new(key(1));
+        assert!(state.assert_admin(&key(1)).is_ok());
+    }
+
+    #[test]
+    fn assert_admin_rejects_wrong_signer() {
+        let state = AdminState::new(key(1));
+        let err = state.assert_admin(&key(2)).unwrap_err();
+        assert_eq!(err, AdminError::Unauthorized);
+    }
+
+    #[test]
+    fn assert_admin_rejects_after_revocation() {
+        let mut state = AdminState::new(key(1));
+        state.revoke_admin(&key(1)).unwrap();
+        let err = state.assert_admin(&key(1)).unwrap_err();
+        assert_eq!(err, AdminError::Revoked);
+    }
+
+    #[test]
+    fn transfer_admin_works() {
+        let mut state = AdminState::new(key(1));
+        state.transfer_admin(&key(1), key(2)).unwrap();
+        assert_eq!(state.admin, Some(key(2)));
+        // old key no longer works
+        assert_eq!(state.assert_admin(&key(1)), Err(AdminError::Unauthorized));
+        // new key works
+        assert!(state.assert_admin(&key(2)).is_ok());
+    }
+
+    #[test]
+    fn transfer_admin_rejects_wrong_signer() {
+        let mut state = AdminState::new(key(1));
+        let err = state.transfer_admin(&key(2), key(3)).unwrap_err();
+        assert_eq!(err, AdminError::Unauthorized);
+        // state unchanged
+        assert_eq!(state.admin, Some(key(1)));
+    }
+
+    #[test]
+    fn revoke_admin_works() {
+        let mut state = AdminState::new(key(1));
+        state.revoke_admin(&key(1)).unwrap();
+        assert!(state.is_revoked());
+        assert_eq!(state.admin, None);
+    }
+
+    #[test]
+    fn revoke_admin_rejects_wrong_signer() {
+        let mut state = AdminState::new(key(1));
+        let err = state.revoke_admin(&key(2)).unwrap_err();
+        assert_eq!(err, AdminError::Unauthorized);
+        // state unchanged
+        assert!(!state.is_revoked());
+    }
+
+    #[test]
+    fn revoke_admin_rejects_already_revoked() {
+        let mut state = AdminState::new(key(1));
+        state.revoke_admin(&key(1)).unwrap();
+        // try to revoke again with any key
+        let err = state.revoke_admin(&key(1)).unwrap_err();
+        assert_eq!(err, AdminError::Revoked);
+    }
+}

--- a/spel-admin-authority/src/lib.rs
+++ b/spel-admin-authority/src/lib.rs
@@ -110,6 +110,40 @@ impl AdminState {
     }
 }
 
+/// The standard config PDA account data for admin-authority programs.
+///
+/// Store this in your program's config PDA (pda = literal("config")).
+/// The `admin_state` field controls access to privileged instructions.
+///
+/// ```rust,ignore
+/// #[account_type]
+/// #[derive(BorshSerialize, BorshDeserialize)]
+/// pub struct MyProgramConfig {
+///     pub admin_state: AdminState,
+///     pub my_value: u64,
+/// }
+/// ```
+///
+/// Or use `AdminConfig` directly if you only need the admin state + a u64 value.
+#[derive(Debug, Clone, PartialEq, borsh::BorshSerialize, borsh::BorshDeserialize,
+         serde::Serialize, serde::Deserialize)]
+pub struct AdminConfig {
+    /// The admin authority state.
+    pub admin_state: AdminState,
+    /// A configurable value gated behind admin authority.
+    pub config_value: u64,
+}
+
+impl AdminConfig {
+    /// Create a new AdminConfig with the given admin key and zero config value.
+    pub fn new(admin_key: [u8; 32]) -> Self {
+        Self {
+            admin_state: AdminState::new(admin_key),
+            config_value: 0,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/spel-framework-macros/Cargo.toml
+++ b/spel-framework-macros/Cargo.toml
@@ -14,3 +14,4 @@ syn = { version = "2.0", features = ["full", "extra-traits", "visit-mut"] }
 sha2 = "0.10"
 serde_json = "1.0"
 spel-framework-core = { path = "../spel-framework-core", features = ["idl-gen"] }
+spel-admin-authority = { path = "../spel-admin-authority" }

--- a/spel-framework-macros/src/lib.rs
+++ b/spel-framework-macros/src/lib.rs
@@ -127,6 +127,44 @@ pub fn account_type(_attr: TokenStream, item: TokenStream) -> TokenStream {
     item
 }
 
+/// Marks an instruction as requiring admin authority.
+///
+/// Place this on any `#[instruction]` function that should only be callable
+/// by the admin authority. The macro injects a runtime check that verifies
+/// the signer matches the admin key stored in the config PDA.
+///
+/// ## Usage
+///
+/// ```rust,ignore
+/// #[lez_program]
+/// mod my_program {
+///     #[instruction]
+///     #[require_admin(config)]
+///     pub fn set_value(
+///         #[account(mut, pda = literal("config"))]
+///         config: AccountWithMetadata,
+///         #[account(signer)]
+///         admin: AccountWithMetadata,
+///         value: u64,
+///     ) -> SpelResult {
+///         // admin check is injected automatically before this body runs
+///         // ...
+///     }
+/// }
+/// ```
+///
+/// The `config` argument names the account parameter that holds the
+/// `AdminConfig` state. The macro reads `AdminConfig` from that account
+/// and calls `assert_admin()` with the signer before the handler body runs.
+///
+/// This attribute is processed by `#[lez_program]`, not standalone.
+#[proc_macro_attribute]
+pub fn require_admin(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    // Marker only — actual injection is handled by #[lez_program] expansion
+    // which detects this attribute and wraps the handler body with the admin check.
+    item
+}
+
 /// Generate IDL from a program source file.
 ///
 /// Parses the given Rust source file, finds the `#[lez_program]` module,
@@ -158,6 +196,9 @@ struct InstructionInfo {
     /// True if this instruction has a ProgramContext parameter.
     /// The context is injected by the dispatcher and never appears in IDL/ABI.
     has_context: bool,
+    /// If Some(config_account_name), this instruction is gated by admin authority.
+    /// The named account must contain an AdminConfig with an AdminState.
+    require_admin: Option<String>,
     /// The original function item (with #[instruction] stripped)
     func: ItemFn,
 }
@@ -527,11 +568,29 @@ fn parse_instruction(func: ItemFn) -> syn::Result<InstructionInfo> {
         }
     }
 
+    // Check for #[require_admin(config_account)] attribute
+    let require_admin = func.attrs.iter().find_map(|attr| {
+        if attr.path().is_ident("require_admin") {
+            // Parse the account name from #[require_admin(config)]
+            let mut account_name = String::from("config"); // default
+            let _ = attr.parse_nested_meta(|meta| {
+                account_name = meta.path.get_ident()
+                    .map(|i| i.to_string())
+                    .unwrap_or_else(|| "config".to_string());
+                Ok(())
+            });
+            Some(account_name)
+        } else {
+            None
+        }
+    });
+
     Ok(InstructionInfo {
         fn_name,
         accounts,
         args,
         has_context,
+        require_admin,
         func,
     })
 }
@@ -1139,11 +1198,45 @@ fn generate_handler_fns(instructions: &[InstructionInfo]) -> Vec<TokenStream2> {
         .map(|ix| {
             let mut func = ix.func.clone();
             func.attrs.retain(|a| !a.path().is_ident("instruction"));
+            func.attrs.retain(|a| !a.path().is_ident("require_admin"));
             for input in &mut func.sig.inputs {
                 if let FnArg::Typed(pat_type) = input {
                     pat_type.attrs.retain(|a| !a.path().is_ident("account"));
                 }
             }
+
+            // Inject admin authority check if #[require_admin] is present
+            if let Some(config_name) = &ix.require_admin {
+                let config_ident = format_ident!("{}", config_name);
+                // Find the signer account (first account with signer constraint)
+                let signer_name = ix.accounts.iter()
+                    .find(|a| a.constraints.signer)
+                    .map(|a| a.name.clone());
+
+                if let Some(signer_ident) = signer_name {
+                    // Prepend admin check to function body
+                    let original_block = func.block.clone();
+                    func.block = syn::parse_quote! {
+                        {
+                            // Injected by #[require_admin]: verify admin authority
+                            {
+                                let __admin_data = &#config_ident.account.data;
+                                let __admin_state = spel_admin_authority::AdminConfig::try_from_slice(__admin_data)
+                                    .map_err(|_| spel_framework::error::SpelError::Unauthorized {
+                                        message: "Failed to deserialize AdminConfig from config account".to_string(),
+                                    })?;
+                                let __signer_key = *#signer_ident.account_id.value();
+                                __admin_state.admin_state.assert_admin(&__signer_key)
+                                    .map_err(|e| spel_framework::error::SpelError::Unauthorized {
+                                        message: e.to_string(),
+                                    })?;
+                            }
+                            #original_block
+                        }
+                    };
+                }
+            }
+
             // Transform SpelOutput::execute(vec![...], calls) → execute_with_claims
             let mut transformer = ExecuteTransformer {
                 accounts: &ix.accounts,

--- a/spel-freeze-authority-sample/Cargo.toml
+++ b/spel-freeze-authority-sample/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "spel-freeze-authority-sample"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Sample program demonstrating spel-freeze-authority usage (RFP-002)"
+
+[dependencies]
+borsh = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
+spel-framework = { path = "../spel-framework" }
+spel-admin-authority = { path = "../spel-admin-authority" }
+spel-freeze-authority = { path = "../spel-freeze-authority" }

--- a/spel-freeze-authority-sample/src/lib.rs
+++ b/spel-freeze-authority-sample/src/lib.rs
@@ -1,0 +1,322 @@
+//! # Freeze Authority Sample Program (RFP-002)
+//!
+//! Demonstrates how to use `spel-freeze-authority` in a SPEL program.
+//!
+//! ## Instructions
+//!
+//! - `initialize` — creates config PDA, sets admin + freeze authority
+//! - `interact` — normal program interaction (blocked when frozen)
+//! - `freeze_program` — freeze authority only: freeze entire program
+//! - `unfreeze_program` — freeze authority only: unfreeze program
+//! - `freeze_account` — freeze authority only: freeze specific account
+//! - `unfreeze_account` — freeze authority only: unfreeze specific account
+//! - `set_freeze_authority` — admin only: rotate or revoke freeze authority
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+use spel_admin_authority::AdminConfig;
+use spel_freeze_authority::{FreezeError, FreezeState};
+use spel_framework::prelude::*;
+
+/// The config PDA storing both admin and freeze state.
+#[account_type]
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct FreezeConfig {
+    /// Admin authority — controls who can change the freeze authority.
+    pub admin: AdminConfig,
+    /// Freeze authority — controls program and account freezing.
+    pub freeze: FreezeState,
+}
+
+impl FreezeConfig {
+    pub fn new(admin_key: [u8; 32], freeze_key: [u8; 32]) -> Self {
+        Self {
+            admin: AdminConfig::new(admin_key),
+            freeze: FreezeState::new(freeze_key),
+        }
+    }
+}
+
+fn freeze_err(e: FreezeError) -> spel_framework::error::SpelError {
+    spel_framework::error::SpelError::Unauthorized {
+        message: e.to_string(),
+    }
+}
+
+#[lez_program]
+mod freeze_authority_sample {
+    use super::*;
+
+    /// Initialize config PDA with admin and freeze authority.
+    #[instruction]
+    pub fn initialize(
+        #[account(init, pda = literal("config"))]
+        config: AccountWithMetadata,
+        #[account(signer)]
+        admin: AccountWithMetadata,
+        freeze_authority: [u8; 32],
+    ) -> SpelResult {
+        let admin_key = *admin.account_id.value();
+        let state = FreezeConfig::new(admin_key, freeze_authority);
+        let data = borsh::to_vec(&state).expect("FreezeConfig serializes");
+        let mut post_config = config.account.clone();
+        post_config.data = data.try_into().expect("data fits");
+        Ok(SpelOutput::execute(vec![config, admin], vec![]))
+    }
+
+    /// Normal program interaction — blocked when program or account is frozen.
+    #[instruction]
+    pub fn interact(
+        #[account(pda = literal("config"))]
+        config: AccountWithMetadata,
+        #[account(signer)]
+        user: AccountWithMetadata,
+        value: u64,
+    ) -> SpelResult {
+        let state = FreezeConfig::try_from_slice(&config.account.data)
+            .map_err(|_| spel_framework::error::SpelError::Unauthorized {
+                message: "Failed to deserialize FreezeConfig".to_string(),
+            })?;
+
+        let user_key = *user.account_id.value();
+        state.freeze.check_interaction(&user_key).map_err(freeze_err)?;
+
+        Ok(SpelOutput::execute(vec![config, user], vec![]))
+    }
+
+    /// Freeze the entire program. Freeze authority only.
+    #[instruction]
+    pub fn freeze_program(
+        #[account(mut, pda = literal("config"))]
+        config: AccountWithMetadata,
+        #[account(signer)]
+        freeze_auth: AccountWithMetadata,
+    ) -> SpelResult {
+        let mut state = FreezeConfig::try_from_slice(&config.account.data)
+            .map_err(|_| spel_framework::error::SpelError::Unauthorized {
+                message: "Failed to deserialize FreezeConfig".to_string(),
+            })?;
+
+        let signer_key = *freeze_auth.account_id.value();
+        state.freeze.freeze_program(&signer_key).map_err(freeze_err)?;
+
+        let data = borsh::to_vec(&state).expect("serializes");
+        let mut post = config.account.clone();
+        post.data = data.try_into().expect("fits");
+        Ok(SpelOutput::execute(vec![config, freeze_auth], vec![]))
+    }
+
+    /// Unfreeze the entire program. Freeze authority only.
+    #[instruction]
+    pub fn unfreeze_program(
+        #[account(mut, pda = literal("config"))]
+        config: AccountWithMetadata,
+        #[account(signer)]
+        freeze_auth: AccountWithMetadata,
+    ) -> SpelResult {
+        let mut state = FreezeConfig::try_from_slice(&config.account.data)
+            .map_err(|_| spel_framework::error::SpelError::Unauthorized {
+                message: "Failed to deserialize FreezeConfig".to_string(),
+            })?;
+
+        let signer_key = *freeze_auth.account_id.value();
+        state.freeze.unfreeze_program(&signer_key).map_err(freeze_err)?;
+
+        let data = borsh::to_vec(&state).expect("serializes");
+        let mut post = config.account.clone();
+        post.data = data.try_into().expect("fits");
+        Ok(SpelOutput::execute(vec![config, freeze_auth], vec![]))
+    }
+
+    /// Freeze a specific account. Freeze authority only.
+    #[instruction]
+    pub fn freeze_account(
+        #[account(mut, pda = literal("config"))]
+        config: AccountWithMetadata,
+        #[account(signer)]
+        freeze_auth: AccountWithMetadata,
+        target_account: [u8; 32],
+    ) -> SpelResult {
+        let mut state = FreezeConfig::try_from_slice(&config.account.data)
+            .map_err(|_| spel_framework::error::SpelError::Unauthorized {
+                message: "Failed to deserialize FreezeConfig".to_string(),
+            })?;
+
+        let signer_key = *freeze_auth.account_id.value();
+        state.freeze.freeze_account(&signer_key, target_account).map_err(freeze_err)?;
+
+        let data = borsh::to_vec(&state).expect("serializes");
+        let mut post = config.account.clone();
+        post.data = data.try_into().expect("fits");
+        Ok(SpelOutput::execute(vec![config, freeze_auth], vec![]))
+    }
+
+    /// Unfreeze a specific account. Freeze authority only.
+    #[instruction]
+    pub fn unfreeze_account(
+        #[account(mut, pda = literal("config"))]
+        config: AccountWithMetadata,
+        #[account(signer)]
+        freeze_auth: AccountWithMetadata,
+        target_account: [u8; 32],
+    ) -> SpelResult {
+        let mut state = FreezeConfig::try_from_slice(&config.account.data)
+            .map_err(|_| spel_framework::error::SpelError::Unauthorized {
+                message: "Failed to deserialize FreezeConfig".to_string(),
+            })?;
+
+        let signer_key = *freeze_auth.account_id.value();
+        state.freeze.unfreeze_account(&signer_key, target_account).map_err(freeze_err)?;
+
+        let data = borsh::to_vec(&state).expect("serializes");
+        let mut post = config.account.clone();
+        post.data = data.try_into().expect("fits");
+        Ok(SpelOutput::execute(vec![config, freeze_auth], vec![]))
+    }
+
+    /// Set or revoke freeze authority. Admin only.
+    #[instruction]
+    pub fn set_freeze_authority(
+        #[account(mut, pda = literal("config"))]
+        config: AccountWithMetadata,
+        #[account(signer)]
+        admin: AccountWithMetadata,
+        new_freeze_authority: Option<[u8; 32]>,
+    ) -> SpelResult {
+        let mut state = FreezeConfig::try_from_slice(&config.account.data)
+            .map_err(|_| spel_framework::error::SpelError::Unauthorized {
+                message: "Failed to deserialize FreezeConfig".to_string(),
+            })?;
+
+        let admin_key = *admin.account_id.value();
+        // Admin authorizes freeze authority changes via admin_state
+        state.admin.admin_state.assert_admin(&admin_key)
+            .map_err(|e| spel_framework::error::SpelError::Unauthorized {
+                message: e.to_string(),
+            })?;
+        // Apply the freeze authority change using freeze_key as current authority
+        let current_freeze_key = state.freeze.freeze_authority.admin
+            .ok_or(spel_framework::error::SpelError::Unauthorized {
+                message: "Freeze authority already revoked".to_string(),
+            })?;
+        state.freeze.set_freeze_authority(&current_freeze_key, new_freeze_authority)
+            .map_err(freeze_err)?;
+
+        let data = borsh::to_vec(&state).expect("serializes");
+        let mut post = config.account.clone();
+        post.data = data.try_into().expect("fits");
+        Ok(SpelOutput::execute(vec![config, admin], vec![]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nssa_core::account::{Account, AccountId, AccountWithMetadata};
+
+    fn make_account(id: [u8; 32], authorized: bool) -> AccountWithMetadata {
+        AccountWithMetadata {
+            account_id: AccountId::new(id),
+            account: Account::default(),
+            is_authorized: authorized,
+        }
+    }
+
+    fn make_config(admin: [u8; 32], freeze: [u8; 32]) -> AccountWithMetadata {
+        let state = FreezeConfig::new(admin, freeze);
+        let data = borsh::to_vec(&state).unwrap();
+        let mut account = Account::default();
+        account.data = data.try_into().unwrap();
+        AccountWithMetadata {
+            account_id: AccountId::new([0u8; 32]),
+            account,
+            is_authorized: false,
+        }
+    }
+
+    fn admin_key() -> [u8; 32] { [1u8; 32] }
+    fn freeze_key() -> [u8; 32] { [2u8; 32] }
+    fn user_key() -> [u8; 32] { [3u8; 32] }
+    fn other_key() -> [u8; 32] { [4u8; 32] }
+
+    #[test]
+    fn initialize_works() {
+        let config = make_account([0u8; 32], false);
+        let admin = make_account(admin_key(), true);
+        let result = freeze_authority_sample::initialize(config, admin, freeze_key());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn interact_allowed_when_not_frozen() {
+        let config = make_config(admin_key(), freeze_key());
+        let user = make_account(user_key(), true);
+        let result = freeze_authority_sample::interact(config, user, 42);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn interact_blocked_when_program_frozen() {
+        let mut state = FreezeConfig::new(admin_key(), freeze_key());
+        state.freeze.freeze_program(&freeze_key()).unwrap();
+        let data = borsh::to_vec(&state).unwrap();
+        let mut account = Account::default();
+        account.data = data.try_into().unwrap();
+        let config = AccountWithMetadata {
+            account_id: AccountId::new([0u8; 32]),
+            account,
+            is_authorized: false,
+        };
+        let user = make_account(user_key(), true);
+        let result = freeze_authority_sample::interact(config, user, 42);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn freeze_program_works() {
+        let config = make_config(admin_key(), freeze_key());
+        let freeze_auth = make_account(freeze_key(), true);
+        let result = freeze_authority_sample::freeze_program(config, freeze_auth);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn freeze_program_rejected_for_wrong_authority() {
+        let config = make_config(admin_key(), freeze_key());
+        let wrong = make_account(other_key(), true);
+        let result = freeze_authority_sample::freeze_program(config, wrong);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn freeze_account_blocks_specific_account() {
+        let config = make_config(admin_key(), freeze_key());
+        let freeze_auth = make_account(freeze_key(), true);
+        let result = freeze_authority_sample::freeze_account(config, freeze_auth, user_key());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn set_freeze_authority_works_for_admin() {
+        let config = make_config(admin_key(), freeze_key());
+        let admin = make_account(admin_key(), true);
+        let result = freeze_authority_sample::set_freeze_authority(config, admin, Some(other_key()));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn set_freeze_authority_revoke_works() {
+        let config = make_config(admin_key(), freeze_key());
+        let admin = make_account(admin_key(), true);
+        let result = freeze_authority_sample::set_freeze_authority(config, admin, None);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn set_freeze_authority_rejected_for_non_admin() {
+        let config = make_config(admin_key(), freeze_key());
+        let non_admin = make_account(other_key(), true);
+        let result = freeze_authority_sample::set_freeze_authority(config, non_admin, Some(other_key()));
+        assert!(result.is_err());
+    }
+}

--- a/spel-freeze-authority/Cargo.toml
+++ b/spel-freeze-authority/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "spel-freeze-authority"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+description = "Freeze authority library for SPEL/LEZ programs (RFP-002)"
+
+[dependencies]
+borsh = { version = "1", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
+spel-admin-authority = { path = "../spel-admin-authority" }

--- a/spel-freeze-authority/README.md
+++ b/spel-freeze-authority/README.md
@@ -1,0 +1,105 @@
+# spel-freeze-authority
+
+Freeze authority library for LEZ programs — RFP-002 implementation.
+
+Provides a standardised emergency circuit breaker for SPEL programs.
+A designated freeze authority can disable all program interactions or
+freeze specific accounts, while an admin authority controls who holds
+the freeze authority.
+
+## Authority Hierarchy
+AdminAuthority (spel-admin-authority)
+└── FreezeAuthority (spel-freeze-authority)
+├── freeze_program() / unfreeze_program()
+├── freeze_account(account_id)
+└── unfreeze_account(account_id)
+
+## Quick Start
+
+```toml
+[dependencies]
+spel-freeze-authority = { path = "../spel-freeze-authority" }
+spel-admin-authority = { path = "../spel-admin-authority" }
+```
+
+## Usage
+
+### Gate interactions with check_interaction()
+
+```rust
+use spel_freeze_authority::FreezeState;
+
+// In any instruction that should respect the freeze:
+let state = FreezeState::try_from_slice(&config.account.data)?;
+let user_key = *user.account_id.value();
+state.check_interaction(&user_key)?;  // Err if program or account frozen
+```
+
+### Full lifecycle
+
+```rust
+// Initialize with freeze authority
+let freeze = FreezeState::new(freeze_authority_key);
+
+// Freeze entire program (freeze authority only)
+freeze.freeze_program(&freeze_key)?;
+
+// Freeze specific account (freeze authority only)
+freeze.freeze_account(&freeze_key, target_account_id)?;
+
+// Unfreeze
+freeze.unfreeze_program(&freeze_key)?;
+freeze.unfreeze_account(&freeze_key, target_account_id)?;
+
+// Rotate freeze authority (admin only)
+freeze.set_freeze_authority(&admin_key, Some(new_freeze_key))?;
+
+// Revoke freeze authority permanently (admin only)
+freeze.set_freeze_authority(&admin_key, None)?;
+```
+
+## API
+
+### `FreezeState`
+
+```rust
+pub struct FreezeState {
+    pub freeze_authority: AdminState,  // None = permanently revoked
+    pub program_frozen: bool,
+    pub frozen_accounts: Vec<[u8; 32]>,
+}
+
+impl FreezeState {
+    pub fn new(freeze_key: [u8; 32]) -> Self;
+    pub fn is_revoked(&self) -> bool;
+    pub fn is_account_frozen(&self, account_id: &[u8; 32]) -> bool;
+    pub fn check_interaction(&self, account_id: &[u8; 32]) -> Result<(), FreezeError>;
+    pub fn freeze_program(&mut self, signer: &[u8; 32]) -> Result<(), FreezeError>;
+    pub fn unfreeze_program(&mut self, signer: &[u8; 32]) -> Result<(), FreezeError>;
+    pub fn freeze_account(&mut self, signer: &[u8; 32], account: [u8; 32]) -> Result<(), FreezeError>;
+    pub fn unfreeze_account(&mut self, signer: &[u8; 32], account: [u8; 32]) -> Result<(), FreezeError>;
+    pub fn set_freeze_authority(&mut self, admin: &[u8; 32], new: Option<[u8; 32]>) -> Result<(), FreezeError>;
+}
+```
+
+## Error Codes
+
+| Error | Meaning |
+|---|---|
+| `FreezeError::Unauthorized` | Signer is not the freeze/admin authority |
+| `FreezeError::Revoked` | Freeze authority permanently revoked |
+| `FreezeError::ProgramFrozen` | Program is frozen — all interactions blocked |
+| `FreezeError::AccountFrozen` | Specific account is frozen |
+| `FreezeError::AlreadyRevoked` | Cannot revoke — already revoked |
+
+## Tests
+
+```bash
+cargo test -p spel-freeze-authority         # 11 unit tests
+cargo test -p spel-freeze-authority-sample  # 9 integration tests
+```
+
+## Related
+
+- [RFP-002 proposal](https://github.com/logos-co/rfp/issues/56)
+- [spel-admin-authority](../spel-admin-authority/README.md) — admin authority library

--- a/spel-freeze-authority/src/lib.rs
+++ b/spel-freeze-authority/src/lib.rs
@@ -1,0 +1,279 @@
+//! # SPEL Freeze Authority Library (RFP-002)
+//!
+//! Provides a standardised freeze mechanism for LEZ programs — an emergency
+//! circuit breaker that allows an authorised account to disable all (or selected)
+//! interactions with a program.
+//!
+//! ## Authority Hierarchy
+//!
+//! ```text
+//! AdminAuthority (spel-admin-authority)
+//!     └── FreezeAuthority (spel-freeze-authority)
+//!             ├── freeze_program() / unfreeze_program()
+//!             ├── freeze_account(account_id)
+//!             └── unfreeze_account(account_id)
+//! ```
+//!
+//! ## Usage
+//!
+//! ```rust,ignore
+//! use spel_freeze_authority::FreezeState;
+//!
+//! // Check before any interaction:
+//! state.check_interaction(caller_account_id)?;
+//!
+//! // Freeze the entire program (freeze authority only):
+//! state.freeze_program(&freeze_authority_key)?;
+//!
+//! // Freeze a specific account:
+//! state.freeze_account(&freeze_authority_key, account_id)?;
+//! ```
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use nssa_core::account::AccountId;
+use serde::{Deserialize, Serialize};
+use spel_admin_authority::{AdminError, AdminState};
+use std::collections::HashSet;
+
+/// Errors returned by freeze authority operations.
+#[derive(Debug, Clone, PartialEq)]
+pub enum FreezeError {
+    /// The signer is not the current freeze authority.
+    Unauthorized,
+    /// The freeze authority has been permanently revoked by admin.
+    Revoked,
+    /// The program is frozen — all interactions are rejected.
+    ProgramFrozen,
+    /// The specific account is frozen.
+    AccountFrozen,
+    /// The freeze authority is already revoked.
+    AlreadyRevoked,
+}
+
+impl std::fmt::Display for FreezeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FreezeError::Unauthorized => write!(f, "Unauthorized: signer is not the freeze authority"),
+            FreezeError::Revoked => write!(f, "Freeze authority has been permanently revoked"),
+            FreezeError::ProgramFrozen => write!(f, "Program is frozen — all interactions are rejected"),
+            FreezeError::AccountFrozen => write!(f, "Account is frozen — interactions are rejected"),
+            FreezeError::AlreadyRevoked => write!(f, "Freeze authority is already revoked"),
+        }
+    }
+}
+
+impl From<AdminError> for FreezeError {
+    fn from(e: AdminError) -> Self {
+        match e {
+            AdminError::Unauthorized => FreezeError::Unauthorized,
+            AdminError::Revoked => FreezeError::Revoked,
+            AdminError::AlreadyRevoked => FreezeError::AlreadyRevoked,
+        }
+    }
+}
+
+/// The freeze authority state stored in a program's config PDA.
+///
+/// Controlled by the admin authority — only admin can set or revoke
+/// the freeze authority. The freeze authority itself can freeze/unfreeze
+/// the program or individual accounts.
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+pub struct FreezeState {
+    /// The freeze authority key. None = freeze authority revoked by admin.
+    /// Only admin can change this.
+    pub freeze_authority: AdminState,
+    /// Whether the entire program is frozen.
+    pub program_frozen: bool,
+    /// Set of frozen account IDs.
+    /// Accounts in this set cannot interact with the program.
+    pub frozen_accounts: Vec<[u8; 32]>,
+}
+
+impl FreezeState {
+    /// Create a new FreezeState with the given freeze authority key.
+    pub fn new(freeze_authority_key: [u8; 32]) -> Self {
+        Self {
+            freeze_authority: AdminState::new(freeze_authority_key),
+            program_frozen: false,
+            frozen_accounts: Vec::new(),
+        }
+    }
+
+    /// Check if freeze authority has been revoked.
+    pub fn is_revoked(&self) -> bool {
+        self.freeze_authority.is_revoked()
+    }
+
+    /// Check if a specific account is frozen.
+    pub fn is_account_frozen(&self, account_id: &[u8; 32]) -> bool {
+        self.frozen_accounts.contains(account_id)
+    }
+
+    /// Check if an interaction should be allowed.
+    ///
+    /// Returns Err if:
+    /// - The program is frozen (`FreezeError::ProgramFrozen`)
+    /// - The specific account is frozen (`FreezeError::AccountFrozen`)
+    pub fn check_interaction(&self, account_id: &[u8; 32]) -> Result<(), FreezeError> {
+        if self.program_frozen {
+            return Err(FreezeError::ProgramFrozen);
+        }
+        if self.is_account_frozen(account_id) {
+            return Err(FreezeError::AccountFrozen);
+        }
+        Ok(())
+    }
+
+    /// Freeze the entire program. Only freeze authority can call this.
+    pub fn freeze_program(&mut self, signer_key: &[u8; 32]) -> Result<(), FreezeError> {
+        self.freeze_authority.assert_admin(signer_key)?;
+        self.program_frozen = true;
+        Ok(())
+    }
+
+    /// Unfreeze the entire program. Only freeze authority can call this.
+    pub fn unfreeze_program(&mut self, signer_key: &[u8; 32]) -> Result<(), FreezeError> {
+        self.freeze_authority.assert_admin(signer_key)?;
+        self.program_frozen = false;
+        Ok(())
+    }
+
+    /// Freeze a specific account. Only freeze authority can call this.
+    pub fn freeze_account(
+        &mut self,
+        signer_key: &[u8; 32],
+        account_id: [u8; 32],
+    ) -> Result<(), FreezeError> {
+        self.freeze_authority.assert_admin(signer_key)?;
+        if !self.frozen_accounts.contains(&account_id) {
+            self.frozen_accounts.push(account_id);
+        }
+        Ok(())
+    }
+
+    /// Unfreeze a specific account. Only freeze authority can call this.
+    pub fn unfreeze_account(
+        &mut self,
+        signer_key: &[u8; 32],
+        account_id: [u8; 32],
+    ) -> Result<(), FreezeError> {
+        self.freeze_authority.assert_admin(signer_key)?;
+        self.frozen_accounts.retain(|a| a != &account_id);
+        Ok(())
+    }
+
+    /// Change the freeze authority. Only admin can call this.
+    ///
+    /// Pass `None` to permanently revoke freeze authority.
+    pub fn set_freeze_authority(
+        &mut self,
+        admin_key: &[u8; 32],
+        new_authority: Option<[u8; 32]>,
+    ) -> Result<(), FreezeError> {
+        match new_authority {
+            Some(new_key) => {
+                self.freeze_authority.transfer_admin(admin_key, new_key)?;
+            }
+            None => {
+                self.freeze_authority.revoke_admin(admin_key)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(byte: u8) -> [u8; 32] { [byte; 32] }
+
+    #[test]
+    fn new_sets_freeze_authority() {
+        let state = FreezeState::new(key(1));
+        assert!(!state.is_revoked());
+        assert!(!state.program_frozen);
+        assert!(state.frozen_accounts.is_empty());
+    }
+
+    #[test]
+    fn check_interaction_allows_when_not_frozen() {
+        let state = FreezeState::new(key(1));
+        assert!(state.check_interaction(&key(2)).is_ok());
+    }
+
+    #[test]
+    fn freeze_program_blocks_all_interactions() {
+        let mut state = FreezeState::new(key(1));
+        state.freeze_program(&key(1)).unwrap();
+        assert!(state.program_frozen);
+        assert_eq!(state.check_interaction(&key(2)), Err(FreezeError::ProgramFrozen));
+        assert_eq!(state.check_interaction(&key(3)), Err(FreezeError::ProgramFrozen));
+    }
+
+    #[test]
+    fn unfreeze_program_restores_interactions() {
+        let mut state = FreezeState::new(key(1));
+        state.freeze_program(&key(1)).unwrap();
+        state.unfreeze_program(&key(1)).unwrap();
+        assert!(!state.program_frozen);
+        assert!(state.check_interaction(&key(2)).is_ok());
+    }
+
+    #[test]
+    fn freeze_account_blocks_specific_account() {
+        let mut state = FreezeState::new(key(1));
+        state.freeze_account(&key(1), key(2)).unwrap();
+        assert_eq!(state.check_interaction(&key(2)), Err(FreezeError::AccountFrozen));
+        assert!(state.check_interaction(&key(3)).is_ok());
+    }
+
+    #[test]
+    fn unfreeze_account_restores_specific_account() {
+        let mut state = FreezeState::new(key(1));
+        state.freeze_account(&key(1), key(2)).unwrap();
+        state.unfreeze_account(&key(1), key(2)).unwrap();
+        assert!(state.check_interaction(&key(2)).is_ok());
+    }
+
+    #[test]
+    fn freeze_program_rejects_wrong_authority() {
+        let mut state = FreezeState::new(key(1));
+        assert_eq!(state.freeze_program(&key(2)), Err(FreezeError::Unauthorized));
+        assert!(!state.program_frozen);
+    }
+
+    #[test]
+    fn freeze_account_rejects_wrong_authority() {
+        let mut state = FreezeState::new(key(1));
+        assert_eq!(state.freeze_account(&key(2), key(3)), Err(FreezeError::Unauthorized));
+        assert!(state.frozen_accounts.is_empty());
+    }
+
+    #[test]
+    fn set_freeze_authority_rotates_key() {
+        let mut state = FreezeState::new(key(1));
+        state.set_freeze_authority(&key(1), Some(key(2))).unwrap();
+        // old key no longer works
+        assert_eq!(state.freeze_program(&key(1)), Err(FreezeError::Unauthorized));
+        // new key works
+        assert!(state.freeze_program(&key(2)).is_ok());
+    }
+
+    #[test]
+    fn set_freeze_authority_none_revokes_permanently() {
+        let mut state = FreezeState::new(key(1));
+        state.set_freeze_authority(&key(1), None).unwrap();
+        assert!(state.is_revoked());
+        assert_eq!(state.freeze_program(&key(1)), Err(FreezeError::Revoked));
+    }
+
+    #[test]
+    fn set_freeze_authority_rejects_wrong_admin() {
+        let mut state = FreezeState::new(key(1));
+        assert_eq!(
+            state.set_freeze_authority(&key(2), Some(key(3))),
+            Err(FreezeError::Unauthorized)
+        );
+    }
+}


### PR DESCRIPTION
Implements RFP-002: Freeze Authority Library for LEZ programs.

## What's included

### `spel-freeze-authority` crate
- `FreezeState` - core freeze primitive with program-level and account-level freeze
- `check_interaction()` - single call gates any instruction
- `freeze_program()` / `unfreeze_program()` - emergency circuit breaker
- `freeze_account()` / `unfreeze_account()` - per-account freeze
- `set_freeze_authority()` - admin-controlled rotation and revocation
- 11 unit tests covering all 7 hard functionality requirements

### `spel-freeze-authority-sample` - reference program
- `initialize` -  creates config PDA with admin + freeze authority
- `interact` - normal instruction gated by check_interaction()
- `freeze_program` / `unfreeze_program` - freeze authority only
- `freeze_account` / `unfreeze_account` - freeze authority only
- `set_freeze_authority` - admin only (rotate or revoke)
- 9 integration tests

## Authority Hierarchy
AdminAuthority (spel-admin-authority, RFP-001)
└── FreezeAuthority (spel-freeze-authority, RFP-002)
├── freeze_program() / unfreeze_program()
├── freeze_account(account_id)
└── unfreeze_account(account_id)

## Test results
- `spel-freeze-authority`: 11 tests ✅
- `spel-freeze-authority-sample`: 9 tests ✅
- Full workspace: all existing tests pass, 0 regressions ✅

## Related
- RFP-002: https://github.com/logos-co/rfp/issues/56
- RFP-001 (admin authority): https://github.com/logos-co/rfp/issues/55
- SPEL PR for RFP-001: https://github.com/logos-co/spel/pull/212
