### PR TITLE
feat: spel program-id --format + eliminate FFI helper duplication

### DIFF
--- a/spel-cli/src/cli.rs
+++ b/spel-cli/src/cli.rs
@@ -20,7 +20,8 @@ pub fn print_help(idl: &SpelIdl, binary_name: &str) {
     println!("  --bin-<NAME> <FILE>        Additional program binary (auto-fills --<NAME>-program-id)");
     println!();
     println!("COMMANDS:");
-    println!("  inspect <FILE> [FILE...]   Print ProgramId for ELF binary(ies)");
+    println!("  program-id <FILE> [--format hex|json]  Extract ProgramId from ELF binary(ies)");
+    println!("  inspect <ACCOUNT-ID> --type <TYPE>     Decode account data");
     println!("  generate-idl [PATH]        Generate IDL JSON (auto-detects methods/guest/src/bin/ if no path given)");
     println!("  idl                        Print IDL information");
 

--- a/spel-cli/src/hex.rs
+++ b/spel-cli/src/hex.rs
@@ -1,7 +1,5 @@
 //! Hex encoding/decoding utilities.
 
-use base58::FromBase58;
-
 pub fn hex_encode(bytes: &[u8]) -> String {
     bytes.iter().map(|b| format!("{:02x}", b)).collect()
 }
@@ -22,38 +20,7 @@ pub fn hex_decode(hex: &str) -> Result<Vec<u8>, String> {
 /// Decode a 32-byte value from base58 or hex string.
 /// Strips "Public/" or "Private/" prefix if present before decoding.
 pub fn decode_bytes_32(input: &str) -> Result<[u8; 32], String> {
-    let input = input
-        .strip_prefix("Public/")
-        .or_else(|| input.strip_prefix("Private/"))
-        .unwrap_or(input);
-
-    if let Ok(bytes) = input.from_base58() {
-        if bytes.len() == 32 {
-            let mut arr = [0u8; 32];
-            arr.copy_from_slice(&bytes);
-            return Ok(arr);
-        }
-        return Err(format!(
-            "Base58 decoded to {} bytes, expected 32",
-            bytes.len()
-        ));
-    }
-
-    let hex = input
-        .strip_prefix("0x")
-        .or_else(|| input.strip_prefix("0X"))
-        .unwrap_or(input);
-    let bytes = hex_decode(hex)?;
-    if bytes.len() == 32 {
-        let mut arr = [0u8; 32];
-        arr.copy_from_slice(&bytes);
-        Ok(arr)
-    } else {
-        Err(format!(
-            "Expected 32 bytes, got {} (provide base58 or 64 hex chars)",
-            bytes.len()
-        ))
-    }
+    spel_framework_core::pda::parse_bytes32(input)
 }
 
 /// Parse an account ID, returning the decoded bytes and whether it had a "Private/" prefix.

--- a/spel-cli/src/inspect.rs
+++ b/spel-cli/src/inspect.rs
@@ -5,12 +5,27 @@ use crate::hex::hex_encode;
 use std::fs;
 
 /// Inspect one or more ELF binary files and print their ProgramIds.
-pub fn inspect_binaries(paths: &[String]) {
+///
+/// `format`:
+/// - `None` / `"text"` — human-readable multi-line output (default)
+/// - `"hex"` — one 64-char ImageID hex string per file (machine-readable; useful for
+///   `PROGRAM_ID=$(spel inspect prog.bin --format hex)`)
+/// - `"json"` — JSON object per file with `path`, `program_id_decimal`,
+///   `program_id_hex`, and `image_id_hex` fields
+pub fn inspect_binaries(paths: &[String], format: Option<&str>) {
     if paths.is_empty() {
         eprintln!("Usage: spel inspect <FILE> [FILE...]");
         eprintln!("  Prints the ProgramId ([u32; 8]) for each ELF binary.");
+        eprintln!();
+        eprintln!("Options:");
+        eprintln!("  --format <fmt>   Output format: text (default) | hex | json");
         std::process::exit(1);
     }
+    let fmt = format.unwrap_or("text");
+    if fmt == "json" && paths.len() > 1 {
+        print!("[");
+    }
+    let mut first = true;
     for path in paths {
         let bytes = match fs::read(path) {
             Ok(b) => b,
@@ -22,18 +37,42 @@ pub fn inspect_binaries(paths: &[String]) {
         match Program::new(bytes) {
             Ok(program) => {
                 let id = program.id();
-                let id_strs: Vec<String> = id.iter().map(|w| w.to_string()).collect();
-                let id_hex: Vec<String> = id.iter().map(|w| format!("{:08x}", w)).collect();
-                println!("📦 {}", path);
-                println!("   ProgramId (decimal): {}", id_strs.join(","));
-                println!("   ProgramId (hex):     {}", id_hex.join(","));
                 let id_bytes: Vec<u8> = id.iter().flat_map(|w| w.to_le_bytes()).collect();
-                println!("   ImageID (hex bytes): {}", hex_encode(&id_bytes));
-                println!();
+                let image_id_hex = hex_encode(&id_bytes);
+                match fmt {
+                    "hex" => println!("{}", image_id_hex),
+                    "json" => {
+                        let id_strs: Vec<String> = id.iter().map(|w| w.to_string()).collect();
+                        let id_hex: Vec<String> = id.iter().map(|w| format!("{:08x}", w)).collect();
+                        if paths.len() > 1 {
+                            if !first { print!(","); }
+                            println!();
+                        }
+                        println!(
+                            "{{\"path\":\"{path}\",\"program_id_decimal\":\"{}\",\"program_id_hex\":\"{}\",\"image_id_hex\":\"{}\"}}",
+                            id_strs.join(","),
+                            id_hex.join(","),
+                            image_id_hex,
+                        );
+                        first = false;
+                    }
+                    _ => {
+                        let id_strs: Vec<String> = id.iter().map(|w| w.to_string()).collect();
+                        let id_hex: Vec<String> = id.iter().map(|w| format!("{:08x}", w)).collect();
+                        println!("📦 {}", path);
+                        println!("   ProgramId (decimal): {}", id_strs.join(","));
+                        println!("   ProgramId (hex):     {}", id_hex.join(","));
+                        println!("   ImageID (hex bytes): {}", image_id_hex);
+                        println!();
+                    }
+                }
             }
             Err(e) => {
                 eprintln!("❌ {}: failed to load as program: {:?}", path, e);
             }
         }
+    }
+    if fmt == "json" && paths.len() > 1 {
+        println!("\n]");
     }
 }

--- a/spel-cli/src/inspect.rs
+++ b/spel-cli/src/inspect.rs
@@ -4,17 +4,17 @@ use nssa::program::Program;
 use crate::hex::hex_encode;
 use std::fs;
 
-/// Inspect one or more ELF binary files and print their ProgramIds.
+/// Extract and print ProgramIds from one or more ELF binary files.
 ///
 /// `format`:
 /// - `None` / `"text"` — human-readable multi-line output (default)
 /// - `"hex"` — one 64-char ImageID hex string per file (machine-readable; useful for
-///   `PROGRAM_ID=$(spel inspect prog.bin --format hex)`)
+///   `PROGRAM_ID=$(spel program-id prog.bin --format hex)`)
 /// - `"json"` — JSON object per file with `path`, `program_id_decimal`,
 ///   `program_id_hex`, and `image_id_hex` fields
 pub fn inspect_binaries(paths: &[String], format: Option<&str>) {
     if paths.is_empty() {
-        eprintln!("Usage: spel inspect <FILE> [FILE...]");
+        eprintln!("Usage: spel program-id <FILE> [FILE...]");
         eprintln!("  Prints the ProgramId ([u32; 8]) for each ELF binary.");
         eprintln!();
         eprintln!("Options:");
@@ -22,6 +22,10 @@ pub fn inspect_binaries(paths: &[String], format: Option<&str>) {
         std::process::exit(1);
     }
     let fmt = format.unwrap_or("text");
+    if !matches!(fmt, "text" | "hex" | "json") {
+        eprintln!("❌ --format: unknown format '{}'. Expected: text, hex, json", fmt);
+        std::process::exit(1);
+    }
     if fmt == "json" && paths.len() > 1 {
         print!("[");
     }
@@ -48,12 +52,13 @@ pub fn inspect_binaries(paths: &[String], format: Option<&str>) {
                             if !first { print!(","); }
                             println!();
                         }
-                        println!(
-                            "{{\"path\":\"{path}\",\"program_id_decimal\":\"{}\",\"program_id_hex\":\"{}\",\"image_id_hex\":\"{}\"}}",
-                            id_strs.join(","),
-                            id_hex.join(","),
-                            image_id_hex,
-                        );
+                        let obj = serde_json::json!({
+                            "path": path,
+                            "program_id_decimal": id_strs.join(","),
+                            "program_id_hex": id_hex.join(","),
+                            "image_id_hex": image_id_hex,
+                        });
+                        print!("{}", obj);
                         first = false;
                     }
                     _ => {

--- a/spel-cli/src/lib.rs
+++ b/spel-cli/src/lib.rs
@@ -48,6 +48,7 @@ pub async fn run() {
     let mut dry_run: Option<tx::DryRunFormat> = None;
     let mut type_name: Option<String> = None;
     let mut data_hex: Option<String> = None;
+    let mut inspect_format: Option<String> = None;
     let mut extra_bins: HashMap<String, String> = HashMap::new();
     let mut remaining_args: Vec<String> = vec![args[0].clone()];
     let mut used_separator = false;
@@ -92,6 +93,13 @@ pub async fn run() {
                         process::exit(1);
                     }
                 });
+            }
+            "--format" => {
+                i += 1;
+                if i < args.len() { inspect_format = Some(args[i].clone()); }
+            }
+            s if s.starts_with("--format=") => {
+                inspect_format = Some(s["--format=".len()..].to_string());
             }
             s if s.starts_with("--bin-") => {
                 let name = s.strip_prefix("--bin-").unwrap().to_string();
@@ -213,7 +221,7 @@ pub async fn run() {
                 return;
             }
             "inspect" if type_name.is_none() && data_hex.is_none() && idl_path.is_empty() => {
-                inspect_binaries(&remaining_args[2..]);
+                inspect_binaries(&remaining_args[2..], inspect_format.as_deref());
                 return;
             }
             "inspect" => {
@@ -370,7 +378,7 @@ pub async fn run() {
             ).await;
         }
         Some("inspect") => {
-            inspect_binaries(&remaining_args[2..]);
+            inspect_binaries(&remaining_args[2..], inspect_format.as_deref());
         }
         Some("pda") => {
             compute_pda_command(&idl, program_path.as_deref(), program_id_hex.as_deref(), &remaining_args[2..]);

--- a/spel-cli/src/lib.rs
+++ b/spel-cli/src/lib.rs
@@ -96,10 +96,19 @@ pub async fn run() {
             }
             "--format" => {
                 i += 1;
-                if i < args.len() { inspect_format = Some(args[i].clone()); }
+                if i >= args.len() || args[i].starts_with('-') {
+                    eprintln!("❌ --format requires a value: text, hex, or json");
+                    process::exit(1);
+                }
+                inspect_format = Some(args[i].clone());
             }
             s if s.starts_with("--format=") => {
-                inspect_format = Some(s["--format=".len()..].to_string());
+                let val = &s["--format=".len()..];
+                if val.is_empty() {
+                    eprintln!("❌ --format requires a value: text, hex, or json");
+                    process::exit(1);
+                }
+                inspect_format = Some(val.to_string());
             }
             s if s.starts_with("--bin-") => {
                 let name = s.strip_prefix("--bin-").unwrap().to_string();

--- a/spel-cli/src/lib.rs
+++ b/spel-cli/src/lib.rs
@@ -220,12 +220,11 @@ pub async fn run() {
                 init_project(name, lez_tag.as_deref(), spel_tag.as_deref(), lez_rev.as_deref(), spel_rev.as_deref());
                 return;
             }
-            "inspect" if type_name.is_none() && data_hex.is_none() && idl_path.is_empty() => {
+            "program-id" => {
                 inspect_binaries(&remaining_args[2..], inspect_format.as_deref());
                 return;
             }
             "inspect" => {
-                // Account inspection mode: --type and --idl required
                 if idl_path.is_empty() {
                     eprintln!("Account inspection requires --idl <IDL_FILE>");
                     process::exit(1);
@@ -330,8 +329,8 @@ pub async fn run() {
         eprintln!();
         eprintln!("Commands that don't need --idl:");
         eprintln!("  init <name>              Scaffold a new SPEL project");
-        eprintln!("  inspect <FILE> [FILE...]  Print ProgramId for ELF binary(ies)");
-        eprintln!("  inspect <ACCOUNT-ID> --idl <IDL> --type <TYPE>  Decode account data");
+        eprintln!("  program-id <FILE> [FILE...]  Extract ProgramId from ELF binary(ies)");
+        eprintln!("  inspect <ACCOUNT-ID> --idl <IDL> --type <TYPE>   Decode account data");
         eprintln!("  generate-idl [PATH]      Generate IDL JSON from a program source file or project directory");
         eprintln!();
         eprintln!("  pda <ACCOUNT> [--seed-arg VALUE...]  Compute a PDA defined in the IDL");
@@ -365,7 +364,10 @@ pub async fn run() {
         Some("idl") => {
             println!("{}", serde_json::to_string_pretty(&idl).unwrap());
         }
-        Some("inspect") if type_name.is_some() => {
+        Some("program-id") => {
+            inspect_binaries(&remaining_args[2..], inspect_format.as_deref());
+        }
+        Some("inspect") => {
             let account_id = remaining_args.get(2).unwrap_or_else(|| {
                 eprintln!("Usage: {} inspect <account-id> --idl <IDL> --type <TypeName> [--data <hex>]", args[0]);
                 process::exit(1);
@@ -376,9 +378,6 @@ pub async fn run() {
                 type_name.as_ref().unwrap(),
                 data_hex.as_deref(),
             ).await;
-        }
-        Some("inspect") => {
-            inspect_binaries(&remaining_args[2..], inspect_format.as_deref());
         }
         Some("pda") => {
             compute_pda_command(&idl, program_path.as_deref(), program_id_hex.as_deref(), &remaining_args[2..]);

--- a/spel-client-gen/src/ffi_codegen.rs
+++ b/spel-client-gen/src/ffi_codegen.rs
@@ -47,11 +47,9 @@ pub fn generate_ffi(idl: &SpelIdl, idl_json: &str) -> Result<String, String> {
     writeln!(out, "use std::ffi::{{CStr, CString}};").unwrap();
     writeln!(out, "use std::os::raw::c_char;").unwrap();
     writeln!(out, "use serde_json::{{Value, json}};").unwrap();
-    writeln!(out, "use sha2::{{Sha256, Digest}};").unwrap();
     writeln!(out, "use nssa::{{AccountId, ProgramId, PublicTransaction}};").unwrap();
     writeln!(out, "use nssa::public_transaction::{{Message, WitnessSet}};").unwrap();
     writeln!(out, "use nssa::program::Program;").unwrap();
-    writeln!(out, "use nssa_core::program::PdaSeed;").unwrap();
     writeln!(out, "use sequencer_service_rpc::RpcClient as _;").unwrap();
     writeln!(out, "use wallet::WalletCore;").unwrap();
 
@@ -124,51 +122,9 @@ pub fn generate_ffi(idl: &SpelIdl, idl_json: &str) -> Result<String, String> {
     writeln!(out, "}}").unwrap();
     writeln!(out).unwrap();
 
-    // PDA helper — kept for potential use; all current call sites use compute_pda_with_program.
-    writeln!(out, "#[allow(dead_code)]").unwrap();
-    writeln!(out, "fn compute_pda(seeds: &[&[u8]]) -> AccountId {{").unwrap();
-    writeln!(out, "    let mut hasher = Sha256::new();").unwrap();
-    writeln!(out, "    for seed in seeds {{").unwrap();
-    writeln!(out, "        let mut padded = [0u8; 32];").unwrap();
-    writeln!(out, "        let len = seed.len().min(32);").unwrap();
-    writeln!(out, "        padded[..len].copy_from_slice(&seed[..len]);").unwrap();
-    writeln!(out, "        hasher.update(&padded);").unwrap();
-    writeln!(out, "    }}").unwrap();
-    writeln!(out, "    let hash: [u8; 32] = hasher.finalize().into();").unwrap();
-    writeln!(out, "    AccountId::new(hash)").unwrap();
-    writeln!(out, "}}").unwrap();
-    writeln!(out).unwrap();
-    // compute_pda_with_program: canonical PDA derivation used by fetch functions.
-    // Matches spel_framework_core::pda::compute_pda exactly:
-    //   single seed  → use padded 32-byte seed directly (no SHA-256)
-    //   multi-seed   → SHA-256 of each padded 32-byte seed
-    // Then derives AccountId from (program_id, PdaSeed) so PDAs are program-specific.
-    writeln!(out, "#[allow(dead_code)]").unwrap();
-    writeln!(out, "fn pda_seed_bytes(seeds: &[&[u8]]) -> Result<[u8; 32], String> {{").unwrap();
-    writeln!(out, "    if seeds.is_empty() {{").unwrap();
-    writeln!(out, "        return Err(\"PDA requires at least one seed\".into());").unwrap();
-    writeln!(out, "    }}").unwrap();
-    writeln!(out, "    if seeds.len() == 1 {{").unwrap();
-    writeln!(out, "        let len = seeds[0].len();").unwrap();
-    writeln!(out, "        if len > 32 {{ return Err(format!(\"PDA seed exceeds 32 bytes ({{len}})\")); }}").unwrap();
-    writeln!(out, "        let mut padded = [0u8; 32];").unwrap();
-    writeln!(out, "        padded[..len].copy_from_slice(&seeds[0][..len]);").unwrap();
-    writeln!(out, "        Ok(padded)").unwrap();
-    writeln!(out, "    }} else {{").unwrap();
-    writeln!(out, "        let mut hasher = Sha256::new();").unwrap();
-    writeln!(out, "        for seed in seeds {{").unwrap();
-    writeln!(out, "            let len = seed.len();").unwrap();
-    writeln!(out, "            if len > 32 {{ return Err(format!(\"PDA seed exceeds 32 bytes ({{len}})\")); }}").unwrap();
-    writeln!(out, "            let mut padded = [0u8; 32];").unwrap();
-    writeln!(out, "            padded[..len].copy_from_slice(&seed[..len]);").unwrap();
-    writeln!(out, "            hasher.update(&padded);").unwrap();
-    writeln!(out, "        }}").unwrap();
-    writeln!(out, "        Ok(hasher.finalize().into())").unwrap();
-    writeln!(out, "    }}").unwrap();
-    writeln!(out, "}}").unwrap();
-    writeln!(out, "#[allow(dead_code)]").unwrap();
+    // PDA derivation delegates to spel_framework_core::pda::compute_pda_raw.
     writeln!(out, "fn compute_pda_with_program(program_id: &ProgramId, seeds: &[&[u8]]) -> Result<AccountId, String> {{").unwrap();
-    writeln!(out, "    Ok(AccountId::for_public_pda(program_id, &PdaSeed::new(pda_seed_bytes(seeds)?)))").unwrap();
+    writeln!(out, "    spel_framework_core::pda::compute_pda_raw(program_id, seeds)").unwrap();
     writeln!(out, "}}").unwrap();
     writeln!(out).unwrap();
 
@@ -191,36 +147,13 @@ pub fn generate_ffi(idl: &SpelIdl, idl_json: &str) -> Result<String, String> {
     writeln!(out, "}}").unwrap();
     writeln!(out).unwrap();
 
-    // parse_account_id
+    // parse_account_id / parse_bytes32 delegate to spel_framework_core::pda::parse_bytes32.
     writeln!(out, "fn parse_account_id(s: &str) -> Result<AccountId, String> {{").unwrap();
-    writeln!(out, "    let raw = s;\n    let s = s.strip_prefix(\"Public/\").or_else(|| s.strip_prefix(\"Private/\")).unwrap_or(s);").unwrap();
-    writeln!(out, "    if let Ok(id) = s.parse() {{ return Ok(id); }}").unwrap();
-    writeln!(out, "    let s = s.trim_start_matches(\"0x\");").unwrap();
-    writeln!(out, "    if s.len() == 64 {{").unwrap();
-    writeln!(out, "        let bytes = hex::decode(s).map_err(|e| format!(\"invalid hex: {{}}\", e))?;").unwrap();
-    writeln!(out, "        let mut arr = [0u8; 32]; arr.copy_from_slice(&bytes);").unwrap();
-    writeln!(out, "        return Ok(AccountId::new(arr));").unwrap();
-    writeln!(out, "    }}").unwrap();
-    writeln!(out, "    Err(format!(\"invalid AccountId: {{}}\", raw))").unwrap();
+    writeln!(out, "    spel_framework_core::pda::parse_bytes32(s).map(AccountId::new)").unwrap();
     writeln!(out, "}}").unwrap();
     writeln!(out).unwrap();
-
-    // parse_bytes32 — same inputs as parse_account_id but returns the raw [u8; 32].
-    // Used for IDL fields typed [u8; 32] (PDA seed bytes, keys stored as raw arrays).
     writeln!(out, "fn parse_bytes32(s: &str) -> Result<[u8; 32], String> {{").unwrap();
-    writeln!(out, "    let raw = s;").unwrap();
-    writeln!(out, "    let s = s.strip_prefix(\"Public/\").or_else(|| s.strip_prefix(\"Private/\")).unwrap_or(s);").unwrap();
-    writeln!(out, "    let s = s.trim_start_matches(\"0x\");").unwrap();
-    writeln!(out, "    if s.len() == 64 {{").unwrap();
-    writeln!(out, "        let bytes = hex::decode(s).map_err(|e| format!(\"invalid hex: {{}}\", e))?;").unwrap();
-    writeln!(out, "        let mut arr = [0u8; 32]; arr.copy_from_slice(&bytes);").unwrap();
-    writeln!(out, "        return Ok(arr);").unwrap();
-    writeln!(out, "    }}").unwrap();
-    writeln!(out, "    if let Ok(id) = s.parse::<AccountId>() {{").unwrap();
-    writeln!(out, "        let mut arr = [0u8; 32]; arr.copy_from_slice(id.as_ref());").unwrap();
-    writeln!(out, "        return Ok(arr);").unwrap();
-    writeln!(out, "    }}").unwrap();
-    writeln!(out, "    Err(format!(\"invalid [u8; 32]: {{}}\", raw))").unwrap();
+    writeln!(out, "    spel_framework_core::pda::parse_bytes32(s)").unwrap();
     writeln!(out, "}}").unwrap();
     writeln!(out).unwrap();
 

--- a/spel-client-gen/src/tests.rs
+++ b/spel-client-gen/src/tests.rs
@@ -754,15 +754,11 @@ fn test_ffi_has_catch_unwind() {
 fn test_ffi_parse_account_id_strips_prefix() {
     let output = generate_from_idl_json(SAMPLE_IDL).expect("codegen should succeed");
 
-    // The generated parse_account_id should strip Public/ and Private/ prefixes
+    // parse_account_id and parse_bytes32 now delegate to spel_framework_core which
+    // handles Public/ and Private/ prefix stripping — no inline logic needed.
     assert!(
-        output.ffi_code.contains(r#"s.strip_prefix("Public/")"#),
-        "parse_account_id should strip Public/ prefix: {}",
-        output.ffi_code
-    );
-    assert!(
-        output.ffi_code.contains(r#"s.strip_prefix("Private/")"#),
-        "parse_account_id should strip Private/ prefix: {}",
+        output.ffi_code.contains("spel_framework_core::pda::parse_bytes32"),
+        "parse_account_id must delegate to spel_framework_core::pda::parse_bytes32: {}",
         output.ffi_code
     );
 }
@@ -1453,4 +1449,18 @@ fn test_logos_module_class_name_is_pascal_case() {
     assert!(output.backend_h.contains("MyMultisigBackend"),  "class must be MyMultisigBackend");
     assert!(output.plugin_h.contains("MyMultisigPlugin"),    "plugin class must be MyMultisigPlugin");
     assert!(output.manifest_json.contains("my_multisig"),    "manifest must use snake_case program name");
+}
+
+#[test]
+fn test_ffi_no_inline_pda_or_parse_helpers() {
+    // Regression: generated FFI must delegate to spel_framework_core, not inline these.
+    let output = generate_from_idl_json(SAMPLE_IDL).expect("codegen should succeed");
+    let ffi = &output.ffi_code;
+
+    assert!(!ffi.contains("fn pda_seed_bytes("),
+        "pda_seed_bytes must not be emitted inline; use spel_framework_core::pda::compute_pda_raw");
+    assert!(ffi.contains("spel_framework_core::pda::compute_pda_raw"),
+        "compute_pda_with_program must delegate to spel_framework_core::pda::compute_pda_raw");
+    assert!(ffi.contains("spel_framework_core::pda::parse_bytes32"),
+        "parse_account_id / parse_bytes32 must delegate to spel_framework_core::pda::parse_bytes32");
 }

--- a/spel-framework-core/src/pda.rs
+++ b/spel-framework-core/src/pda.rs
@@ -4,6 +4,7 @@ use nssa_core::account::AccountId;
 use nssa_core::{NullifierPublicKey};
 use nssa_core::program::{PdaSeed, ProgramId};
 use sha2::{Sha256, Digest};
+use base58::FromBase58;
 
 /// Trait for converting a value into a 32-byte PDA seed.
 ///
@@ -127,6 +128,74 @@ pub fn compute_pda_multi(program_id: &ProgramId, seeds: &[&dyn ToSeed]) -> Accou
     let converted: Vec<[u8; 32]> = seeds.iter().map(|s| s.to_seed()).collect();
     let refs: Vec<&[u8; 32]> = converted.iter().collect();
     compute_pda(program_id, &refs)
+}
+
+/// Derive a PDA from a program ID and raw byte-slice seeds (variable length, ≤ 32 bytes each).
+///
+/// Pads each seed to 32 bytes and then delegates to [`compute_pda`]. This is the variant
+/// used by generated FFI code where seeds arrive as `&[u8]` rather than `&[u8; 32]`.
+pub fn compute_pda_raw(program_id: &ProgramId, seeds: &[&[u8]]) -> Result<AccountId, String> {
+    if seeds.is_empty() {
+        return Err("PDA requires at least one seed".into());
+    }
+    let mut arrays: Vec<[u8; 32]> = Vec::with_capacity(seeds.len());
+    for seed in seeds {
+        let len = seed.len();
+        if len > 32 {
+            return Err(format!("PDA seed exceeds 32 bytes ({len})"));
+        }
+        let mut padded = [0u8; 32];
+        padded[..len].copy_from_slice(seed);
+        arrays.push(padded);
+    }
+    let refs: Vec<&[u8; 32]> = arrays.iter().collect();
+    Ok(compute_pda(program_id, &refs))
+}
+
+/// Decode a 32-byte value from a base58 or hex string.
+///
+/// Accepts (in priority order):
+/// - `Public/<value>` or `Private/<value>` — strips the prefix, then processes `<value>`
+/// - `0x<hex>` or `0X<hex>` — 64 hex characters (explicit hex marker, checked first)
+/// - `<hex>` — exactly 64 hex characters (tried before base58 to avoid ambiguity)
+/// - `<base58>` — base58-encoded 32-byte value (~44 chars)
+///
+/// Returns an error if the string does not match any of the above or decodes to a length other than 32.
+pub fn parse_bytes32(input: &str) -> Result<[u8; 32], String> {
+    let s = input
+        .strip_prefix("Public/")
+        .or_else(|| input.strip_prefix("Private/"))
+        .unwrap_or(input);
+
+    let hex_part = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")).unwrap_or(s);
+    if hex_part.len() == 64 {
+        let mut arr = [0u8; 32];
+        let mut ok = true;
+        for (i, chunk) in hex_part.as_bytes().chunks(2).enumerate() {
+            if let Ok(byte_str) = std::str::from_utf8(chunk) {
+                if let Ok(b) = u8::from_str_radix(byte_str, 16) {
+                    arr[i] = b;
+                    continue;
+                }
+            }
+            ok = false;
+            break;
+        }
+        if ok {
+            return Ok(arr);
+        }
+    }
+
+    if let Ok(bytes) = s.from_base58() {
+        if bytes.len() == 32 {
+            let mut arr = [0u8; 32];
+            arr.copy_from_slice(&bytes);
+            return Ok(arr);
+        }
+        return Err(format!("base58 decoded to {} bytes, expected 32", bytes.len()));
+    }
+
+    Err(format!("expected 32 bytes (64 hex chars or base58-encoded key), got: {input}"))
 }
 
 #[cfg(test)]
@@ -329,5 +398,74 @@ mod tests {
         let s3 = seq.to_seed();
         let expected = compute_pda(&program_id, &[&s1, &s2, &s3]);
         assert_eq!(pda, expected);
+    }
+
+    // ── compute_pda_raw tests ───────────────────────────────────────
+
+    #[test]
+    fn test_compute_pda_raw_matches_compute_pda() {
+        let program_id: ProgramId = [1u32; 8];
+        let seed = seed_from_str("test");
+        let expected = compute_pda(&program_id, &[&seed]);
+        let raw = compute_pda_raw(&program_id, &[b"test"]).unwrap();
+        assert_eq!(raw, expected);
+    }
+
+    #[test]
+    fn test_compute_pda_raw_multi_seed() {
+        let program_id: ProgramId = [3u32; 8];
+        let s1 = seed_from_str("prefix");
+        let s2 = [0xabu8; 32];
+        let expected = compute_pda(&program_id, &[&s1, &s2]);
+        let raw = compute_pda_raw(&program_id, &[b"prefix", &[0xabu8; 32]]).unwrap();
+        assert_eq!(raw, expected);
+    }
+
+    #[test]
+    fn test_compute_pda_raw_empty_returns_err() {
+        let program_id: ProgramId = [1u32; 8];
+        assert!(compute_pda_raw(&program_id, &[]).is_err());
+    }
+
+    #[test]
+    fn test_compute_pda_raw_seed_too_long() {
+        let program_id: ProgramId = [1u32; 8];
+        let long = [0u8; 33];
+        assert!(compute_pda_raw(&program_id, &[&long]).is_err());
+    }
+
+    // ── parse_bytes32 tests ─────────────────────────────────────────
+
+    #[test]
+    fn test_parse_bytes32_hex_with_0x() {
+        let input = format!("0x{}", "ab".repeat(32));
+        let result = parse_bytes32(&input).unwrap();
+        assert_eq!(result, [0xab; 32]);
+    }
+
+    #[test]
+    fn test_parse_bytes32_hex_without_0x() {
+        let input = "ab".repeat(32);
+        let result = parse_bytes32(&input).unwrap();
+        assert_eq!(result, [0xab; 32]);
+    }
+
+    #[test]
+    fn test_parse_bytes32_public_prefix_stripped() {
+        let hex = format!("0x{}", "cd".repeat(32));
+        let with_prefix = format!("Public/{}", hex);
+        assert_eq!(parse_bytes32(&with_prefix).unwrap(), [0xcdu8; 32]);
+    }
+
+    #[test]
+    fn test_parse_bytes32_private_prefix_stripped() {
+        let hex = "ef".repeat(32);
+        let with_prefix = format!("Private/{}", hex);
+        assert_eq!(parse_bytes32(&with_prefix).unwrap(), [0xefu8; 32]);
+    }
+
+    #[test]
+    fn test_parse_bytes32_wrong_length() {
+        assert!(parse_bytes32("deadbeef").is_err());
     }
 }


### PR DESCRIPTION
## Summary

- **Rename `spel inspect <FILE>` → `spel program-id`** — `inspect` was overloaded (binary extraction vs account decoding). `program-id` says exactly what it does; `spel inspect` now means account data decoding only, with no flag-based disambiguation.
- **`spel program-id --format hex|json`** (#208) — machine-readable output; `--format hex` prints one 64-char ImageID per binary (useful for `PROGRAM_ID=$(spel program-id prog.bin --format hex)`); `--format json` produces properly escaped JSON via `serde_json`; unknown format values exit with an error.
- **Eliminate FFI helper duplication** (#210) — `parse_bytes32` and `compute_pda_raw` added to `spel-framework-core`; `decode_bytes_32` in `spel-cli` and all generated-FFI inline helpers now delegate to the single source of truth.

Also closes #214 and #183 (already fixed in earlier work, posted closing comments).

## Changes

### `spel-cli/src/lib.rs`
- Dispatch `"program-id"` → `inspect_binaries`; `"inspect"` is now solely for account decoding
- `--format` flag: errors on missing value (`--format` with no arg) and empty value (`--format=`)

### `spel-cli/src/inspect.rs`
- Updated doc comment and usage string from `spel inspect` to `spel program-id`
- `--format json`: replaced raw path interpolation with `serde_json::json!()` — paths with quotes, backslashes, or control characters now produce valid JSON
- Unknown `--format` values now exit 1 with a clear error (no more silent fallthrough to text)

### `spel-cli/src/cli.rs`
- Help text updated to show `program-id` and `inspect` as distinct commands

### `spel-framework-core/src/pda.rs`
- `parse_bytes32(input: &str) -> Result<[u8; 32], String>` — handles `Public/`/`Private/` prefix, `0x` hex, bare 64-char hex (tried before base58 to avoid ambiguity), base58
- `compute_pda_raw(program_id, seeds: &[&[u8]]) -> Result<AccountId, String>` — pads variable-length seeds, delegates to typed `compute_pda`

### `spel-cli/src/hex.rs`
- `decode_bytes_32` → one-liner delegation to `spel_framework_core::pda::parse_bytes32`

### `spel-client-gen/src/ffi_codegen.rs`
- Removed inline `compute_pda`, `pda_seed_bytes`, `parse_account_id`, `parse_bytes32` bodies
- All three now delegate to `spel_framework_core::pda`
- Removed now-unused `sha2` and `PdaSeed` imports from the generated FFI header

### `spel-client-gen/src/tests.rs`
- `test_ffi_no_inline_pda_or_parse_helpers` — regression asserts inline copies are gone and delegation is present

## Test plan

- [ ] `cargo test -p spel-framework-core` — includes new `parse_bytes32` + `compute_pda_raw` tests
- [ ] `cargo test -p spel-client-gen` — includes delegation regression test
- [ ] `spel program-id <binary> --format hex` outputs a 64-char hex string
- [ ] `spel program-id <binary> --format json` outputs valid JSON (including for paths with special chars)
- [ ] `spel program-id <binary> --format=` exits 1 with an error message
- [ ] `spel program-id <binary> --format jsno` exits 1 with an error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)