### PR TITLE
feat(framework-core): feature-gate decode module

### DIFF
--- a/spel-framework-core/Cargo.toml
+++ b/spel-framework-core/Cargo.toml
@@ -5,7 +5,11 @@ edition = "2021"
 description = "Core types for the SPEL program framework"
 
 [features]
-default = []
+# `decode` is enabled by default for CLI and FFI consumers.
+# Guest programs that don't need runtime Borsh account decoding can opt out:
+#   spel-framework-core = { ..., default-features = false }
+default = ["decode"]
+decode = []
 idl-gen = ["dep:syn", "dep:proc-macro2", "dep:toml"]
 host = ["dep:nssa"]
 

--- a/spel-framework-core/Cargo.toml
+++ b/spel-framework-core/Cargo.toml
@@ -9,7 +9,7 @@ description = "Core types for the SPEL program framework"
 # Guest programs that don't need runtime Borsh account decoding can opt out:
 #   spel-framework-core = { ..., default-features = false }
 default = ["decode"]
-decode = []
+decode = ["dep:base58"]
 idl-gen = ["dep:syn", "dep:proc-macro2", "dep:toml"]
 host = ["dep:nssa"]
 
@@ -20,7 +20,7 @@ thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
-base58 = "0.2"
+base58 = { version = "0.2", optional = true }
 
 nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3", optional = true }
 

--- a/spel-framework-core/src/lib.rs
+++ b/spel-framework-core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod idl;
 pub mod pda;
 pub mod validation;
 pub mod context;
+#[cfg(feature = "decode")]
 pub mod decode;
 
 #[cfg(feature = "idl-gen")]


### PR DESCRIPTION
## Summary

Gate `spel-framework-core::decode` behind a `decode` Cargo feature so guest programs (RISC Zero zkVM) can opt out of compiling the runtime account decoding logic.

## Changes

- `spel-framework-core/Cargo.toml`: adds `decode = []` feature, included in `default`
- `spel-framework-core/src/lib.rs`: `pub mod decode` is now `#[cfg(feature = "decode")]`

## Backward compatibility

The feature is in `default`, so existing users are unaffected. Guest programs that want to exclude it can use:

```toml
spel-framework-core = { path = "...", default-features = false }
```

Closes #215.

## Test plan

- [ ] `cargo check -p spel-framework-core` — compile with default features
- [ ] `cargo check -p spel-framework-core --no-default-features` — compile without `decode`
- [ ] `cargo check -p spel -p spel-client-gen` — downstream crates unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)