### PR TITLE
feat(codegen): name-based rest-account arg derivation

### DIFF
--- a/spel-client-gen/src/ffi_codegen.rs
+++ b/spel-client-gen/src/ffi_codegen.rs
@@ -293,7 +293,9 @@ pub fn generate_ffi(idl: &SpelIdl, idl_json: &str) -> Result<String, String> {
             if acc.rest {
                 // If there's a Vec<[u8;32]> arg, derive rest accounts from it when the
                 // JSON field is absent — the UI sends keys only once (as the instruction arg).
-                let src_arg = ix.args.iter().find(|a| is_vec_bytes32(&a.type_));
+                // Use name-based matching first (e.g. member_accounts → members/member),
+                // falling back to the first Vec<[u8;32]> arg.
+                let src_arg = find_rest_arg(&acc.name, &ix.args);
                 if let Some(src) = src_arg {
                     let src_name = rust_ident(&src.name);
                     writeln!(out, "    let {name}: Vec<AccountId> = if v[\"{}\"].is_array() {{", acc.name).unwrap();

--- a/spel-client-gen/src/tests.rs
+++ b/spel-client-gen/src/tests.rs
@@ -1475,13 +1475,18 @@ fn test_rest_account_name_match_single_vec() {
         "accounts": [], "types": [], "errors": []
     }"#;
     let output = generate_from_idl_json(idl).expect("codegen should succeed");
-    // The derived fallback should reference `members`, not require the caller to pass member_accounts
-    assert!(output.ffi_code.contains("members"), "FFI should reference members arg");
+    // Rest accounts must be derived from the `members` arg, not required as a separate JSON field.
+    assert!(
+        output.ffi_code.contains("members.iter()"),
+        "FFI should derive member_accounts from members.iter(): {}",
+        output.ffi_code
+    );
 }
 
 #[test]
 fn test_rest_account_name_match_prefers_named_arg() {
-    // Two Vec<[u8;32]> args: name matching picks the right one for each rest account.
+    // Two Vec<[u8;32]> args: name matching must pick `members` for `member_accounts`,
+    // not the first arg (`signers`).
     let idl = r#"{
         "version": "0.1.0",
         "name": "test_prog",
@@ -1500,7 +1505,12 @@ fn test_rest_account_name_match_prefers_named_arg() {
     }"#;
     let output = generate_from_idl_json(idl).expect("codegen should succeed");
     let ffi = &output.ffi_code;
-    // member_accounts → should derive from `members`, not `signers`
-    assert!(ffi.contains("members.iter()") || ffi.contains("members"),
-        "FFI should derive member_accounts from members arg: {ffi}");
+    assert!(
+        ffi.contains("members.iter()"),
+        "FFI should derive member_accounts from members, not signers: {ffi}"
+    );
+    assert!(
+        !ffi.contains("signers.iter()"),
+        "FFI must not derive member_accounts from signers: {ffi}"
+    );
 }

--- a/spel-client-gen/src/tests.rs
+++ b/spel-client-gen/src/tests.rs
@@ -1514,3 +1514,45 @@ fn test_rest_account_name_match_prefers_named_arg() {
         "FFI must not derive member_accounts from signers: {ffi}"
     );
 }
+
+#[test]
+fn test_rest_account_name_match_non_accounts_suffixes() {
+    // _list, _set, _keys, _ids and _addrs suffixes are also stripped for name matching.
+    for (acc_name, arg_name) in [
+        ("signers_list", "signers"),
+        ("validator_set", "validators"),
+        ("member_keys", "members"),
+        ("node_ids", "nodes"),
+        ("peer_addrs", "peers"),
+    ] {
+        let idl = format!(
+            r#"{{
+                "version": "0.1.0",
+                "name": "test_prog",
+                "instructions": [{{
+                    "name": "op",
+                    "accounts": [
+                        {{"name": "state", "writable": true, "signer": false, "init": false}},
+                        {{"name": "{acc_name}", "writable": false, "signer": false, "init": false, "rest": true}}
+                    ],
+                    "args": [
+                        {{"name": "unrelated", "type": {{"vec": "[u8; 32]"}}}},
+                        {{"name": "{arg_name}", "type": {{"vec": "[u8; 32]"}}}}
+                    ]
+                }}],
+                "accounts": [], "types": [], "errors": []
+            }}"#
+        );
+        let output = generate_from_idl_json(&idl)
+            .unwrap_or_else(|e| panic!("codegen failed for {acc_name}: {e}"));
+        let ffi = &output.ffi_code;
+        assert!(
+            ffi.contains(&format!("{arg_name}.iter()")),
+            "{acc_name} should derive from {arg_name}: {ffi}"
+        );
+        assert!(
+            !ffi.contains("unrelated.iter()"),
+            "{acc_name} must not fall back to unrelated: {ffi}"
+        );
+    }
+}

--- a/spel-client-gen/src/tests.rs
+++ b/spel-client-gen/src/tests.rs
@@ -1454,3 +1454,53 @@ fn test_logos_module_class_name_is_pascal_case() {
     assert!(output.plugin_h.contains("MyMultisigPlugin"),    "plugin class must be MyMultisigPlugin");
     assert!(output.manifest_json.contains("my_multisig"),    "manifest must use snake_case program name");
 }
+
+#[test]
+fn test_rest_account_name_match_single_vec() {
+    // Single Vec<[u8;32]> arg: still derives correctly (unchanged behaviour).
+    let idl = r#"{
+        "version": "0.1.0",
+        "name": "test_prog",
+        "instructions": [{
+            "name": "create",
+            "accounts": [
+                {"name": "state", "writable": true, "signer": false, "init": false},
+                {"name": "member_accounts", "writable": false, "signer": false, "init": false, "rest": true}
+            ],
+            "args": [
+                {"name": "members", "type": {"vec": "[u8; 32]"}},
+                {"name": "threshold", "type": "u64"}
+            ]
+        }],
+        "accounts": [], "types": [], "errors": []
+    }"#;
+    let output = generate_from_idl_json(idl).expect("codegen should succeed");
+    // The derived fallback should reference `members`, not require the caller to pass member_accounts
+    assert!(output.ffi_code.contains("members"), "FFI should reference members arg");
+}
+
+#[test]
+fn test_rest_account_name_match_prefers_named_arg() {
+    // Two Vec<[u8;32]> args: name matching picks the right one for each rest account.
+    let idl = r#"{
+        "version": "0.1.0",
+        "name": "test_prog",
+        "instructions": [{
+            "name": "multi",
+            "accounts": [
+                {"name": "state", "writable": true, "signer": false, "init": false},
+                {"name": "member_accounts", "writable": false, "signer": false, "init": false, "rest": true}
+            ],
+            "args": [
+                {"name": "signers", "type": {"vec": "[u8; 32]"}},
+                {"name": "members", "type": {"vec": "[u8; 32]"}}
+            ]
+        }],
+        "accounts": [], "types": [], "errors": []
+    }"#;
+    let output = generate_from_idl_json(idl).expect("codegen should succeed");
+    let ffi = &output.ffi_code;
+    // member_accounts → should derive from `members`, not `signers`
+    assert!(ffi.contains("members.iter()") || ffi.contains("members"),
+        "FFI should derive member_accounts from members arg: {ffi}");
+}

--- a/spel-client-gen/src/util.rs
+++ b/spel-client-gen/src/util.rs
@@ -128,15 +128,9 @@ pub fn idl_type_to_json_parse(ty: &spel_framework_core::idl::IdlType, var: &str)
 /// Priority:
 /// 1. An arg whose name matches after stripping `_accounts` from `acc_name`
 ///    and normalising plural/singular (e.g. `member_accounts` → `members`/`member`).
-/// 2. The first arg of type `Vec<[u8;32]>` regardless of name.
-///
-/// Returns `None` if no `Vec<[u8;32]>` arg exists at all.
-/// Find the best-matching `Vec<[u8;32]>` instruction arg for a `rest: true` account.
-///
-/// Priority:
-/// 1. An arg whose name matches after stripping `_accounts` from `acc_name`
-///    and normalising plural/singular (e.g. `member_accounts` → `members`/`member`).
-/// 2. The first arg of type `Vec<[u8;32]>` regardless of name.
+/// 2. The first `Vec<[u8;32]>` arg, regardless of name (preserves pre-existing behaviour
+///    for instructions with a single such arg, and acts as a fallback when name matching
+///    fails — e.g. non-`_accounts` suffixes like `signers_list` are not stripped).
 ///
 /// Returns `None` if no `Vec<[u8;32]>` arg exists at all.
 pub fn find_rest_arg<'a>(
@@ -151,9 +145,12 @@ pub fn find_rest_arg<'a>(
     if candidates.len() == 1 {
         return Some(candidates[0]);
     }
-    // Build candidate names from acc_name:
-    //   member_accounts → member, members
-    //   signers → signer, signers
+    // Derive match names from acc_name. Only `_accounts` is stripped; other suffixes
+    // (e.g. `_list`, `_set`) fall through to the first-arg fallback below.
+    //   member_accounts → base=member, singular=member, plural=members
+    //   signers         → base=signers, singular=signer, plural=signers
+    // Note: simple `strip_suffix('s')` is intentional — blockchain arg names are
+    // programmer-chosen identifiers where irregular plurals are extremely rare.
     let base = acc_name.strip_suffix("_accounts").unwrap_or(acc_name);
     let singular = base.strip_suffix('s').unwrap_or(base);
     let plural = if base.ends_with('s') { base.to_string() } else { format!("{base}s") };
@@ -163,6 +160,7 @@ pub fn find_rest_arg<'a>(
             return Some(arg);
         }
     }
+    // No name match — fall back to first candidate (same as old behaviour).
     Some(candidates[0])
 }
 

--- a/spel-client-gen/src/util.rs
+++ b/spel-client-gen/src/util.rs
@@ -123,14 +123,17 @@ pub fn idl_type_to_json_parse(ty: &spel_framework_core::idl::IdlType, var: &str)
     }
 }
 
+/// Known collection suffixes stripped when deriving an arg name from a rest-account name.
+const COLLECTION_SUFFIXES: &[&str] = &["_accounts", "_list", "_set", "_keys", "_ids", "_addrs"];
+
 /// Find the best-matching `Vec<[u8;32]>` instruction arg for a `rest: true` account.
 ///
 /// Priority:
-/// 1. An arg whose name matches after stripping `_accounts` from `acc_name`
-///    and normalising plural/singular (e.g. `member_accounts` → `members`/`member`).
-/// 2. The first `Vec<[u8;32]>` arg, regardless of name (preserves pre-existing behaviour
-///    for instructions with a single such arg, and acts as a fallback when name matching
-///    fails — e.g. non-`_accounts` suffixes like `signers_list` are not stripped).
+/// 1. An arg whose name matches after stripping a known collection suffix from `acc_name`
+///    (see [`COLLECTION_SUFFIXES`]) and normalising plural/singular:
+///    `member_accounts` → `member`/`members`, `signers_list` → `signer`/`signers`.
+/// 2. The first `Vec<[u8;32]>` arg, regardless of name — preserves existing behaviour
+///    for single-arg instructions and acts as a fallback for unrecognised naming patterns.
 ///
 /// Returns `None` if no `Vec<[u8;32]>` arg exists at all.
 pub fn find_rest_arg<'a>(
@@ -145,13 +148,15 @@ pub fn find_rest_arg<'a>(
     if candidates.len() == 1 {
         return Some(candidates[0]);
     }
-    // Derive match names from acc_name. Only `_accounts` is stripped; other suffixes
-    // (e.g. `_list`, `_set`) fall through to the first-arg fallback below.
-    //   member_accounts → base=member, singular=member, plural=members
-    //   signers         → base=signers, singular=signer, plural=signers
-    // Note: simple `strip_suffix('s')` is intentional — blockchain arg names are
-    // programmer-chosen identifiers where irregular plurals are extremely rare.
-    let base = acc_name.strip_suffix("_accounts").unwrap_or(acc_name);
+    // Strip the first matching collection suffix to get the semantic base name.
+    //   member_accounts → member,  signers_list → signers,  validator_set → validator
+    // Then derive singular (strip trailing 's') and plural (append 's') forms.
+    // Simple strip_suffix('s') is intentional: blockchain identifiers are programmer-chosen
+    // and irregular plurals (status→statu, boss→bos) don't occur in practice.
+    let base = COLLECTION_SUFFIXES
+        .iter()
+        .find_map(|s| acc_name.strip_suffix(s))
+        .unwrap_or(acc_name);
     let singular = base.strip_suffix('s').unwrap_or(base);
     let plural = if base.ends_with('s') { base.to_string() } else { format!("{base}s") };
     for &arg in &candidates {

--- a/spel-client-gen/src/util.rs
+++ b/spel-client-gen/src/util.rs
@@ -123,6 +123,49 @@ pub fn idl_type_to_json_parse(ty: &spel_framework_core::idl::IdlType, var: &str)
     }
 }
 
+/// Find the best-matching `Vec<[u8;32]>` instruction arg for a `rest: true` account.
+///
+/// Priority:
+/// 1. An arg whose name matches after stripping `_accounts` from `acc_name`
+///    and normalising plural/singular (e.g. `member_accounts` → `members`/`member`).
+/// 2. The first arg of type `Vec<[u8;32]>` regardless of name.
+///
+/// Returns `None` if no `Vec<[u8;32]>` arg exists at all.
+/// Find the best-matching `Vec<[u8;32]>` instruction arg for a `rest: true` account.
+///
+/// Priority:
+/// 1. An arg whose name matches after stripping `_accounts` from `acc_name`
+///    and normalising plural/singular (e.g. `member_accounts` → `members`/`member`).
+/// 2. The first arg of type `Vec<[u8;32]>` regardless of name.
+///
+/// Returns `None` if no `Vec<[u8;32]>` arg exists at all.
+pub fn find_rest_arg<'a>(
+    acc_name: &str,
+    args: &'a [spel_framework_core::idl::IdlArg],
+) -> Option<&'a spel_framework_core::idl::IdlArg> {
+    let candidates: Vec<&spel_framework_core::idl::IdlArg> =
+        args.iter().filter(|a| is_vec_bytes32(&a.type_)).collect();
+    if candidates.is_empty() {
+        return None;
+    }
+    if candidates.len() == 1 {
+        return Some(candidates[0]);
+    }
+    // Build candidate names from acc_name:
+    //   member_accounts → member, members
+    //   signers → signer, signers
+    let base = acc_name.strip_suffix("_accounts").unwrap_or(acc_name);
+    let singular = base.strip_suffix('s').unwrap_or(base);
+    let plural = if base.ends_with('s') { base.to_string() } else { format!("{base}s") };
+    for &arg in &candidates {
+        let n = arg.name.as_str();
+        if n == base || n == singular || n == plural.as_str() {
+            return Some(arg);
+        }
+    }
+    Some(candidates[0])
+}
+
 /// Returns true if `ty` is a `Vec` whose element type is a 32-byte value
 /// (`[u8; 32]`, `AccountId`, or any spelling thereof).
 pub fn is_vec_bytes32(ty: &spel_framework_core::idl::IdlType) -> bool {


### PR DESCRIPTION
## Summary

When a `rest: true` account has multiple `Vec<[u8;32]>` args to pick from, the generator now prefers the one whose name matches the account name rather than always taking the first one.

**Matching logic** (in order):
1. Strip `_accounts` suffix from the account name → try exact, singular (`-s`), and plural (`+s`) forms against arg names
2. Fall back to first `Vec<[u8;32]>` arg (existing behaviour for single-arg case)

**Examples:**
- `member_accounts` → prefers arg `members` or `member` over `signers`
- `signers` → prefers arg `signers` or `signer`

## Changes

- `spel-client-gen/src/util.rs` — adds `find_rest_arg(acc_name, args)` helper
- `spel-client-gen/src/ffi_codegen.rs` — uses `find_rest_arg` instead of `iter().find(is_vec_bytes32)`
- `spel-client-gen/src/tests.rs` — two new tests covering single-arg (unchanged) and multi-arg name-preference cases

Closes #211.

## Test plan

- [ ] `cargo test -p spel-client-gen` — 49 tests pass
- [ ] `test_rest_account_name_match_prefers_named_arg` — explicitly verifies name-based selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)