### PR TITLE
feat(cli): rename 'inspect <FILE>' to 'program-id'

### DIFF
--- a/spel-cli/src/cli.rs
+++ b/spel-cli/src/cli.rs
@@ -20,7 +20,8 @@ pub fn print_help(idl: &SpelIdl, binary_name: &str) {
     println!("  --bin-<NAME> <FILE>        Additional program binary (auto-fills --<NAME>-program-id)");
     println!();
     println!("COMMANDS:");
-    println!("  inspect <FILE> [FILE...]   Print ProgramId for ELF binary(ies)");
+    println!("  program-id <FILE> [FILE...]  Extract ProgramId from ELF binary(ies)");
+    println!("  inspect <ACCOUNT-ID> --type <TYPE>  Decode account data");
     println!("  generate-idl [PATH]        Generate IDL JSON (auto-detects methods/guest/src/bin/ if no path given)");
     println!("  idl                        Print IDL information");
 

--- a/spel-cli/src/lib.rs
+++ b/spel-cli/src/lib.rs
@@ -212,12 +212,11 @@ pub async fn run() {
                 init_project(name, lez_tag.as_deref(), spel_tag.as_deref(), lez_rev.as_deref(), spel_rev.as_deref());
                 return;
             }
-            "inspect" if type_name.is_none() && data_hex.is_none() && idl_path.is_empty() => {
+            "program-id" => {
                 inspect_binaries(&remaining_args[2..]);
                 return;
             }
             "inspect" => {
-                // Account inspection mode: --type and --idl required
                 if idl_path.is_empty() {
                     eprintln!("Account inspection requires --idl <IDL_FILE>");
                     process::exit(1);
@@ -322,7 +321,7 @@ pub async fn run() {
         eprintln!();
         eprintln!("Commands that don't need --idl:");
         eprintln!("  init <name>              Scaffold a new SPEL project");
-        eprintln!("  inspect <FILE> [FILE...]  Print ProgramId for ELF binary(ies)");
+        eprintln!("  program-id <FILE> [FILE...]  Extract ProgramId from ELF binary(ies)");
         eprintln!("  inspect <ACCOUNT-ID> --idl <IDL> --type <TYPE>  Decode account data");
         eprintln!("  generate-idl [PATH]      Generate IDL JSON from a program source file or project directory");
         eprintln!();
@@ -357,7 +356,10 @@ pub async fn run() {
         Some("idl") => {
             println!("{}", serde_json::to_string_pretty(&idl).unwrap());
         }
-        Some("inspect") if type_name.is_some() => {
+        Some("program-id") => {
+            inspect_binaries(&remaining_args[2..]);
+        }
+        Some("inspect") => {
             let account_id = remaining_args.get(2).unwrap_or_else(|| {
                 eprintln!("Usage: {} inspect <account-id> --idl <IDL> --type <TypeName> [--data <hex>]", args[0]);
                 process::exit(1);
@@ -368,9 +370,6 @@ pub async fn run() {
                 type_name.as_ref().unwrap(),
                 data_hex.as_deref(),
             ).await;
-        }
-        Some("inspect") => {
-            inspect_binaries(&remaining_args[2..]);
         }
         Some("pda") => {
             compute_pda_command(&idl, program_path.as_deref(), program_id_hex.as_deref(), &remaining_args[2..]);


### PR DESCRIPTION
## Summary

`spel inspect` was doing two unrelated things depending on which flags were present — a classic overloaded-verb smell:

- `spel inspect <FILE>` → extract ProgramId from ELF binary
- `spel inspect <ACCOUNT-ID> --idl ... --type ...` → decode account data

This PR splits them cleanly:

| Before | After |
|--------|-------|
| `spel inspect prog.bin` | `spel program-id prog.bin` |
| `spel inspect <ID> --idl ... --type ...` | unchanged — `spel inspect` now has one meaning |

The flag-based guard (`type_name.is_none() && idl_path.is_empty()`) that disambiguated them is gone. Help text updated in both dispatch paths.

Note: PR #218 adds `--format hex|json` to the binary inspection path — that should be rebased onto `program-id` once both are merged.

## Test plan

- [ ] `spel program-id <binary>` prints the ProgramId
- [ ] `spel inspect <account-id> --idl ... --type ...` decodes account data
- [ ] `spel inspect <binary>` (old form) prints a clear error, not silently misbehaves

🤖 Generated with [Claude Code](https://claude.com/claude-code)