### PR TITLE
feat(context): add ClockContext for opt-in timestamp/block_id access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "e2e"
+      - name: Install logos-blockchain-circuits
+        run: |
+          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/1da154c74b911318fb853d37261f8a05ffe513b4/scripts/setup-logos-blockchain-circuits.sh | bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build (all packages including spel)
         run: cargo build -p spel-framework -p spel-framework-core -p spel-framework-macros -p spel-client-gen -p spel
       - name: E2E tests
@@ -76,6 +81,12 @@ jobs:
           export PATH="$HOME/.risc0/bin:$PATH"
           rzup install cargo-risczero ${{ env.RISC0_VERSION }}
           rzup install rust
+
+      - name: Install logos-blockchain-circuits
+        run: |
+          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/1da154c74b911318fb853d37261f8a05ffe513b4/scripts/setup-logos-blockchain-circuits.sh | bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Clone LEZ at correct revision
         run: |
@@ -176,6 +187,18 @@ jobs:
           path: /tmp/lssa/target/release/wallet
           key: wallet-${{ needs.sequencer-setup.outputs.lez-rev }}
 
+      - name: Install logos-blockchain-circuits
+        run: |
+          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/1da154c74b911318fb853d37261f8a05ffe513b4/scripts/setup-logos-blockchain-circuits.sh | bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install logos-blockchain-circuits
+        run: |
+          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/1da154c74b911318fb853d37261f8a05ffe513b4/scripts/setup-logos-blockchain-circuits.sh | bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Restore spel CLI cache (PR-specific)
         uses: actions/cache@v4
         with:
@@ -199,6 +222,12 @@ jobs:
           export PATH="$HOME/.risc0/bin:$PATH"
           rzup install cargo-risczero ${{ env.RISC0_VERSION }}
           rzup install rust
+
+      - name: Install logos-blockchain-circuits
+        run: |
+          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/1da154c74b911318fb853d37261f8a05ffe513b4/scripts/setup-logos-blockchain-circuits.sh | bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run privacy smoke test
         env:
@@ -242,6 +271,18 @@ jobs:
           path: /tmp/lssa/target/release/wallet
           key: wallet-${{ needs.sequencer-setup.outputs.lez-rev }}
 
+      - name: Install logos-blockchain-circuits
+        run: |
+          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/1da154c74b911318fb853d37261f8a05ffe513b4/scripts/setup-logos-blockchain-circuits.sh | bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install logos-blockchain-circuits
+        run: |
+          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/1da154c74b911318fb853d37261f8a05ffe513b4/scripts/setup-logos-blockchain-circuits.sh | bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Restore spel CLI cache (PR-specific)
         uses: actions/cache@v4
         with:
@@ -265,6 +306,12 @@ jobs:
           export PATH="$HOME/.risc0/bin:$PATH"
           rzup install cargo-risczero ${{ env.RISC0_VERSION }}
           rzup install rust
+
+      - name: Install logos-blockchain-circuits
+        run: |
+          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/1da154c74b911318fb853d37261f8a05ffe513b4/scripts/setup-logos-blockchain-circuits.sh | bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run FFI call test
         env:
@@ -307,6 +354,12 @@ jobs:
         with:
           path: /tmp/lssa/target/release/wallet
           key: wallet-${{ needs.sequencer-setup.outputs.lez-rev }}
+
+      - name: Install logos-blockchain-circuits
+        run: |
+          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/1da154c74b911318fb853d37261f8a05ffe513b4/scripts/setup-logos-blockchain-circuits.sh | bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Restore spel CLI cache (PR-specific)
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,6 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           prefix-key: "e2e"
-      - name: Install logos-blockchain-circuits
-        run: |
-          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/1da154c74b911318fb853d37261f8a05ffe513b4/scripts/setup-logos-blockchain-circuits.sh | bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Build (all packages including spel)
         run: cargo build -p spel-framework -p spel-framework-core -p spel-framework-macros -p spel-client-gen -p spel
       - name: E2E tests
@@ -81,12 +76,6 @@ jobs:
           export PATH="$HOME/.risc0/bin:$PATH"
           rzup install cargo-risczero ${{ env.RISC0_VERSION }}
           rzup install rust
-
-      - name: Install logos-blockchain-circuits
-        run: |
-          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/1da154c74b911318fb853d37261f8a05ffe513b4/scripts/setup-logos-blockchain-circuits.sh | bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Clone LEZ at correct revision
         run: |
@@ -187,18 +176,6 @@ jobs:
           path: /tmp/lssa/target/release/wallet
           key: wallet-${{ needs.sequencer-setup.outputs.lez-rev }}
 
-      - name: Install logos-blockchain-circuits
-        run: |
-          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/1da154c74b911318fb853d37261f8a05ffe513b4/scripts/setup-logos-blockchain-circuits.sh | bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install logos-blockchain-circuits
-        run: |
-          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/1da154c74b911318fb853d37261f8a05ffe513b4/scripts/setup-logos-blockchain-circuits.sh | bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Restore spel CLI cache (PR-specific)
         uses: actions/cache@v4
         with:
@@ -222,12 +199,6 @@ jobs:
           export PATH="$HOME/.risc0/bin:$PATH"
           rzup install cargo-risczero ${{ env.RISC0_VERSION }}
           rzup install rust
-
-      - name: Install logos-blockchain-circuits
-        run: |
-          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/1da154c74b911318fb853d37261f8a05ffe513b4/scripts/setup-logos-blockchain-circuits.sh | bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run privacy smoke test
         env:
@@ -271,18 +242,6 @@ jobs:
           path: /tmp/lssa/target/release/wallet
           key: wallet-${{ needs.sequencer-setup.outputs.lez-rev }}
 
-      - name: Install logos-blockchain-circuits
-        run: |
-          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/1da154c74b911318fb853d37261f8a05ffe513b4/scripts/setup-logos-blockchain-circuits.sh | bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install logos-blockchain-circuits
-        run: |
-          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/1da154c74b911318fb853d37261f8a05ffe513b4/scripts/setup-logos-blockchain-circuits.sh | bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Restore spel CLI cache (PR-specific)
         uses: actions/cache@v4
         with:
@@ -306,12 +265,6 @@ jobs:
           export PATH="$HOME/.risc0/bin:$PATH"
           rzup install cargo-risczero ${{ env.RISC0_VERSION }}
           rzup install rust
-
-      - name: Install logos-blockchain-circuits
-        run: |
-          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/1da154c74b911318fb853d37261f8a05ffe513b4/scripts/setup-logos-blockchain-circuits.sh | bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run FFI call test
         env:
@@ -354,12 +307,6 @@ jobs:
         with:
           path: /tmp/lssa/target/release/wallet
           key: wallet-${{ needs.sequencer-setup.outputs.lez-rev }}
-
-      - name: Install logos-blockchain-circuits
-        run: |
-          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/1da154c74b911318fb853d37261f8a05ffe513b4/scripts/setup-logos-blockchain-circuits.sh | bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Restore spel CLI cache (PR-specific)
         uses: actions/cache@v4

--- a/.github/workflows/lez-compat-improved.yml
+++ b/.github/workflows/lez-compat-improved.yml
@@ -253,16 +253,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y pkg-config libssl-dev cmake
 
-      - name: Install logos-blockchain-circuits
-        run: |
-          if [ -f scripts/setup-logos-blockchain-circuits.sh ]; then
-            bash scripts/setup-logos-blockchain-circuits.sh
-          else
-            echo "Setup script not found, skipping..."
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Cargo metadata (dependency analysis)
         id: deps
         run: |

--- a/spel-client-gen/src/codegen.rs
+++ b/spel-client-gen/src/codegen.rs
@@ -208,7 +208,11 @@ pub fn generate_client(idl: &SpelIdl) -> Result<String, String> {
         // account so it lands at pre_states[0] as the dispatcher expects.
         writeln!(out, "        let mut account_ids: Vec<AccountId> = vec![").unwrap();
         if ix.has_clock_context {
-            writeln!(out, "            AccountId::new(*b\"/LEZ/ClockProgramAccount/0000001\"),").unwrap();
+            writeln!(
+                out,
+                "            AccountId::new(*b\"/LEZ/ClockProgramAccount/0000001\"),"
+            )
+            .unwrap();
         }
         for acc in ix.accounts.iter().filter(|a| !a.rest) {
             writeln!(out, "            accounts.{},", rust_ident(&acc.name)).unwrap();

--- a/spel-client-gen/src/codegen.rs
+++ b/spel-client-gen/src/codegen.rs
@@ -204,8 +204,12 @@ pub fn generate_client(idl: &SpelIdl) -> Result<String, String> {
             writeln!(out, "        }};").unwrap();
         }
 
-        // Account IDs
+        // Account IDs. When the instruction uses ClockContext, prepend the LEZ clock
+        // account so it lands at pre_states[0] as the dispatcher expects.
         writeln!(out, "        let mut account_ids: Vec<AccountId> = vec![").unwrap();
+        if ix.has_clock_context {
+            writeln!(out, "            AccountId::new(*b\"/LEZ/ClockProgramAccount/0000001\"),").unwrap();
+        }
         for acc in ix.accounts.iter().filter(|a| !a.rest) {
             writeln!(out, "            accounts.{},", rust_ident(&acc.name)).unwrap();
         }

--- a/spel-client-gen/src/ffi_codegen.rs
+++ b/spel-client-gen/src/ffi_codegen.rs
@@ -450,7 +450,9 @@ pub fn generate_ffi(idl: &SpelIdl, idl_json: &str) -> Result<String, String> {
         }
         writeln!(out).unwrap();
 
-        // Build account_ids vec (non-rest accounts first, then rest)
+        // Build account_ids vec (non-rest accounts first, then rest).
+        // When the instruction uses ClockContext, prepend the LEZ clock account so it
+        // lands at pre_states[0] as the dispatcher expects.
         let has_rest = ix.accounts.iter().any(|a| a.rest);
         let account_ids_binding = if has_rest { "let mut" } else { "let" };
         writeln!(
@@ -458,6 +460,9 @@ pub fn generate_ffi(idl: &SpelIdl, idl_json: &str) -> Result<String, String> {
             "    {account_ids_binding} account_ids: Vec<AccountId> = vec!["
         )
         .unwrap();
+        if ix.has_clock_context {
+            writeln!(out, "        AccountId::new(*b\"/LEZ/ClockProgramAccount/0000001\"),").unwrap();
+        }
         for acc in ix.accounts.iter().filter(|a| !a.rest) {
             writeln!(out, "        {},", rust_ident(&acc.name)).unwrap();
         }

--- a/spel-client-gen/src/ffi_codegen.rs
+++ b/spel-client-gen/src/ffi_codegen.rs
@@ -461,7 +461,11 @@ pub fn generate_ffi(idl: &SpelIdl, idl_json: &str) -> Result<String, String> {
         )
         .unwrap();
         if ix.has_clock_context {
-            writeln!(out, "        AccountId::new(*b\"/LEZ/ClockProgramAccount/0000001\"),").unwrap();
+            writeln!(
+                out,
+                "        AccountId::new(*b\"/LEZ/ClockProgramAccount/0000001\"),"
+            )
+            .unwrap();
         }
         for acc in ix.accounts.iter().filter(|a| !a.rest) {
             writeln!(out, "        {},", rust_ident(&acc.name)).unwrap();

--- a/spel-client-gen/src/tests.rs
+++ b/spel-client-gen/src/tests.rs
@@ -262,6 +262,7 @@ fn test_pda_helpers_single_arg_seed() {
             discriminator: None,
             execution: None,
             variant: None,
+            has_clock_context: false,
         }],
         accounts: vec![],
         types: vec![],
@@ -345,6 +346,7 @@ fn test_pda_helpers_multi_seed() {
             discriminator: None,
             execution: None,
             variant: None,
+            has_clock_context: false,
         }],
         accounts: vec![],
         types: vec![],
@@ -421,6 +423,7 @@ fn test_pda_helpers_deduplication() {
         discriminator: None,
         execution: None,
         variant: None,
+        has_clock_context: false,
     };
 
     let idl = SpelIdl {
@@ -500,6 +503,7 @@ fn test_pda_helpers_u64_single_seed() {
             discriminator: None,
             execution: None,
             variant: None,
+            has_clock_context: false,
         }],
         accounts: vec![],
         types: vec![],
@@ -588,6 +592,7 @@ fn test_pda_helpers_u64_multi_seed() {
             discriminator: None,
             execution: None,
             variant: None,
+            has_clock_context: false,
         }],
         accounts: vec![],
         types: vec![],

--- a/spel-framework-core/src/context.rs
+++ b/spel-framework-core/src/context.rs
@@ -5,7 +5,7 @@
 //! values from [`nssa_core::program::ProgramInput`] at call time.
 //! The context parameter is **never** part of the instruction ABI or IDL.
 
-use crate::prelude::ProgramId;
+use crate::prelude::{BlockId, ProgramId, Timestamp};
 
 /// Trusted execution metadata supplied by the SPEL guest entrypoint.
 ///
@@ -41,5 +41,43 @@ impl ProgramContext {
             self_program_id,
             caller_program_id,
         }
+    }
+}
+
+/// Clock metadata injected by the SPEL dispatcher when an `#[instruction]` handler
+/// declares a `ClockContext` parameter.
+///
+/// Use this to access the current block number and timestamp without adding
+/// them to the instruction schema. Like [`ProgramContext`], it is **never**
+/// part of the instruction ABI or IDL. The dispatcher reads it from the
+/// LEZ clock account (`/LEZ/ClockProgramAccount/0000001`), which the
+/// transaction builder automatically prepends to the account list.
+///
+/// ```ignore
+/// #[instruction]
+/// pub fn time_locked_transfer(
+///     ctx: ProgramContext,
+///     clock: ClockContext,
+///     #[account(owner = self_program_id)]
+///     vault: AccountWithMetadata,
+///     unlock_timestamp: u64,
+/// ) -> SpelResult {
+///     if clock.timestamp < unlock_timestamp {
+///         return Err(SpelError::new(1, "still locked"));
+///     }
+/// }
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq, borsh::BorshDeserialize)]
+pub struct ClockContext {
+    /// The block number at the time of execution.
+    pub block_id: BlockId,
+    /// The block timestamp in milliseconds since the Unix epoch.
+    pub timestamp: Timestamp,
+}
+
+impl ClockContext {
+    #[must_use]
+    pub const fn new(block_id: BlockId, timestamp: Timestamp) -> Self {
+        Self { block_id, timestamp }
     }
 }

--- a/spel-framework-core/src/context.rs
+++ b/spel-framework-core/src/context.rs
@@ -78,6 +78,9 @@ pub struct ClockContext {
 impl ClockContext {
     #[must_use]
     pub const fn new(block_id: BlockId, timestamp: Timestamp) -> Self {
-        Self { block_id, timestamp }
+        Self {
+            block_id,
+            timestamp,
+        }
     }
 }

--- a/spel-framework-core/src/idl.rs
+++ b/spel-framework-core/src/idl.rs
@@ -71,6 +71,12 @@ pub struct IdlInstruction {
     /// Variant name in PascalCase (lssa-lang compat).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub variant: Option<String>,
+    /// True when the handler declares a `ClockContext` parameter.
+    /// The dispatcher reads the LEZ clock account (`/LEZ/ClockProgramAccount/0000001`)
+    /// from `pre_states[0]` and injects it; transaction builders must prepend that
+    /// account to the account list. Never appears in the instruction ABI or IDL args.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub has_clock_context: bool,
 }
 
 /// An account expected by an instruction.

--- a/spel-framework-core/src/idl_gen.rs
+++ b/spel-framework-core/src/idl_gen.rs
@@ -610,6 +610,20 @@ fn parse_instruction(func: ItemFn) -> Result<InstructionInfo, IdlGenError> {
                     // ProgramContext is injected by the dispatcher and never part of the IDL/ABI.
                 } else if is_clock_context_type(ty) {
                     // ClockContext is injected by the dispatcher and never part of the IDL/ABI.
+                    // Mirror the proc-macro constraints: at most one ClockContext, and it must
+                    // appear before any account or arg parameters.
+                    if has_clock_context {
+                        return Err(IdlGenError::Parse(syn::Error::new_spanned(
+                            ty,
+                            "instruction functions can have at most one ClockContext parameter",
+                        )));
+                    }
+                    if !accounts.is_empty() || !args.is_empty() {
+                        return Err(IdlGenError::Parse(syn::Error::new_spanned(
+                            ty,
+                            "ClockContext must appear before any account or arg parameters",
+                        )));
+                    }
                     has_clock_context = true;
                 } else {
                     args.push(ArgParam {

--- a/spel-framework-core/src/idl_gen.rs
+++ b/spel-framework-core/src/idl_gen.rs
@@ -210,6 +210,7 @@ fn generate_idl_inner(
                 discriminator: None,
                 execution: None,
                 variant: None,
+                has_clock_context: ix.has_clock_context,
             }
         })
         .collect();
@@ -546,6 +547,7 @@ struct InstructionInfo {
     fn_name: Ident,
     accounts: Vec<AccountParam>,
     args: Vec<ArgParam>,
+    has_clock_context: bool,
 }
 
 struct AccountParam {
@@ -582,6 +584,7 @@ fn parse_instruction(func: ItemFn) -> Result<InstructionInfo, IdlGenError> {
     let fn_name = func.sig.ident.clone();
     let mut accounts = Vec::new();
     let mut args = Vec::new();
+    let mut has_clock_context = false;
 
     for input in &func.sig.inputs {
         match input {
@@ -605,6 +608,9 @@ fn parse_instruction(func: ItemFn) -> Result<InstructionInfo, IdlGenError> {
                     });
                 } else if is_context_type(ty) {
                     // ProgramContext is injected by the dispatcher and never part of the IDL/ABI.
+                } else if is_clock_context_type(ty) {
+                    // ClockContext is injected by the dispatcher and never part of the IDL/ABI.
+                    has_clock_context = true;
                 } else {
                     args.push(ArgParam {
                         name: param_name,
@@ -625,6 +631,7 @@ fn parse_instruction(func: ItemFn) -> Result<InstructionInfo, IdlGenError> {
         fn_name,
         accounts,
         args,
+        has_clock_context,
     })
 }
 
@@ -642,6 +649,15 @@ fn is_context_type(ty: &Type) -> bool {
     if let Type::Path(type_path) = ty {
         if let Some(segment) = type_path.path.segments.last() {
             return segment.ident == "ProgramContext";
+        }
+    }
+    false
+}
+
+fn is_clock_context_type(ty: &Type) -> bool {
+    if let Type::Path(type_path) = ty {
+        if let Some(segment) = type_path.path.segments.last() {
+            return segment.ident == "ClockContext";
         }
     }
     false

--- a/spel-framework-core/src/lib.rs
+++ b/spel-framework-core/src/lib.rs
@@ -39,7 +39,7 @@ pub mod prelude {
     pub use nssa_core::program::{read_nssa_inputs, InstructionData, ProgramInput, ProgramOutput};
 
     // Execution context for instruction handlers (issue #172)
-    pub use crate::context::ProgramContext;
+    pub use crate::context::{ClockContext, ProgramContext};
 
     // nssa::public_transaction (host-only)
     #[cfg(feature = "host")]

--- a/spel-framework-core/tests/context_parameter.rs
+++ b/spel-framework-core/tests/context_parameter.rs
@@ -1,10 +1,10 @@
-//! Test that ProgramContext is properly handled by the framework.
+//! Test that ProgramContext and ClockContext are properly handled by the framework.
 //!
-//! This tests the contract: instruction handlers can declare a ProgramContext
-//! parameter and receive trusted execution metadata without polluting the IDL.
+//! This tests the contract: instruction handlers can declare ProgramContext and/or
+//! ClockContext parameters and receive trusted execution metadata without polluting the IDL.
 
 use nssa_core::program::ProgramId;
-use spel_framework_core::context::ProgramContext;
+use spel_framework_core::context::{ClockContext, ProgramContext};
 
 /// Verify ProgramContext can be constructed and accessed.
 #[test]
@@ -115,4 +115,59 @@ fn test_handler_uses_caller_program_id() {
 
     assert!(is_authorized_caller(&ctx, caller_program));
     assert!(!is_authorized_caller(&ctx, [99u32; 8]));
+}
+
+// ── ClockContext tests ────────────────────────────────────────────────────────
+
+#[test]
+fn test_clock_context_construction() {
+    let clock = ClockContext::new(42, 1_700_000_000_000);
+    assert_eq!(clock.block_id, 42);
+    assert_eq!(clock.timestamp, 1_700_000_000_000);
+}
+
+#[test]
+fn test_clock_context_clone_copy() {
+    let clock = ClockContext::new(10, 999);
+    let clock2 = clock;
+    let clock3 = clock.clone();
+    assert_eq!(clock.block_id, clock2.block_id);
+    assert_eq!(clock.block_id, clock3.block_id);
+}
+
+#[test]
+fn test_clock_context_equality() {
+    let a = ClockContext::new(1, 100);
+    let b = ClockContext::new(1, 100);
+    let c = ClockContext::new(2, 200);
+    assert_eq!(a, b);
+    assert_ne!(a, c);
+}
+
+#[test]
+fn test_clock_context_debug() {
+    let clock = ClockContext::new(7, 42);
+    let s = format!("{:?}", clock);
+    assert!(s.contains("ClockContext"));
+}
+
+#[test]
+fn test_clock_context_borsh_roundtrip() {
+    use borsh::{BorshDeserialize, BorshSerialize};
+
+    // ClockAccountData layout: block_id (u64 LE) then timestamp (u64 LE)
+    let mut bytes = Vec::new();
+    99u64.serialize(&mut bytes).unwrap();
+    1_234_567_890_000u64.serialize(&mut bytes).unwrap();
+
+    let clock = ClockContext::try_from_slice(&bytes).expect("borsh decode should succeed");
+    assert_eq!(clock.block_id, 99);
+    assert_eq!(clock.timestamp, 1_234_567_890_000);
+}
+
+#[test]
+fn test_clock_context_borsh_wrong_length_fails() {
+    use borsh::BorshDeserialize;
+    let result = ClockContext::try_from_slice(&[0u8; 4]);
+    assert!(result.is_err(), "decoding 4 bytes should fail (need 16)");
 }

--- a/spel-framework-macros/src/lib.rs
+++ b/spel-framework-macros/src/lib.rs
@@ -881,7 +881,8 @@ fn generate_match_arms(mod_name: &Ident, instructions: &[InstructionInfo]) -> Ve
             let validate_fn_name = format_ident!("__validate_{}", ix.fn_name);
 
             // When ClockContext is present, strip pre_states[0] as the clock account,
-            // decode it into ClockContext, and rebind `pre_states` to the remainder.
+            // validate its account_id against the well-known LEZ clock address, decode
+            // it into ClockContext, and rebind `pre_states` to the remainder.
             // The original pre_states[0] is saved so its post_state can be reinserted
             // at position 0 after the handler returns, keeping the zip in main() aligned.
             let clock_setup = if ix.has_clock_context {
@@ -892,8 +893,21 @@ fn generate_match_arms(mod_name: &Ident, instructions: &[InstructionInfo]) -> Ve
                             panic!("SPEL ClockContext: expected clock account as first pre_state, found none");
                         }
                         let __c = __ps.remove(0);
-                        let __ctx = borsh::from_slice::<spel_framework::context::ClockContext>(&__c.account.data)
-                            .expect("SPEL ClockContext: failed to decode clock account data");
+                        // Reject pre_states[0] that isn't the expected LEZ clock account.
+                        // Without this check a caller could forge timestamp/block_id by
+                        // supplying an attacker-controlled account at position 0.
+                        const __EXPECTED_CLOCK_ID: nssa_core::account::AccountId =
+                            nssa_core::account::AccountId::new(*b"/LEZ/ClockProgramAccount/0000001");
+                        if __c.account_id != __EXPECTED_CLOCK_ID {
+                            panic!(
+                                "SPEL ClockContext: pre_states[0] is not the LEZ clock account \
+                                 (expected /LEZ/ClockProgramAccount/0000001)"
+                            );
+                        }
+                        let __ctx = borsh::from_slice::<spel_framework::context::ClockContext>(
+                            &__c.account.data,
+                        )
+                        .expect("SPEL ClockContext: failed to decode clock account data");
                         (__c, __ctx, __ps)
                     };
                 }

--- a/spel-framework-macros/src/lib.rs
+++ b/spel-framework-macros/src/lib.rs
@@ -166,6 +166,11 @@ struct InstructionInfo {
     /// True if this instruction has a ProgramContext parameter.
     /// The context is injected by the dispatcher and never appears in IDL/ABI.
     has_context: bool,
+    /// True if this instruction has a ClockContext parameter.
+    /// The dispatcher reads the clock account from pre_states[0] and injects it;
+    /// it never appears in the IDL/ABI. Transaction builders must prepend the
+    /// clock account (`/LEZ/ClockProgramAccount/0000001`) to the account list.
+    has_clock_context: bool,
     /// The original function item (with #[instruction] stripped)
     func: ItemFn,
 }
@@ -497,6 +502,7 @@ fn parse_instruction(func: ItemFn) -> syn::Result<InstructionInfo> {
     let mut accounts = Vec::new();
     let mut args = Vec::new();
     let mut has_context = false;
+    let mut has_clock_context = false;
 
     for (idx, input) in func.sig.inputs.iter().enumerate() {
         match input {
@@ -533,6 +539,21 @@ fn parse_instruction(func: ItemFn) -> syn::Result<InstructionInfo> {
                         ));
                     }
                     has_context = true;
+                } else if is_clock_context_type(ty) {
+                    // ClockContext — injected by dispatcher from the clock pre_state, not part of ABI/IDL.
+                    if has_clock_context {
+                        return Err(syn::Error::new_spanned(
+                            ty,
+                            "instruction functions can have at most one ClockContext parameter",
+                        ));
+                    }
+                    if !accounts.is_empty() || !args.is_empty() {
+                        return Err(syn::Error::new_spanned(
+                            ty,
+                            "ClockContext must appear before any account or arg parameters",
+                        ));
+                    }
+                    has_clock_context = true;
                 } else {
                     args.push(ArgParam {
                         name: param_name,
@@ -554,6 +575,7 @@ fn parse_instruction(func: ItemFn) -> syn::Result<InstructionInfo> {
         accounts,
         args,
         has_context,
+        has_clock_context,
         func,
     })
 }
@@ -598,6 +620,16 @@ fn is_context_type(ty: &Type) -> bool {
     if let Type::Path(type_path) = ty {
         if let Some(segment) = type_path.path.segments.last() {
             return segment.ident == "ProgramContext";
+        }
+    }
+    false
+}
+
+/// Check if a type is ClockContext (clock context injected from the clock pre_state).
+fn is_clock_context_type(ty: &Type) -> bool {
+    if let Type::Path(type_path) = ty {
+        if let Some(segment) = type_path.path.segments.last() {
+            return segment.ident == "ClockContext";
         }
     }
     false
@@ -848,6 +880,27 @@ fn generate_match_arms(mod_name: &Ident, instructions: &[InstructionInfo]) -> Ve
             });
             let validate_fn_name = format_ident!("__validate_{}", ix.fn_name);
 
+            // When ClockContext is present, strip pre_states[0] as the clock account,
+            // decode it into ClockContext, and rebind `pre_states` to the remainder.
+            // The original pre_states[0] is saved so its post_state can be reinserted
+            // at position 0 after the handler returns, keeping the zip in main() aligned.
+            let clock_setup = if ix.has_clock_context {
+                quote! {
+                    let (__clock_account_pre, __clock_context, pre_states) = {
+                        let mut __ps = pre_states;
+                        if __ps.is_empty() {
+                            panic!("SPEL ClockContext: expected clock account as first pre_state, found none");
+                        }
+                        let __c = __ps.remove(0);
+                        let __ctx = borsh::from_slice::<spel_framework::context::ClockContext>(&__c.account.data)
+                            .expect("SPEL ClockContext: failed to decode clock account data");
+                        (__c, __ctx, __ps)
+                    };
+                }
+            } else {
+                quote! {}
+            };
+
             let call_args: Vec<TokenStream2> = {
                 let mut args: Vec<TokenStream2> = Vec::new();
                 // Context is always first if present (enforced by parse_instruction).
@@ -860,6 +913,10 @@ fn generate_match_arms(mod_name: &Ident, instructions: &[InstructionInfo]) -> Ve
                         )
                     });
                 }
+                // ClockContext comes after ProgramContext (enforced by parse_instruction).
+                if ix.has_clock_context {
+                    args.push(quote! { __clock_context });
+                }
                 args.extend(ix.accounts.iter().map(|a| {
                     let name = &a.name;
                     quote! { #name }
@@ -869,6 +926,26 @@ fn generate_match_arms(mod_name: &Ident, instructions: &[InstructionInfo]) -> Ve
                     quote! { #name }
                 }));
                 args
+            };
+
+            // Re-insert the clock account as an unchanged post_state at position 0 so
+            // that pre_states_clone[0] (the clock account) and post_states[0] align in
+            // the zip used to build ProgramOutput.
+            let map_output = if ix.has_clock_context {
+                quote! {
+                    .map(|output| {
+                        let mut __parts = output.into_parts();
+                        __parts.post_states.insert(
+                            0,
+                            nssa_core::program::AccountPostState::new(
+                                __clock_account_pre.account.clone()
+                            ),
+                        );
+                        __parts
+                    })
+                }
+            } else {
+                quote! { .map(|output| output.into_parts()) }
             };
 
             // Collect arg seed values to pass to validation
@@ -952,10 +1029,11 @@ fn generate_match_arms(mod_name: &Ident, instructions: &[InstructionInfo]) -> Ve
 
             quote! {
                 #pattern => {
+                    #clock_setup
                     #account_destructure
                     #validation_call
                     #mod_name::#fn_name(#(#call_args),*)
-                        .map(|output| output.into_parts())
+                        #map_output
                 }
             }
         })
@@ -1850,6 +1928,7 @@ fn generate_idl_fn(
                     .collect::<String>()
             };
 
+            let has_clock = ix.has_clock_context;
             quote! {
                 spel_framework::idl::IdlInstruction {
                     name: #ix_name.to_string(),
@@ -1861,6 +1940,7 @@ fn generate_idl_fn(
                         private_owned: false,
                     }),
                     variant: Some(#variant_name_str.to_string()),
+                    has_clock_context: #has_clock,
                 }
             }
         })
@@ -1984,11 +2064,17 @@ fn generate_idl_json(
                 })
                 .collect();
 
+            let clock_json = if ix.has_clock_context {
+                ",\"has_clock_context\":true".to_string()
+            } else {
+                String::new()
+            };
             format!(
-                "{{\"name\":\"{}\",\"accounts\":[{}],\"args\":[{}]}}",
+                "{{\"name\":\"{}\",\"accounts\":[{}],\"args\":[{}]{}}}",
                 ix_name,
                 accounts_json.join(","),
-                args_json.join(",")
+                args_json.join(","),
+                clock_json,
             )
         })
         .collect();


### PR DESCRIPTION
## Summary

Implements **Option 1** from the design discussion in #226: a `ClockContext` parameter that gives instruction handlers opt-in access to the current block number and timestamp without polluting the ABI or IDL.

- Add `ClockContext { block_id: BlockId, timestamp: Timestamp }` struct in `spel-framework-core` (borsh-decodable, matches LEZ `ClockAccountData` layout)
- Macro recognises `ClockContext` by type name (same as `ProgramContext`) and injects it from `pre_states[0]`
- `has_clock_context: bool` added to `IdlInstruction` — transaction builders (FFI, Rust client codegen) automatically prepend the LEZ clock account (`/LEZ/ClockProgramAccount/0000001`) when the flag is set
- `idl_gen.rs` updated to parse and propagate the new context type
- 6 new unit tests for `ClockContext` construction, copy/clone, equality, debug, borsh roundtrip, and borsh error path

## Usage

```rust
#[instruction]
pub fn time_locked_transfer(
    ctx: ProgramContext,
    clock: ClockContext,   // opt-in; injected by dispatcher, not in IDL/ABI
    #[account(owner = self_program_id)]
    vault: AccountWithMetadata,
    unlock_timestamp: u64,
) -> SpelResult {
    if clock.timestamp < unlock_timestamp {
        return Err(SpelError::new(1, "transfer is still time-locked"));
    }
    // ...
}
```

Instructions that do not declare `ClockContext` are completely unaffected — **no breaking changes**.

## Implementation notes

- The clock account is re-inserted as an **unchanged post-state at position 0** after the handler returns, so the `pre_states_clone.zip(post_states)` loop in the generated `main()` stays aligned.
- Position rule: `ClockContext` must come before any account or arg parameters (enforced at macro parse time). It may follow `ProgramContext` or appear first if there is no `ProgramContext`.
- Default clock account used: `CLOCK_01` (updated every block, `*b"/LEZ/ClockProgramAccount/0000001"`). Cadence selection can be added as a follow-up.

## Test plan

- [ ] All existing workspace tests pass (`cargo test --workspace --exclude spel-ffi-compile-test`)
- [ ] New `test_clock_context_*` tests in `spel-framework-core/tests/context_parameter.rs` all pass
- [ ] Manually write a small program using `ClockContext` and verify the generated IDL contains `"has_clock_context":true`
- [ ] Verify generated FFI code prepends the clock account when `has_clock_context` is set

Closes #226 (Option 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)