### PR TITLE
chore(deps): retag LEZ dependency from v0.2.0-rc3 to v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,7 +67,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 [[package]]
 name = "amm_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.1.2#cf3639d8252040d13b3d4e933feb19b42c76e14a"
 dependencies = [
  "borsh",
  "nssa_core",
@@ -625,7 +625,7 @@ dependencies = [
 [[package]]
 name = "ata_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.1.2#cf3639d8252040d13b3d4e933feb19b42c76e14a"
 dependencies = [
  "nssa_core",
  "risc0-zkvm",
@@ -1071,7 +1071,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "clock_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.1.2#cf3639d8252040d13b3d4e933feb19b42c76e14a"
 dependencies = [
  "borsh",
  "nssa_core",
@@ -1105,7 +1105,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.1.2#cf3639d8252040d13b3d4e933feb19b42c76e14a"
 dependencies = [
  "anyhow",
  "base64",
@@ -2829,7 +2829,7 @@ dependencies = [
 [[package]]
 name = "key_protocol"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.1.2#cf3639d8252040d13b3d4e933feb19b42c76e14a"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3660,7 +3660,7 @@ dependencies = [
 [[package]]
 name = "nssa"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.1.2#cf3639d8252040d13b3d4e933feb19b42c76e14a"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3682,7 +3682,7 @@ dependencies = [
 [[package]]
 name = "nssa_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.1.2#cf3639d8252040d13b3d4e933feb19b42c76e14a"
 dependencies = [
  "base58",
  "borsh",
@@ -5067,7 +5067,7 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 [[package]]
 name = "sequencer_service_protocol"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.1.2#cf3639d8252040d13b3d4e933feb19b42c76e14a"
 dependencies = [
  "common",
  "nssa",
@@ -5077,7 +5077,7 @@ dependencies = [
 [[package]]
 name = "sequencer_service_rpc"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.1.2#cf3639d8252040d13b3d4e933feb19b42c76e14a"
 dependencies = [
  "jsonrpsee",
  "sequencer_service_protocol",
@@ -5556,7 +5556,7 @@ dependencies = [
 [[package]]
 name = "testnet_initial_state"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.1.2#cf3639d8252040d13b3d4e933feb19b42c76e14a"
 dependencies = [
  "common",
  "key_protocol",
@@ -5682,7 +5682,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "token_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.1.2#cf3639d8252040d13b3d4e933feb19b42c76e14a"
 dependencies = [
  "borsh",
  "nssa_core",
@@ -6203,7 +6203,7 @@ dependencies = [
 [[package]]
 name = "wallet"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.1.2#cf3639d8252040d13b3d4e933feb19b42c76e14a"
 dependencies = [
  "amm_core",
  "anyhow",

--- a/spel-cli/Cargo.toml
+++ b/spel-cli/Cargo.toml
@@ -10,11 +10,11 @@ path = "src/bin/main.rs"
 
 [dependencies]
 spel-framework-core = { path = "../spel-framework-core", features = ["idl-gen"] }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
-nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
-common = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
-sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3", features = ["client"] }
-wallet = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.1.2" }
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.1.2" }
+common = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.1.2" }
+sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.1.2", features = ["client"] }
+wallet = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.1.2" }
 risc0-zkvm = { version = "3.0.3", features = ["std"] }
 base58 = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/spel-cli/src/init.rs
+++ b/spel-cli/src/init.rs
@@ -97,7 +97,7 @@ ui/
     let lez_ref_ffi = match (lez_tag, lez_rev) {
         (Some(t), _) => format!("tag = \"{}\"", t),
         (_, Some(r)) => format!("rev = \"{}\"", r),
-        _ => "tag = \"v0.2.0-rc3\"".to_string(),
+        _ => "tag = \"v0.1.2\"".to_string(),
     };
     let spel_ref_ffi = match (spel_tag, spel_rev) {
         (Some(t), _) => format!("tag = \"{}\"", t),
@@ -688,7 +688,7 @@ risc0-zkvm = {{ version = "=3.0.5", features = ["std"] }}
     let lez_ref = match (lez_tag, lez_rev) {
         (Some(t), _) => format!("tag = \"{}\"", t),
         (_, Some(r)) => format!("rev = \"{}\"", r),
-        _ => "tag = \"v0.2.0-rc3\"".to_string(),
+        _ => "tag = \"v0.1.2\"".to_string(),
     };
     let spel_ref = match (spel_tag, spel_rev) {
         (Some(t), _) => format!("tag = \"{}\"", t),

--- a/spel-cli/src/lib.rs
+++ b/spel-cli/src/lib.rs
@@ -208,7 +208,7 @@ pub async fn run() {
                     println!("Create a new SPEL project");
                     println!();
                     println!("Options:");
-                    println!("  --lez-tag <TAG>     LEZ version tag (default: v0.2.0-rc3)");
+                    println!("  --lez-tag <TAG>     LEZ version tag (default: v0.1.2)");
                     println!("  --spel-rev <REV>    SPEL revision (default: refs/pull/122/head)");
                     println!("  --lez-rev <REV>     LEZ revision (alternative to --lez-tag)");
                     println!("  --spel-tag <TAG>    SPEL tag (alternative to --spel-rev)");
@@ -216,7 +216,7 @@ pub async fn run() {
                     println!("Examples:");
                     println!("  spel init my-project");
                     println!(
-                        "  spel init my-project --lez-tag v0.2.0-rc3 --spel-rev refs/pull/122/head"
+                        "  spel init my-project --lez-tag v0.1.2 --spel-rev refs/pull/122/head"
                     );
                     return;
                 }

--- a/spel-cli/src/serialize.rs
+++ b/spel-cli/src/serialize.rs
@@ -292,7 +292,7 @@ mod tests {
     /// Verifies spel CLI's serialization is compatible with the guest-side
     /// Deserializer from risc0_zkvm (used by nssa_core::program::read_nssa_inputs).
     /// This is the contract between the CLI (transaction sender) and the
-    /// on-chain program (transaction executor) at LEZ v0.2.0-rc3.
+    /// on-chain program (transaction executor) at LEZ v0.1.2.
     #[test]
     fn serialize_deserialize_roundtrip_with_bytes32() {
         #[derive(Deserialize, Debug, PartialEq)]

--- a/spel-ffi-compile-test/Cargo.toml
+++ b/spel-ffi-compile-test/Cargo.toml
@@ -8,11 +8,11 @@ publish = false
 spel-client-gen = { path = "../spel-client-gen" }
 
 [dependencies]
-nssa        = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
-nssa_core   = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
-common      = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
-sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3", features = ["client"] }
-wallet      = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
+nssa        = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.1.2" }
+nssa_core   = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.1.2" }
+common      = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.1.2" }
+sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.1.2", features = ["client"] }
+wallet      = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.1.2" }
 serde_json  = "1"
 serde       = { version = "1", features = ["derive"] }
 borsh       = "1.5"

--- a/spel-framework-core/Cargo.toml
+++ b/spel-framework-core/Cargo.toml
@@ -14,7 +14,7 @@ idl-gen = ["dep:syn", "dep:proc-macro2", "dep:toml"]
 host = ["dep:nssa"]
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3", features = ["host"] }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.1.2", features = ["host"] }
 borsh = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
@@ -22,7 +22,7 @@ serde_json = "1.0"
 sha2 = "0.10"
 base58 = { version = "0.2", optional = true }
 
-nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3", optional = true }
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.1.2", optional = true }
 
 syn = { version = "2.0", features = ["full", "extra-traits"], optional = true }
 proc-macro2 = { version = "1.0", optional = true }

--- a/spel-framework/Cargo.toml
+++ b/spel-framework/Cargo.toml
@@ -11,8 +11,8 @@ host = ["dep:nssa", "spel-framework-core/host"]
 [dependencies]
 spel-framework-core = { path = "../spel-framework-core" }
 spel-framework-macros = { path = "../spel-framework-macros" }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3", features = ["host"] }
-nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3", optional = true }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.1.2", features = ["host"] }
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.1.2", optional = true }
 borsh = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 

--- a/test-modules/test_modules_ffi/Cargo.toml
+++ b/test-modules/test_modules_ffi/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-nssa        = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
-nssa_core   = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
-common      = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
-sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3", features = ["client"] }
-wallet      = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3" }
+nssa        = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.1.2" }
+nssa_core   = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.1.2" }
+common      = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.1.2" }
+sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.1.2", features = ["client"] }
+wallet      = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.1.2" }
 spel-framework-core = { git = "https://github.com/logos-co/spel.git", tag = "v0.3.0" }
 serde_json  = "1"
 serde       = { version = "1", features = ["derive"] }

--- a/tests/e2e/fixture_program/Cargo.lock
+++ b/tests/e2e/fixture_program/Cargo.lock
@@ -1753,7 +1753,7 @@ checksum = "a5b0c77c1b780822bc749a33e39aeb2c07584ab93332303babeabb645298a76e"
 [[package]]
 name = "nssa_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0-rc3#cf3639d8252040d13b3d4e933feb19b42c76e14a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.1.2#cf3639d8252040d13b3d4e933feb19b42c76e14a"
 dependencies = [
  "base58",
  "borsh",

--- a/tests/e2e/fixture_program/Cargo.toml
+++ b/tests/e2e/fixture_program/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 
 [dependencies]
 spel-framework = { path = "../../../spel-framework" }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0-rc3", features = ["host"] }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.1.2", features = ["host"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
## Summary

`v0.2.0-rc3` and `v0.1.2` resolve to the same commit (`cf3639d8`), so this is a **label-only change** — zero code impact, no API differences, Cargo.lock hashes are identical.

Switching to `v0.1.2` because:
- It is the latest **published GitHub Release** (visible at `/releases`)
- `v0.2.0-rc3` was an unofficial git tag only, never published as a release
- Going forward we should only pin to published releases

Also updates the default LEZ tag in `spel init` scaffolding so newly scaffolded projects start from the published release tag.

## Files changed
- `spel-framework/Cargo.toml`
- `spel-framework-core/Cargo.toml`
- `spel-cli/Cargo.toml`
- `spel-ffi-compile-test/Cargo.toml`
- `test-modules/test_modules_ffi/Cargo.toml`
- `tests/e2e/fixture_program/Cargo.toml`
- `spel-cli/src/init.rs` (scaffold default)
- `Cargo.lock` (tag string in metadata only, resolved SHA unchanged)

## Test plan
- [ ] CI passes (build output is bit-for-bit identical to rc3)