### PR TITLE
ci: pin circuits install script to known-good commit in all workflows

### DIFF
--- a/.github/workflows/lez-compat.yml
+++ b/.github/workflows/lez-compat.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Install logos-blockchain-circuits
         run: |
-          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/main/scripts/setup-logos-blockchain-circuits.sh | bash
+          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/1da154c74b911318fb853d37261f8a05ffe513b4/scripts/setup-logos-blockchain-circuits.sh | bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install logos-blockchain-circuits
         run: |
-          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/main/scripts/setup-logos-blockchain-circuits.sh | bash
+          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/1da154c74b911318fb853d37261f8a05ffe513b4/scripts/setup-logos-blockchain-circuits.sh | bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/weekly-rc.yml
+++ b/.github/workflows/weekly-rc.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Install logos-blockchain-circuits
         if: steps.check.outputs.has_changes == 'true'
         run: |
-          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/main/scripts/setup-logos-blockchain-circuits.sh | bash
+          curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/1da154c74b911318fb853d37261f8a05ffe513b4/scripts/setup-logos-blockchain-circuits.sh | bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- The `setup-logos-blockchain-circuits.sh` script was removed from the `logos-blockchain/logos-blockchain` `main` branch after commit `1da154c`, causing any workflow fetching it from `/main/` to 404.
- `ci.yml` was already fixed in #222; this PR patches the three remaining workflows (`release.yml`, `weekly-rc.yml`, `lez-compat.yml`) that still referenced the broken URL.

## Failing run

https://github.com/logos-co/spel/actions/runs/26747912744/job/78828089331 (`Prepare Release` → `Install logos-blockchain-circuits`)

## Test plan

- [ ] Re-run the `Release` workflow after merge — `Install logos-blockchain-circuits` step should pass.
- [ ] Verify `Weekly RC` and `LEZ Bump` workflows are unblocked on next scheduled run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)