### PR TITLE
spel-cli: support account_id instruction arguments

### DIFF
--- a/spel-cli/src/parse.rs
+++ b/spel-cli/src/parse.rs
@@ -98,6 +98,15 @@ fn parse_primitive(raw: &str, prim: &str) -> Result<ParsedValue, String> {
             _ => Err(format!("Invalid bool '{}': expected true/false", raw)),
         },
         "string" | "String" => Ok(ParsedValue::Str(raw.to_string())),
+        // nssa AccountId is SerializeDisplay/DeserializeFromStr: a base58 string on the
+        // wire, not 32 raw bytes. Normalize any input (base58 / 0xhex / Public-prefixed)
+        // to canonical base58 and carry it as a string.
+        "account_id" => {
+            use base58::ToBase58 as _;
+            crate::hex::decode_bytes_32(raw)
+                .map(|b| ParsedValue::Str(b.to_base58()))
+                .map_err(|e| format!("Invalid account_id '{}': {}", raw, e))
+        }
         other => Ok(ParsedValue::Raw(format!("{}({})", other, raw))),
     }
 }

--- a/spel-cli/src/serialize.rs
+++ b/spel-cli/src/serialize.rs
@@ -125,6 +125,8 @@ fn primitive_to_dynamic(prim: &str, val: &ParsedValue) -> Result<DynamicValue, S
         ("program_id", ParsedValue::U32Array(vals)) => Ok(DynamicValue::Tuple(
             vals.iter().map(|v| DynamicValue::U32(*v)).collect(),
         )),
+        // nssa AccountId serializes via Display (base58 string), not as raw bytes.
+        ("account_id", ParsedValue::Str(s)) => Ok(DynamicValue::Str(s.clone())),
         _ => Err(SerializeError::TypeMismatch {
             expected: prim.to_string(),
             got: format!("{:?}", val),


### PR DESCRIPTION
`spel-framework`'s IDL generator emits the primitive type `account_id` for `AccountId` instruction arguments (`spel-framework-core/src/account_types.rs`), but the CLI's transaction-submit path has no handler for it. `parse_primitive` falls through to `other => Raw("account_id(<value>)")`, and `primitive_to_dynamic` has no `account_id` arm, so any instruction taking an `AccountId` argument fails before submission with:

```
type mismatch: expected account_id, got Raw("account_id(<value>)")
```

It went unnoticed because the e2e fixture program types key-like arguments as `[u8; 32]` rather than `AccountId`, so the path was never exercised.

nssa's `AccountId` derives `SerializeDisplay` / `DeserializeFromStr`, i.e. it is a base58 string on the wire, not raw bytes. This PR:

- adds an `"account_id"` arm to `parse_primitive` that normalizes any input (base58, `0x`hex, or a `Public/` / `Private/` prefixed id) to canonical base58 via `decode_bytes_32`;
- adds a matching `("account_id", ParsedValue::Str(_))` arm to `primitive_to_dynamic` that serializes it as a string.

Existing programs that typed key arguments as `[u8; 32]` are unaffected.

**Testing.** Verified on a locally-run standalone sequencer: an instruction taking an `AccountId` argument now builds, signs, submits, and lands, checked against on-chain account state. Without the change the same command fails as above. Happy to add a CLI unit test covering an `account_id` argument round-trip if you'd like one in this PR.
