### PR TITLE
Runtime idl transaction wrapper api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 [[package]]
 name = "amm_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=0400899fe9b4a059ef919e6db5284c1dfbd43ab8#0400899fe9b4a059ef919e6db5284c1dfbd43ab8"
 dependencies = [
  "borsh",
  "lee_core",
@@ -435,7 +435,7 @@ checksum = "4858a9d740c5007a9069007c3b4e91152d0506f13c1b31dd49051fd537656156"
 [[package]]
 name = "associated_token_account_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=0400899fe9b4a059ef919e6db5284c1dfbd43ab8#0400899fe9b4a059ef919e6db5284c1dfbd43ab8"
 dependencies = [
  "lee_core",
  "risc0-zkvm",
@@ -593,7 +593,7 @@ dependencies = [
 [[package]]
 name = "authenticated_transfer_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=0400899fe9b4a059ef919e6db5284c1dfbd43ab8#0400899fe9b4a059ef919e6db5284c1dfbd43ab8"
 dependencies = [
  "serde",
 ]
@@ -827,7 +827,7 @@ dependencies = [
 [[package]]
 name = "bridge_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=0400899fe9b4a059ef919e6db5284c1dfbd43ab8#0400899fe9b4a059ef919e6db5284c1dfbd43ab8"
 dependencies = [
  "lee_core",
  "serde",
@@ -845,7 +845,7 @@ dependencies = [
 [[package]]
 name = "build_utils"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=0400899fe9b4a059ef919e6db5284c1dfbd43ab8#0400899fe9b4a059ef919e6db5284c1dfbd43ab8"
 dependencies = [
  "anyhow",
  "risc0-binfmt",
@@ -1057,7 +1057,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 [[package]]
 name = "clock_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=0400899fe9b4a059ef919e6db5284c1dfbd43ab8#0400899fe9b4a059ef919e6db5284c1dfbd43ab8"
 dependencies = [
  "borsh",
  "lee_core",
@@ -1097,7 +1097,7 @@ dependencies = [
 [[package]]
 name = "common"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=0400899fe9b4a059ef919e6db5284c1dfbd43ab8#0400899fe9b4a059ef919e6db5284c1dfbd43ab8"
 dependencies = [
  "anyhow",
  "authenticated_transfer_core",
@@ -1885,7 +1885,7 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 [[package]]
 name = "faucet_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=0400899fe9b4a059ef919e6db5284c1dfbd43ab8#0400899fe9b4a059ef919e6db5284c1dfbd43ab8"
 dependencies = [
  "lee_core",
  "serde",
@@ -3224,7 +3224,7 @@ dependencies = [
 [[package]]
 name = "key_protocol"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=0400899fe9b4a059ef919e6db5284c1dfbd43ab8#0400899fe9b4a059ef919e6db5284c1dfbd43ab8"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3246,7 +3246,7 @@ dependencies = [
 [[package]]
 name = "keycard_wallet"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=0400899fe9b4a059ef919e6db5284c1dfbd43ab8#0400899fe9b4a059ef919e6db5284c1dfbd43ab8"
 dependencies = [
  "lee",
  "log",
@@ -3297,7 +3297,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lee"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=0400899fe9b4a059ef919e6db5284c1dfbd43ab8#0400899fe9b4a059ef919e6db5284c1dfbd43ab8"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3318,7 +3318,7 @@ dependencies = [
 [[package]]
 name = "lee_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=0400899fe9b4a059ef919e6db5284c1dfbd43ab8#0400899fe9b4a059ef919e6db5284c1dfbd43ab8"
 dependencies = [
  "base58",
  "borsh",
@@ -5414,7 +5414,7 @@ dependencies = [
 [[package]]
 name = "programs"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=0400899fe9b4a059ef919e6db5284c1dfbd43ab8#0400899fe9b4a059ef919e6db5284c1dfbd43ab8"
 dependencies = [
  "build_utils",
  "lee",
@@ -6503,7 +6503,7 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 [[package]]
 name = "sequencer_service_protocol"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=0400899fe9b4a059ef919e6db5284c1dfbd43ab8#0400899fe9b4a059ef919e6db5284c1dfbd43ab8"
 dependencies = [
  "common",
  "hex",
@@ -6515,7 +6515,7 @@ dependencies = [
 [[package]]
 name = "sequencer_service_rpc"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=0400899fe9b4a059ef919e6db5284c1dfbd43ab8#0400899fe9b4a059ef919e6db5284c1dfbd43ab8"
 dependencies = [
  "jsonrpsee",
  "sequencer_service_protocol",
@@ -6832,6 +6832,7 @@ dependencies = [
  "serde_json",
  "spel-framework-core",
  "tempfile",
+ "thiserror 1.0.69",
  "tokio",
  "toml",
  "wallet",
@@ -7091,7 +7092,7 @@ dependencies = [
 [[package]]
 name = "system_accounts"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=0400899fe9b4a059ef919e6db5284c1dfbd43ab8#0400899fe9b4a059ef919e6db5284c1dfbd43ab8"
 dependencies = [
  "bridge_core",
  "clock_core",
@@ -7139,7 +7140,7 @@ dependencies = [
 [[package]]
 name = "testnet_initial_state"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=0400899fe9b4a059ef919e6db5284c1dfbd43ab8#0400899fe9b4a059ef919e6db5284c1dfbd43ab8"
 dependencies = [
  "key_protocol",
  "lee",
@@ -7266,7 +7267,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "token_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=0400899fe9b4a059ef919e6db5284c1dfbd43ab8#0400899fe9b4a059ef919e6db5284c1dfbd43ab8"
 dependencies = [
  "borsh",
  "lee_core",
@@ -7895,7 +7896,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "vault_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=0400899fe9b4a059ef919e6db5284c1dfbd43ab8#0400899fe9b4a059ef919e6db5284c1dfbd43ab8"
 dependencies = [
  "lee_core",
  "risc0-zkvm",
@@ -7921,7 +7922,7 @@ dependencies = [
 [[package]]
 name = "wallet"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=v0.2.0#a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=0400899fe9b4a059ef919e6db5284c1dfbd43ab8#0400899fe9b4a059ef919e6db5284c1dfbd43ab8"
 dependencies = [
  "amm_core",
  "anyhow",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Developer framework for building SPEL programs — inspired by [Anchor](https://www.anchor-lang.com/) for Solana.
 
-Write your program logic with proc macros. Get IDL generation, a full CLI with TX submission, and project scaffolding for free.
+Write your program logic with proc macros. Get IDL generation, a full CLI with TX submission, a Wallet-ready transaction-resolution API, and project scaffolding for free.
 
 ## Quick Start
 
@@ -157,6 +157,42 @@ This provides:
 - Transaction building and submission with wallet integration
 - `--dry-run` mode for testing
 - `inspect` subcommand to extract ProgramId from binaries
+
+### Transaction Resolution API
+
+Use `spel::tx` when an application owns `WalletCore` and needs validated inputs
+for a direct Wallet build call. The resolvers select one IDL instruction, resolve
+accounts and PDAs, and serialize its arguments in IDL declaration order.
+
+Argument text accepts canonical scalars and JSON containers. It also accepts
+the established CLI forms for boolean aliases, options, arrays and vectors,
+and program IDs, so applications can use the same values accepted by `spel`.
+Canonical JSON remains the preferred representation for structured values.
+
+```rust
+use std::collections::BTreeMap;
+
+use spel::tx::{resolve_public_instruction, SpelInstructionRequest};
+
+// `idl`, `program_id`, and `wallet` are owned by the application.
+let request = SpelInstructionRequest {
+    idl: &idl,
+    instruction: "initialize",
+    accounts: BTreeMap::new(),
+    arguments: BTreeMap::new(),
+};
+let resolved = resolve_public_instruction(request, program_id)?;
+let (program_id, accounts, instruction_data) = resolved.into_parts();
+let _build = wallet
+    .build_pub_tx(accounts, instruction_data, program_id)
+    .await?;
+```
+
+For private programs, use `resolve_private_instruction` with a
+`ProgramWithDependencies`, then pass the resolved parts to
+`WalletCore::build_privacy_preserving_tx`. Resolvers return `SpelTxError` for
+invalid IDL or caller input. They do not initialize a wallet, build, prove,
+sign, submit, poll, print, or change CLI behavior; WalletCore owns those steps.
 
 ### Account Types
 

--- a/README.md
+++ b/README.md
@@ -160,9 +160,39 @@ This provides:
 
 ### Transaction Resolution API
 
-Use `spel::tx` when an application owns `WalletCore` and needs validated inputs
-for a direct Wallet build call. The resolvers select one IDL instruction, resolve
-accounts and PDAs, and serialize its arguments in IDL declaration order.
+Use `spel::tx` when your application owns `WalletCore`. Start with
+`SpelProgram` to select an IDL instruction, provide named inputs, and build a
+native Wallet transaction.
+
+```rust
+use spel::tx::SpelProgram;
+
+// `idl`, `program_id`, `owner_account_id`, and `wallet` are owned by the
+// application.
+let transaction = SpelProgram::new(&idl)
+    .program(program_id)
+    .public("initialize")?
+    .input("owner", owner_account_id)?
+    .build(&wallet)
+    .await?;
+```
+
+`build` resolves the selected instruction and delegates native transaction
+construction to `WalletCore`. It returns `PublicTransaction` for public
+programs. For privacy-preserving programs, bind a borrowed
+`ProgramWithDependencies`, select `.private(...)`, and receive Wallet's native
+`(PrivacyPreservingTransaction, Vec<SharedSecretKey>)` result.
+
+Bare `AccountId` inputs infer public signing intent from the IDL. Use an
+explicit `AccountIdentity` when the caller needs private, shared, keycard, or
+other explicit Wallet identity intent.
+
+#### Direct resolver escape hatch
+
+Use `SpelInstructionRequest` when your application needs direct control over
+the account and argument maps before calling Wallet. The resolver selects one
+IDL instruction, resolves accounts and PDAs, and serializes arguments in IDL
+declaration order.
 
 Argument text accepts canonical scalars and JSON containers. It also accepts
 the established CLI forms for boolean aliases, options, arrays and vectors,
@@ -190,9 +220,12 @@ let _build = wallet
 
 For private programs, use `resolve_private_instruction` with a
 `ProgramWithDependencies`, then pass the resolved parts to
-`WalletCore::build_privacy_preserving_tx`. Resolvers return `SpelTxError` for
-invalid IDL or caller input. They do not initialize a wallet, build, prove,
-sign, submit, poll, print, or change CLI behavior; WalletCore owns those steps.
+`WalletCore::build_privacy_preserving_tx`. Direct resolvers return `SpelTxError`
+for invalid IDL or caller input.
+
+Neither `SpelProgram::build` nor the direct resolver API submits, polls, prints,
+or changes CLI behavior. `WalletCore` owns native construction, proving,
+signing, submission, and confirmation through its separate APIs.
 
 ### Account Types
 

--- a/scripts/smoke-test-privacy.sh
+++ b/scripts/smoke-test-privacy.sh
@@ -34,6 +34,11 @@ if [ -z "${LEZ_TAG:-}" ]; then
     exit 1
 fi
 
+LEZ_INIT_OPTION=--lez-tag
+if [[ "$LEZ_TAG" =~ ^[[:xdigit:]]{7,40}$ ]]; then
+    LEZ_INIT_OPTION=--lez-rev
+fi
+
 # SPEL_TAG defaults to current local state (for local testing) or can be set explicitly
 SPEL_TAG="${SPEL_TAG:-local}"
 SPEL_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -147,7 +152,7 @@ log "  Using local spel: $SPEL_BIN"
 # ─── Step 1: Scaffold project ──────────────────────────────────────────────
 
 log "Step 1: Creating SPEL project (LEZ=${LEZ_TAG})..."
-"$SPEL_BIN" init --lez-tag "$LEZ_TAG" --spel-rev "$SPEL_TAG" "$PROJECT_NAME" \
+"$SPEL_BIN" init "$LEZ_INIT_OPTION" "$LEZ_TAG" --spel-rev "$SPEL_TAG" "$PROJECT_NAME" \
     > "$LOG_DIR/init.log" 2>&1 || fail "spel init failed (see $LOG_DIR/init.log)"
 cd "$PROJECT_NAME"
 log "  ✓ Project scaffolded"
@@ -320,33 +325,19 @@ log "  ✓ Program deployed"
 
 log "Step 7: Generating test accounts..."
 
-# Create a public account (random)
-PUBLIC_ACCOUNT="0x$(openssl rand -hex 32)"
-log "  Public account: ${PUBLIC_ACCOUNT:0:20}..."
-
 # Create a private account via wallet (wallet holds the ZK keys)
 PRIVATE_ACCOUNT=$(echo "$WALLET_PASSWORD" | $WALLET_BIN account new private 2>&1 | grep -o "Private/[^ ]*" | head -1)
 [ -n "$PRIVATE_ACCOUNT" ] || fail "Could not create private account from wallet"
 log "  Private account: ${PRIVATE_ACCOUNT:0:30}..."
 
-# ─── Step 8: Test PUBLIC transaction ────────────────────────────────────
-
-log "Step 8: Testing PUBLIC transaction..."
+# Create a public account owned by Wallet for the build-only and CLI checks.
 FRESH_ACCOUNT=$(echo "$WALLET_PASSWORD" | $WALLET_BIN account new public 2>&1 | grep -o "Public/[^ ]*" | head -1)
 [ -n "$FRESH_ACCOUNT" ] || fail "Could not create public account from wallet"
 log "  Fresh account: ${FRESH_ACCOUNT:0:20}..."
 
-SEQUENCER_URL="$SEQUENCER_URL" "$SPEL_BIN" --idl "$IDL_ABS" -p "$GUEST_BIN_ABS" \
-    greet \
-    --account "$FRESH_ACCOUNT" \
-    --greeting "72,101,108,108,111,32,80,117,98,108,105,99" \
-    > "$LOG_DIR/public-tx.log" 2>&1 || fail "Public TX failed (see $LOG_DIR/public-tx.log)"
+# ─── Step 8: Init auth-transfer for private account ─────────────────────
 
-log "  ✓ Public TX submitted and confirmed"
-
-# ─── Step 9: Init auth-transfer for private account ─────────────────────
-
-log "Step 9: Initializing auth-transfer for private account..."
+log "Step 8: Initializing auth-transfer for private account..."
 echo "$WALLET_PASSWORD" | $WALLET_BIN auth-transfer init --account-id "$PRIVATE_ACCOUNT" \
     > "$LOG_DIR/auth-transfer.log" 2>&1 || fail "auth-transfer init failed (see $LOG_DIR/auth-transfer.log)"
 log "  ✓ auth-transfer initialized"
@@ -355,9 +346,33 @@ log "  ✓ auth-transfer initialized"
 log "  Waiting for auth-transfer to be confirmed..."
 sleep 20
 
-# ─── Step 10: Test PRIVACY-PRESERVING transaction ───────────────────────
+# ─── Step 9: Test runtime-IDL build-only API ─────────────────────────────
 
-log "Step 10: Testing PRIVACY-PRESERVING transaction..."
+log "Step 9: Testing runtime-IDL build-only API..."
+SPEL_RUNTIME_IDL_SMOKE_IDL="$IDL_ABS" \
+SPEL_RUNTIME_IDL_SMOKE_GUEST_BIN="$GUEST_BIN_ABS" \
+SPEL_RUNTIME_IDL_SMOKE_PUBLIC_ACCOUNT="$FRESH_ACCOUNT" \
+SPEL_RUNTIME_IDL_SMOKE_PRIVATE_ACCOUNT="$PRIVATE_ACCOUNT" \
+cargo test --manifest-path "$SPEL_DIR/Cargo.toml" -p spel \
+    --test runtime_idl_wallet_smoke runtime_idl_builds_do_not_submit_or_change_state \
+    -- --ignored --exact \
+    > "$LOG_DIR/runtime-idl-build.log" 2>&1 || { cat "$LOG_DIR/runtime-idl-build.log"; fail "Runtime-IDL build-only smoke failed"; }
+log "  ✓ Runtime-IDL transactions built without submission"
+
+# ─── Step 10: Test PUBLIC transaction ───────────────────────────────────
+
+log "Step 10: Testing PUBLIC transaction..."
+SEQUENCER_URL="$SEQUENCER_URL" "$SPEL_BIN" --idl "$IDL_ABS" -p "$GUEST_BIN_ABS" \
+    greet \
+    --account "$FRESH_ACCOUNT" \
+    --greeting "72,101,108,108,111,32,80,117,98,108,105,99" \
+    > "$LOG_DIR/public-tx.log" 2>&1 || fail "Public TX failed (see $LOG_DIR/public-tx.log)"
+
+log "  ✓ Public TX submitted and confirmed"
+
+# ─── Step 11: Test PRIVACY-PRESERVING transaction ───────────────────────
+
+log "Step 11: Testing PRIVACY-PRESERVING transaction..."
 SEQUENCER_URL="$SEQUENCER_URL" "$SPEL_BIN" --idl "$IDL_ABS" -p "$GUEST_BIN_ABS" \
     greet \
     --account "$PRIVATE_ACCOUNT" \
@@ -370,6 +385,7 @@ log "  ✓ Privacy-preserving TX submitted and confirmed"
 
 log ""
 log "🎉 Privacy smoke test PASSED!"
+log "  Runtime-IDL:     $LOG_DIR/runtime-idl-build.log"
 log "  Public TX:       $LOG_DIR/public-tx.log"
 log "  Auth-transfer:   $LOG_DIR/auth-transfer.log"
 log "  Private TX:      $LOG_DIR/private-tx.log"

--- a/spel-cli/Cargo.toml
+++ b/spel-cli/Cargo.toml
@@ -24,7 +24,7 @@ base58 = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 borsh = "1.5"
-tokio = { version = "1.28.2", features = ["net", "rt-multi-thread", "sync", "macros"] }
+tokio = { version = "1.28.2", features = ["net", "rt-multi-thread", "sync", "macros", "time"] }
 hex = "0.4"
 toml = "0.8"
 thiserror = "1.0"

--- a/spel-cli/Cargo.toml
+++ b/spel-cli/Cargo.toml
@@ -10,23 +10,24 @@ path = "src/bin/main.rs"
 
 [dependencies]
 spel-framework-core = { path = "../spel-framework-core", features = ["idl-gen"] }
-# Pinned to lez-core-v0.2.0, which matches the live testnet: `/LEE/v0.3` public-tx
-# signing (spel/co issue #234) and the wallet storage schema written by the wallet
-# CLI (#235). nssa_core/nssa were renamed to lee_core/lee upstream — aliased back
-# via `package` so spel's source keeps compiling.
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", package = "lee_core" }
-nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", package = "lee" }
-common = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0" }
-sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["client"] }
-wallet = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0" }
+# Pinned to the Wallet build API commit on top of lez-core-v0.2.0. This retains
+# the live testnet's `/LEE/v0.3` signing and wallet storage compatibility.
+# nssa_core/nssa were renamed to lee_core/lee upstream — aliased back via
+# `package` so spel's source keeps compiling.
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "0400899fe9b4a059ef919e6db5284c1dfbd43ab8", package = "lee_core" }
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "0400899fe9b4a059ef919e6db5284c1dfbd43ab8", package = "lee" }
+common = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "0400899fe9b4a059ef919e6db5284c1dfbd43ab8" }
+sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "0400899fe9b4a059ef919e6db5284c1dfbd43ab8", features = ["client"] }
+wallet = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "0400899fe9b4a059ef919e6db5284c1dfbd43ab8" }
 risc0-zkvm = { version = "3.0.3", features = ["std"] }
 base58 = "0.2"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 borsh = "1.5"
 tokio = { version = "1.28.2", features = ["net", "rt-multi-thread", "sync", "macros"] }
 hex = "0.4"
 toml = "0.8"
+thiserror = "1.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/spel-cli/src/generate_idl.rs
+++ b/spel-cli/src/generate_idl.rs
@@ -170,7 +170,7 @@ mod tests {
 
     impl Drop for TempDir {
         fn drop(&mut self) {
-            let _ = fs::remove_dir_all(&self.0);
+            drop(fs::remove_dir_all(&self.0));
         }
     }
 

--- a/spel-cli/src/parse.rs
+++ b/spel-cli/src/parse.rs
@@ -1,6 +1,7 @@
 //! IDL type-aware value parsing from CLI strings.
 
 use crate::hex::{hex_decode, hex_encode};
+use nssa_core::program::ProgramId;
 use spel_framework_core::idl::IdlType;
 
 /// A parsed CLI value with type information preserved.
@@ -96,7 +97,7 @@ fn parse_primitive(raw: &str, prim: &str) -> Result<ParsedValue, String> {
             .parse::<u128>()
             .map(ParsedValue::U128)
             .map_err(|e| format!("Invalid u128 '{}': {}", raw, e)),
-        "program_id" => parse_program_id(raw),
+        "program_id" => parse_program_id(raw).map(|value| ParsedValue::U32Array(value.to_vec())),
         // `AccountId` serializes via `SerializeDisplay` (base58 string), so normalize the
         // input (base58 or 0x-hex) to canonical base58 and carry it as a string.
         "account_id" => {
@@ -113,29 +114,29 @@ fn parse_primitive(raw: &str, prim: &str) -> Result<ParsedValue, String> {
     }
 }
 
-fn parse_program_id(raw: &str) -> Result<ParsedValue, String> {
+/// Parse established ProgramId text into little-endian u32 limbs.
+pub(crate) fn parse_program_id(raw: &str) -> Result<ProgramId, String> {
     if raw.contains(',') {
         let parts: Vec<&str> = raw.split(',').map(|s| s.trim()).collect();
         if parts.len() != 8 {
             return Err(format!("ProgramId needs 8 u32 values, got {}", parts.len()));
         }
-        let mut vals = Vec::with_capacity(8);
+        let mut program_id = [0; 8];
         for (i, p) in parts.iter().enumerate() {
             let v = if p.starts_with("0x") || p.starts_with("0X") {
                 u32::from_str_radix(&p[2..], 16)
             } else {
                 p.parse::<u32>()
             };
-            vals.push(v.map_err(|e| format!("ProgramId[{}] invalid u32 '{}': {}", i, p, e))?);
+            program_id[i] =
+                v.map_err(|e| format!("ProgramId[{}] invalid u32 '{}': {}", i, p, e))?;
         }
-        Ok(ParsedValue::U32Array(vals))
+        Ok(program_id)
     } else if raw.len() == 64 && raw.chars().all(|c| c.is_ascii_hexdigit()) {
-        let bytes = hex_decode(raw)?;
-        let mut vals = Vec::with_capacity(8);
-        for chunk in bytes.chunks(4) {
-            vals.push(u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
-        }
-        Ok(ParsedValue::U32Array(vals))
+        let bytes: [u8; 32] = hex_decode(raw)?
+            .try_into()
+            .map_err(|_| format!("Invalid ProgramId '{}': expected 32 bytes", raw))?;
+        Ok(program_id_from_bytes(bytes))
     } else {
         // base58 (or 0x-prefixed hex) ImageID → little-endian u32 limbs, matching the bare-hex
         // branch above so all representations of the same ProgramId agree.
@@ -178,12 +179,22 @@ fn parse_program_id(raw: &str) -> Result<ParsedValue, String> {
                 ));
             }
         }
-        let mut vals = Vec::with_capacity(8);
-        for chunk in bytes.chunks(4) {
-            vals.push(u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
-        }
-        Ok(ParsedValue::U32Array(vals))
+        Ok(program_id_from_bytes(bytes))
     }
+}
+
+fn program_id_from_bytes(bytes: [u8; 32]) -> ProgramId {
+    let mut program_id = [0; 8];
+    for (index, word) in program_id.iter_mut().enumerate() {
+        let offset = index * 4;
+        *word = u32::from_le_bytes([
+            bytes[offset],
+            bytes[offset + 1],
+            bytes[offset + 2],
+            bytes[offset + 3],
+        ]);
+    }
+    program_id
 }
 
 fn parse_array(raw: &str, elem_type: &IdlType, size: usize) -> Result<ParsedValue, String> {
@@ -433,5 +444,31 @@ mod tests {
         // Fail-closed for junk that doesn't decode to a 32-byte ImageID.
         assert!(parse_program_id("not-a-program-id").is_err());
         assert!(parse_program_id("deadbeef").is_err());
+    }
+
+    #[test]
+    fn shared_program_id_decoder_preserves_cli_forms() {
+        let bytes = [0x11; 32];
+        let expected = [0x1111_1111; 8];
+        let csv = expected
+            .iter()
+            .map(u32::to_string)
+            .collect::<Vec<_>>()
+            .join(",");
+        let inputs = [
+            csv,
+            format!("0x{}", "11".repeat(32)),
+            nssa::AccountId::new(bytes).to_string(),
+        ];
+        let ty = IdlType::Primitive("program_id".to_string());
+
+        for input in inputs {
+            assert_eq!(parse_program_id(&input).unwrap(), expected);
+            let parsed = parse_value(&input, &ty).unwrap();
+            assert!(matches!(
+                parsed,
+                ParsedValue::U32Array(values) if values == expected.to_vec()
+            ));
+        }
     }
 }

--- a/spel-cli/src/tx.rs
+++ b/spel-cli/src/tx.rs
@@ -1,5 +1,14 @@
 //! Transaction building and submission.
 
+mod pda_resolution;
+mod resolution;
+mod value;
+
+pub use resolution::{
+    resolve_private_instruction, resolve_public_instruction, ResolvedPrivateInstruction,
+    ResolvedPublicInstruction, SpelInstructionRequest, SpelTxError,
+};
+
 use crate::cli::{snake_to_kebab, to_pascal_case};
 use crate::hex::{decode_bytes_32, hex_encode, parse_account_id};
 use crate::parse::{parse_string_vec, parse_value, ParsedValue};

--- a/spel-cli/src/tx.rs
+++ b/spel-cli/src/tx.rs
@@ -2,11 +2,16 @@
 
 mod pda_resolution;
 mod resolution;
+mod runtime;
 mod value;
 
 pub use resolution::{
     resolve_private_instruction, resolve_public_instruction, ResolvedPrivateInstruction,
     ResolvedPublicInstruction, SpelInstructionRequest, SpelTxError,
+};
+pub use runtime::{
+    BoundSpelProgram, PrivateInstructionBuilder, PublicInstructionBuilder, SpelBuildError,
+    SpelInput, SpelProgram, SpelProgramBinding,
 };
 
 use crate::cli::{snake_to_kebab, to_pascal_case};

--- a/spel-cli/src/tx/pda_resolution.rs
+++ b/spel-cli/src/tx/pda_resolution.rs
@@ -1,0 +1,296 @@
+use std::collections::BTreeMap;
+
+use nssa_core::program::ProgramId;
+use spel_framework_core::{
+    idl::{IdlAccountItem, IdlInstruction, IdlSeed},
+    pda::{compute_pda, compute_private_pda_with_identifier},
+};
+use wallet::AccountIdentity;
+
+use super::{resolution::SpelTxError, value::ArgumentValue};
+
+enum PdaState {
+    Visiting,
+    Done(AccountIdentity),
+}
+
+pub(crate) fn account_seed_target<'a>(
+    instruction: &'a IdlInstruction,
+    path: &str,
+) -> Option<&'a IdlAccountItem> {
+    instruction
+        .accounts
+        .iter()
+        .find(|account| account.name == path)
+        .or_else(|| {
+            path.strip_suffix(".id")
+                .and_then(|name| (!name.is_empty()).then_some(name))
+                .and_then(|name| {
+                    instruction
+                        .accounts
+                        .iter()
+                        .find(|account| account.name == name)
+                })
+        })
+}
+
+pub(crate) fn resolve_pdas(
+    instruction: &IdlInstruction,
+    inputs: &BTreeMap<String, Vec<AccountIdentity>>,
+    arguments: &BTreeMap<String, ArgumentValue>,
+    program_id: ProgramId,
+    private_path: bool,
+) -> Result<BTreeMap<String, AccountIdentity>, SpelTxError> {
+    let pda_names: Vec<_> = instruction
+        .accounts
+        .iter()
+        .filter(|account| account.pda.is_some())
+        .map(|account| account.name.clone())
+        .collect();
+    let mut resolver = PdaResolver {
+        instruction,
+        inputs,
+        arguments,
+        program_id,
+        private_path,
+        states: BTreeMap::new(),
+    };
+
+    for name in &pda_names {
+        resolver.resolve_pda(name)?;
+    }
+
+    Ok(resolver
+        .states
+        .into_iter()
+        .filter_map(|(name, state)| match state {
+            PdaState::Done(identity) => Some((name, identity)),
+            PdaState::Visiting => None,
+        })
+        .collect())
+}
+
+struct PdaResolver<'a> {
+    instruction: &'a IdlInstruction,
+    inputs: &'a BTreeMap<String, Vec<AccountIdentity>>,
+    arguments: &'a BTreeMap<String, ArgumentValue>,
+    program_id: ProgramId,
+    private_path: bool,
+    states: BTreeMap<String, PdaState>,
+}
+
+impl PdaResolver<'_> {
+    fn resolve_pda(&mut self, name: &str) -> Result<AccountIdentity, SpelTxError> {
+        if let Some(state) = self.states.get(name) {
+            return match state {
+                PdaState::Done(identity) => Ok(identity.clone()),
+                PdaState::Visiting => Err(SpelTxError::PdaResolution {
+                    account: name.to_owned(),
+                    seed_index: None,
+                    reason: "PDA dependency cycle".to_string(),
+                }),
+            };
+        }
+
+        let account = self
+            .account(name)
+            .ok_or_else(|| SpelTxError::PdaResolution {
+                account: name.to_owned(),
+                seed_index: None,
+                reason: "PDA account is not declared".to_string(),
+            })?
+            .clone();
+        let pda = account
+            .pda
+            .clone()
+            .ok_or_else(|| SpelTxError::PdaResolution {
+                account: name.to_owned(),
+                seed_index: None,
+                reason: "account is not a PDA".to_string(),
+            })?;
+
+        self.states.insert(name.to_owned(), PdaState::Visiting);
+
+        let mut seeds = Vec::with_capacity(pda.seeds.len());
+        for (seed_index, seed) in pda.seeds.iter().enumerate() {
+            seeds.push(self.resolve_seed(&account.name, seed_index, seed)?);
+        }
+        let seed_refs: Vec<_> = seeds.iter().collect();
+
+        let identity = if pda.private {
+            self.resolve_private_pda(&account, &seed_refs)?
+        } else {
+            AccountIdentity::PublicNoSign(compute_pda(&self.program_id, &seed_refs))
+        };
+
+        self.states
+            .insert(account.name.clone(), PdaState::Done(identity.clone()));
+        Ok(identity)
+    }
+
+    fn resolve_seed(
+        &mut self,
+        account: &str,
+        seed_index: usize,
+        seed: &IdlSeed,
+    ) -> Result<[u8; 32], SpelTxError> {
+        match seed {
+            IdlSeed::Const { value } => constant_seed(value).ok_or_else(|| {
+                self.pda_error(account, Some(seed_index), "constant seed exceeds 32 bytes")
+            }),
+            IdlSeed::Account { path } => {
+                let target = account_seed_target(self.instruction, path)
+                    .ok_or_else(|| {
+                        self.pda_error(
+                            account,
+                            Some(seed_index),
+                            "account seed references an undeclared account",
+                        )
+                    })?
+                    .clone();
+                if target.rest {
+                    return Err(self.pda_error(
+                        account,
+                        Some(seed_index),
+                        "account seed cannot reference a rest account",
+                    ));
+                }
+
+                let identity = if target.pda.is_some() {
+                    if matches!(self.states.get(&target.name), Some(PdaState::Visiting)) {
+                        return Err(self.pda_error(
+                            account,
+                            Some(seed_index),
+                            "PDA dependency cycle",
+                        ));
+                    }
+                    self.resolve_pda(&target.name)?
+                } else {
+                    self.inputs
+                        .get(&target.name)
+                        .and_then(|identities| identities.first())
+                        .cloned()
+                        .ok_or_else(|| {
+                            self.pda_error(
+                                account,
+                                Some(seed_index),
+                                "account seed input is unavailable",
+                            )
+                        })?
+                };
+                Ok(*identity.account_id().value())
+            },
+            IdlSeed::Arg { path } => {
+                let argument = self
+                    .instruction
+                    .args
+                    .iter()
+                    .find(|argument| argument.name == *path)
+                    .ok_or_else(|| {
+                        self.pda_error(
+                            account,
+                            Some(seed_index),
+                            "argument seed references an undeclared argument",
+                        )
+                    })?;
+                let value = self.arguments.get(path).ok_or_else(|| {
+                    self.pda_error(
+                        account,
+                        Some(seed_index),
+                        "argument seed input is unavailable",
+                    )
+                })?;
+                value
+                    .seed_bytes(&argument.type_)
+                    .map_err(|reason| self.pda_error(account, Some(seed_index), reason))
+            },
+        }
+    }
+
+    fn resolve_private_pda(
+        &self,
+        account: &IdlAccountItem,
+        seeds: &[&[u8; 32]],
+    ) -> Result<AccountIdentity, SpelTxError> {
+        if !self.private_path {
+            return Err(SpelTxError::InvalidIdl {
+                instruction: self.instruction.name.clone(),
+                path: format!("accounts.{}", account.name),
+                reason: "public resolution does not support private PDAs".to_string(),
+            });
+        }
+
+        let identity = self
+            .inputs
+            .get(&account.name)
+            .and_then(|identities| identities.first())
+            .cloned()
+            .ok_or_else(|| SpelTxError::MissingAccount {
+                name: account.name.clone(),
+            })?;
+        let (npk, identifier) = match &identity {
+            AccountIdentity::PrivatePdaForeign {
+                npk, identifier, ..
+            }
+            | AccountIdentity::PrivatePdaShared {
+                npk, identifier, ..
+            } => (npk, *identifier),
+            _ => {
+                return Err(SpelTxError::InvalidAccount {
+                    account: account.name.clone(),
+                    index: self.account_index(&account.name),
+                    reason: "private PDA initialization requires a foreign or shared private PDA identity"
+                        .to_string(),
+                });
+            },
+        };
+
+        let expected =
+            compute_private_pda_with_identifier(&self.program_id, seeds, npk, identifier);
+        if identity.account_id() != expected {
+            return Err(SpelTxError::InvalidAccount {
+                account: account.name.clone(),
+                index: self.account_index(&account.name),
+                reason: "private PDA identity does not match the derived address".to_string(),
+            });
+        }
+
+        Ok(identity)
+    }
+
+    fn account(&self, name: &str) -> Option<&IdlAccountItem> {
+        self.instruction
+            .accounts
+            .iter()
+            .find(|account| account.name == name)
+    }
+
+    fn account_index(&self, name: &str) -> usize {
+        self.instruction
+            .accounts
+            .iter()
+            .position(|account| account.name == name)
+            .unwrap_or_default()
+    }
+
+    fn pda_error(
+        &self,
+        account: &str,
+        seed_index: Option<usize>,
+        reason: impl Into<String>,
+    ) -> SpelTxError {
+        SpelTxError::PdaResolution {
+            account: account.to_owned(),
+            seed_index,
+            reason: reason.into(),
+        }
+    }
+}
+
+fn constant_seed(value: &str) -> Option<[u8; 32]> {
+    (value.len() <= 32).then(|| {
+        let mut seed = [0; 32];
+        seed[..value.len()].copy_from_slice(value.as_bytes());
+        seed
+    })
+}

--- a/spel-cli/src/tx/resolution.rs
+++ b/spel-cli/src/tx/resolution.rs
@@ -1,0 +1,1834 @@
+//! Fallible, resolver-only IDL transaction inputs.
+//!
+//! This module resolves canonical IDL names, account identities, PDA accounts, and
+//! instruction data. It does not read files, initialize a wallet, build a
+//! transaction, submit a transaction, poll, print, or terminate the process.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::serialize::SerializeError;
+use nssa::privacy_preserving_transaction::circuit::ProgramWithDependencies;
+use nssa_core::program::{InstructionData, ProgramId};
+use spel_framework_core::idl::{IdlInstruction, IdlSeed, SpelIdl};
+use thiserror::Error;
+use wallet::AccountIdentity;
+
+use super::{
+    pda_resolution,
+    value::{self, ArgumentValue, ValueParseError},
+};
+
+/// Raw caller input for resolving one IDL instruction.
+///
+/// Construct this type with exact IDL account and argument names. The resolver
+/// consumes it synchronously and follows IDL declaration order rather than map
+/// order.
+pub struct SpelInstructionRequest<'a> {
+    /// IDL containing the instruction to resolve.
+    pub idl: &'a SpelIdl,
+    /// Exact IDL instruction name.
+    pub instruction: &'a str,
+    /// Exact IDL account names mapped to fixed or rest account identities.
+    pub accounts: BTreeMap<String, Vec<AccountIdentity>>,
+    /// Exact IDL argument names mapped to canonical or CLI-compatible input text.
+    ///
+    /// Canonical JSON is preferred for containers; established valid CLI forms
+    /// remain accepted.
+    pub arguments: BTreeMap<String, String>,
+}
+
+/// Resolved inputs for a public Wallet transaction build.
+pub struct ResolvedPublicInstruction {
+    program_id: ProgramId,
+    accounts: Vec<AccountIdentity>,
+    instruction_data: InstructionData,
+}
+
+impl ResolvedPublicInstruction {
+    /// Returns the target program ID.
+    #[must_use]
+    pub const fn program_id(&self) -> ProgramId {
+        self.program_id
+    }
+
+    /// Returns ordered Wallet account identities.
+    #[must_use]
+    pub fn accounts(&self) -> &[AccountIdentity] {
+        &self.accounts
+    }
+
+    /// Returns the RISC0-serialized instruction words.
+    #[must_use]
+    pub fn instruction_data(&self) -> &[u32] {
+        &self.instruction_data
+    }
+
+    /// Consumes the resolved instruction into Wallet build inputs.
+    #[must_use]
+    pub fn into_parts(self) -> (ProgramId, Vec<AccountIdentity>, InstructionData) {
+        (self.program_id, self.accounts, self.instruction_data)
+    }
+}
+
+/// Resolved inputs for a privacy-preserving Wallet transaction build.
+pub struct ResolvedPrivateInstruction {
+    program: ProgramWithDependencies,
+    accounts: Vec<AccountIdentity>,
+    instruction_data: InstructionData,
+}
+
+impl ResolvedPrivateInstruction {
+    /// Returns the caller-supplied program and dependency binaries.
+    #[must_use]
+    pub const fn program(&self) -> &ProgramWithDependencies {
+        &self.program
+    }
+
+    /// Returns ordered Wallet account identities.
+    #[must_use]
+    pub fn accounts(&self) -> &[AccountIdentity] {
+        &self.accounts
+    }
+
+    /// Returns the RISC0-serialized instruction words.
+    #[must_use]
+    pub fn instruction_data(&self) -> &[u32] {
+        &self.instruction_data
+    }
+
+    /// Consumes the resolved instruction into Wallet build inputs.
+    #[must_use]
+    pub fn into_parts(
+        self,
+    ) -> (
+        ProgramWithDependencies,
+        Vec<AccountIdentity>,
+        InstructionData,
+    ) {
+        (self.program, self.accounts, self.instruction_data)
+    }
+}
+
+/// Structured failure returned by the resolver-only transaction API.
+#[non_exhaustive]
+#[derive(Debug, Error)]
+pub enum SpelTxError {
+    /// No IDL instruction has the requested exact name.
+    #[error("unknown instruction `{instruction}`")]
+    UnknownInstruction {
+        /// Requested instruction name.
+        instruction: String,
+    },
+    /// More than one IDL instruction has the requested exact name.
+    #[error("ambiguous instruction `{instruction}`")]
+    AmbiguousInstruction {
+        /// Requested instruction name.
+        instruction: String,
+        /// Number of matching instruction declarations.
+        matches: usize,
+    },
+    /// The selected IDL instruction has an unsupported or malformed shape.
+    #[error("invalid IDL for instruction `{instruction}` at `{path}`: {reason}")]
+    InvalidIdl {
+        /// Selected instruction name.
+        instruction: String,
+        /// IDL-relative path of the invalid declaration.
+        path: String,
+        /// Redacted, human-readable explanation.
+        reason: String,
+    },
+    /// A required account input is absent.
+    #[error("missing account `{name}`")]
+    MissingAccount {
+        /// Exact IDL account name.
+        name: String,
+    },
+    /// An account input is unknown or forbidden for the IDL account shape.
+    #[error("unexpected account `{name}`")]
+    UnexpectedAccount {
+        /// Exact caller-supplied account name.
+        name: String,
+    },
+    /// An account input has the wrong number of identities.
+    #[error("invalid account count for `{name}`: expected {expected}, got {actual}")]
+    InvalidAccountCount {
+        /// Exact IDL account name.
+        name: String,
+        /// Required identity count.
+        expected: usize,
+        /// Caller-supplied identity count.
+        actual: usize,
+    },
+    /// An identity contradicts the selected resolver path or IDL account flags.
+    #[error("invalid account `{account}` at index {index}: {reason}")]
+    InvalidAccount {
+        /// Exact IDL account name.
+        account: String,
+        /// Zero-based final account position.
+        index: usize,
+        /// Redacted, human-readable explanation.
+        reason: String,
+    },
+    /// A required argument input is absent.
+    #[error("missing argument `{name}`")]
+    MissingArgument {
+        /// Exact IDL argument name.
+        name: String,
+    },
+    /// An argument input does not exist on the selected instruction.
+    #[error("unexpected argument `{name}`")]
+    UnexpectedArgument {
+        /// Exact caller-supplied argument name.
+        name: String,
+    },
+    /// An argument cannot be parsed as its selected IDL type.
+    #[error("failed to parse argument `{name}` at {path:?}: {reason}")]
+    ArgumentParse {
+        /// Exact IDL argument name.
+        name: String,
+        /// Zero-based nested array/vector positions from outermost to innermost.
+        path: Vec<usize>,
+        /// Redacted, human-readable explanation.
+        reason: String,
+    },
+    /// A PDA definition, dependency, or seed cannot be resolved.
+    #[error("failed to resolve PDA `{account}`: {reason}")]
+    PdaResolution {
+        /// Exact IDL PDA account name.
+        account: String,
+        /// Zero-based seed position, or `None` for a whole-PDA failure.
+        seed_index: Option<usize>,
+        /// Redacted, human-readable explanation.
+        reason: String,
+    },
+    /// Two final account positions resolve to the same account ID.
+    #[error("duplicate resolved account `{account}` at index {index}")]
+    DuplicateResolvedAccount {
+        /// First IDL account name that resolved to this ID.
+        first_account: String,
+        /// First zero-based final account position.
+        first_index: usize,
+        /// Duplicate IDL account name.
+        account: String,
+        /// Duplicate zero-based final account position.
+        index: usize,
+    },
+    /// RISC0 serialization of resolved instruction fields failed.
+    #[error("failed to serialize instruction `{instruction}`")]
+    InstructionSerialization {
+        /// Selected instruction name.
+        instruction: String,
+        /// Concrete RISC0 serialization failure.
+        #[source]
+        source: SerializeError,
+    },
+}
+
+/// Resolves one IDL instruction into direct public Wallet build inputs.
+///
+/// ```no_run
+/// use std::collections::BTreeMap;
+///
+/// use nssa_core::program::ProgramId;
+/// use spel::tx::{SpelInstructionRequest, resolve_public_instruction};
+/// use spel_framework_core::idl::SpelIdl;
+/// use wallet::WalletCore;
+///
+/// fn prepare(idl: &SpelIdl, program_id: ProgramId, wallet: &WalletCore) {
+///     let request = SpelInstructionRequest {
+///         idl,
+///         instruction: "initialize",
+///         accounts: BTreeMap::new(),
+///         arguments: BTreeMap::new(),
+///     };
+///     let resolved = resolve_public_instruction(request, program_id).unwrap();
+///     let (program_id, accounts, instruction_data) = resolved.into_parts();
+///     let _build = wallet.build_pub_tx(accounts, instruction_data, program_id);
+/// }
+/// ```
+///
+/// # Errors
+///
+/// Returns [`SpelTxError`] when the selected IDL, caller input, account
+/// identities, PDA dependencies, or instruction serialization is invalid.
+pub fn resolve_public_instruction(
+    request: SpelInstructionRequest<'_>,
+    program_id: ProgramId,
+) -> Result<ResolvedPublicInstruction, SpelTxError> {
+    let resolved = resolve(request, program_id, ResolverPath::Public)?;
+    Ok(ResolvedPublicInstruction {
+        program_id,
+        accounts: resolved.accounts,
+        instruction_data: resolved.instruction_data,
+    })
+}
+
+/// Resolves one IDL instruction into direct privacy-preserving Wallet build inputs.
+///
+/// ```no_run
+/// use std::collections::BTreeMap;
+///
+/// use nssa::privacy_preserving_transaction::circuit::ProgramWithDependencies;
+/// use spel::tx::{SpelInstructionRequest, resolve_private_instruction};
+/// use spel_framework_core::idl::SpelIdl;
+/// use wallet::WalletCore;
+///
+/// fn prepare(idl: &SpelIdl, program: ProgramWithDependencies, wallet: &WalletCore) {
+///     let request = SpelInstructionRequest {
+///         idl,
+///         instruction: "initialize",
+///         accounts: BTreeMap::new(),
+///         arguments: BTreeMap::new(),
+///     };
+///     let resolved = resolve_private_instruction(request, program).unwrap();
+///     let (program, accounts, instruction_data) = resolved.into_parts();
+///     let _build = wallet.build_privacy_preserving_tx(accounts, instruction_data, &program);
+/// }
+/// ```
+///
+/// # Errors
+///
+/// Returns [`SpelTxError`] when the selected IDL, caller input, account
+/// identities, PDA dependencies, or instruction serialization is invalid.
+pub fn resolve_private_instruction(
+    request: SpelInstructionRequest<'_>,
+    program: ProgramWithDependencies,
+) -> Result<ResolvedPrivateInstruction, SpelTxError> {
+    let resolved = resolve(request, program.program.id(), ResolverPath::Private)?;
+    Ok(ResolvedPrivateInstruction {
+        program,
+        accounts: resolved.accounts,
+        instruction_data: resolved.instruction_data,
+    })
+}
+
+enum ResolverPath {
+    Public,
+    Private,
+}
+
+impl ResolverPath {
+    const fn is_private(&self) -> bool {
+        matches!(self, Self::Private)
+    }
+}
+
+struct ResolvedParts {
+    accounts: Vec<AccountIdentity>,
+    instruction_data: InstructionData,
+}
+
+fn resolve(
+    request: SpelInstructionRequest<'_>,
+    program_id: ProgramId,
+    path: ResolverPath,
+) -> Result<ResolvedParts, SpelTxError> {
+    let SpelInstructionRequest {
+        idl,
+        instruction: instruction_name,
+        accounts: inputs,
+        arguments: raw_arguments,
+    } = request;
+    let (instruction_index, instruction) = select_instruction(idl, instruction_name)?;
+
+    validate_selected_instruction(instruction, path.is_private())?;
+    validate_account_inputs(instruction, &inputs)?;
+    let arguments = parse_arguments(instruction, &raw_arguments)?;
+    validate_identities(instruction, &inputs, path.is_private())?;
+    let pdas = pda_resolution::resolve_pdas(
+        instruction,
+        &inputs,
+        &arguments,
+        program_id,
+        path.is_private(),
+    )?;
+    let accounts = flatten_accounts(instruction, &inputs, &pdas)?;
+    let variant_index = u32::try_from(instruction_index)
+        .map_err(|_| invalid_idl(instruction, "instructions", "instruction index exceeds u32"))?;
+    let fields: Vec<_> = instruction
+        .args
+        .iter()
+        .map(|argument| {
+            arguments
+                .get(&argument.name)
+                .ok_or_else(|| SpelTxError::MissingArgument {
+                    name: argument.name.clone(),
+                })
+        })
+        .collect::<Result<_, _>>()?;
+    let instruction_data =
+        value::serialize_instruction(variant_index, &fields).map_err(|source| {
+            SpelTxError::InstructionSerialization {
+                instruction: instruction.name.clone(),
+                source,
+            }
+        })?;
+
+    Ok(ResolvedParts {
+        accounts,
+        instruction_data,
+    })
+}
+
+fn select_instruction<'a>(
+    idl: &'a SpelIdl,
+    instruction: &str,
+) -> Result<(usize, &'a IdlInstruction), SpelTxError> {
+    let matches: Vec<_> = idl
+        .instructions
+        .iter()
+        .enumerate()
+        .filter(|(_, candidate)| candidate.name == instruction)
+        .collect();
+    match matches.as_slice() {
+        [] => Err(SpelTxError::UnknownInstruction {
+            instruction: instruction.to_owned(),
+        }),
+        [(index, selected)] => Ok((*index, *selected)),
+        _ => Err(SpelTxError::AmbiguousInstruction {
+            instruction: instruction.to_owned(),
+            matches: matches.len(),
+        }),
+    }
+}
+
+fn validate_selected_instruction(
+    instruction: &IdlInstruction,
+    private_path: bool,
+) -> Result<(), SpelTxError> {
+    let mut account_names = BTreeSet::new();
+    let mut rest_seen = false;
+    for (index, account) in instruction.accounts.iter().enumerate() {
+        let path = format!("accounts[{index}]");
+        if account.name.is_empty() {
+            return Err(invalid_idl(instruction, &path, "account name is empty"));
+        }
+        if !account_names.insert(&account.name) {
+            return Err(invalid_idl(instruction, &path, "duplicate account name"));
+        }
+        if account.rest {
+            if rest_seen || index + 1 != instruction.accounts.len() {
+                return Err(invalid_idl(
+                    instruction,
+                    &path,
+                    "rest account must be the only final account",
+                ));
+            }
+            if account.pda.is_some() {
+                return Err(invalid_idl(
+                    instruction,
+                    &path,
+                    "rest account cannot be a PDA",
+                ));
+            }
+            rest_seen = true;
+        }
+        if account.pda.is_some() && account.signer {
+            return Err(invalid_idl(
+                instruction,
+                &path,
+                "PDA account cannot be a signer",
+            ));
+        }
+        if account.init && !account.writable {
+            return Err(invalid_idl(
+                instruction,
+                &path,
+                "initialized account must be writable",
+            ));
+        }
+        if let Some(pda) = &account.pda {
+            if pda.private {
+                if !private_path {
+                    return Err(invalid_idl(
+                        instruction,
+                        &path,
+                        "public resolution does not support private PDAs",
+                    ));
+                }
+                if !account.init {
+                    return Err(invalid_idl(
+                        instruction,
+                        &path,
+                        "private PDA reuse is unsupported",
+                    ));
+                }
+            }
+        }
+    }
+
+    let mut argument_names = BTreeSet::new();
+    for (index, argument) in instruction.args.iter().enumerate() {
+        let path = format!("args[{index}]");
+        if argument.name.is_empty() {
+            return Err(invalid_idl(instruction, &path, "argument name is empty"));
+        }
+        if !argument_names.insert(&argument.name) {
+            return Err(invalid_idl(instruction, &path, "duplicate argument name"));
+        }
+        value::validate_type(&argument.type_)
+            .map_err(|reason| invalid_idl(instruction, &path, reason))?;
+    }
+
+    validate_pda_definitions(instruction)?;
+
+    Ok(())
+}
+
+fn validate_pda_definitions(instruction: &IdlInstruction) -> Result<(), SpelTxError> {
+    for account in &instruction.accounts {
+        let Some(pda) = &account.pda else {
+            continue;
+        };
+        if pda.seeds.is_empty() {
+            return Err(pda_resolution_error(
+                &account.name,
+                None,
+                "PDA requires at least one seed",
+            ));
+        }
+
+        for (seed_index, seed) in pda.seeds.iter().enumerate() {
+            match seed {
+                IdlSeed::Const { value } if value.len() > 32 => {
+                    return Err(pda_resolution_error(
+                        &account.name,
+                        Some(seed_index),
+                        "constant seed exceeds 32 bytes",
+                    ));
+                },
+                IdlSeed::Const { .. } => {},
+                IdlSeed::Account { path } => {
+                    let target = pda_resolution::account_seed_target(instruction, path)
+                        .ok_or_else(|| {
+                            pda_resolution_error(
+                                &account.name,
+                                Some(seed_index),
+                                "account seed references an undeclared account",
+                            )
+                        })?;
+                    if target.rest {
+                        return Err(pda_resolution_error(
+                            &account.name,
+                            Some(seed_index),
+                            "account seed cannot reference a rest account",
+                        ));
+                    }
+                },
+                IdlSeed::Arg { path } => {
+                    let argument = instruction
+                        .args
+                        .iter()
+                        .find(|argument| argument.name == *path)
+                        .ok_or_else(|| {
+                            pda_resolution_error(
+                                &account.name,
+                                Some(seed_index),
+                                "argument seed references an undeclared argument",
+                            )
+                        })?;
+                    value::validate_seed_type(&argument.type_).map_err(|reason| {
+                        pda_resolution_error(&account.name, Some(seed_index), reason)
+                    })?;
+                },
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_account_inputs(
+    instruction: &IdlInstruction,
+    inputs: &BTreeMap<String, Vec<AccountIdentity>>,
+) -> Result<(), SpelTxError> {
+    for name in inputs.keys() {
+        let Some(account) = instruction
+            .accounts
+            .iter()
+            .find(|account| account.name == *name)
+        else {
+            return Err(SpelTxError::UnexpectedAccount { name: name.clone() });
+        };
+        if matches!(&account.pda, Some(pda) if !pda.private) {
+            return Err(SpelTxError::UnexpectedAccount { name: name.clone() });
+        }
+    }
+
+    for account in &instruction.accounts {
+        if account.rest || matches!(&account.pda, Some(pda) if !pda.private) {
+            continue;
+        }
+        let Some(identities) = inputs.get(&account.name) else {
+            return Err(SpelTxError::MissingAccount {
+                name: account.name.clone(),
+            });
+        };
+        if identities.len() != 1 {
+            return Err(SpelTxError::InvalidAccountCount {
+                name: account.name.clone(),
+                expected: 1,
+                actual: identities.len(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn parse_arguments(
+    instruction: &IdlInstruction,
+    raw_arguments: &BTreeMap<String, String>,
+) -> Result<BTreeMap<String, ArgumentValue>, SpelTxError> {
+    for name in raw_arguments.keys() {
+        if !instruction
+            .args
+            .iter()
+            .any(|argument| argument.name == *name)
+        {
+            return Err(SpelTxError::UnexpectedArgument { name: name.clone() });
+        }
+    }
+
+    let mut arguments = BTreeMap::new();
+    for argument in &instruction.args {
+        let raw =
+            raw_arguments
+                .get(&argument.name)
+                .ok_or_else(|| SpelTxError::MissingArgument {
+                    name: argument.name.clone(),
+                })?;
+        let value = value::parse_argument(raw, &argument.type_)
+            .map_err(|error| argument_parse_error(&argument.name, error))?;
+        arguments.insert(argument.name.clone(), value);
+    }
+    Ok(arguments)
+}
+
+fn validate_identities(
+    instruction: &IdlInstruction,
+    inputs: &BTreeMap<String, Vec<AccountIdentity>>,
+    private_path: bool,
+) -> Result<(), SpelTxError> {
+    for (account_index, account) in instruction.accounts.iter().enumerate() {
+        if account.pda.is_some() {
+            continue;
+        }
+        let identities = inputs
+            .get(&account.name)
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        for (identity_index, identity) in identities.iter().enumerate() {
+            let index = account_index + identity_index;
+            if !private_path && !identity.is_public() {
+                return Err(SpelTxError::InvalidAccount {
+                    account: account.name.clone(),
+                    index,
+                    reason: "public resolution does not accept private identities".to_string(),
+                });
+            }
+            if account.init && matches!(identity, AccountIdentity::PublicNoSign(_)) {
+                return Err(SpelTxError::InvalidAccount {
+                    account: account.name.clone(),
+                    index,
+                    reason: "initialized non-PDA account requires signing intent".to_string(),
+                });
+            }
+            if account.signer && !identity_can_sign(identity) {
+                return Err(SpelTxError::InvalidAccount {
+                    account: account.name.clone(),
+                    index,
+                    reason: "signer account requires signing-capable identity intent".to_string(),
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn flatten_accounts(
+    instruction: &IdlInstruction,
+    inputs: &BTreeMap<String, Vec<AccountIdentity>>,
+    pdas: &BTreeMap<String, AccountIdentity>,
+) -> Result<Vec<AccountIdentity>, SpelTxError> {
+    let mut resolved = Vec::new();
+    for account in &instruction.accounts {
+        if account.pda.is_some() {
+            let identity =
+                pdas.get(&account.name)
+                    .cloned()
+                    .ok_or_else(|| SpelTxError::PdaResolution {
+                        account: account.name.clone(),
+                        seed_index: None,
+                        reason: "PDA did not resolve".to_string(),
+                    })?;
+            resolved.push((account.name.clone(), identity));
+        } else if account.rest {
+            if let Some(identities) = inputs.get(&account.name) {
+                resolved.extend(
+                    identities
+                        .iter()
+                        .cloned()
+                        .map(|identity| (account.name.clone(), identity)),
+                );
+            }
+        } else {
+            let identity = inputs
+                .get(&account.name)
+                .and_then(|identities| identities.first())
+                .cloned()
+                .ok_or_else(|| SpelTxError::MissingAccount {
+                    name: account.name.clone(),
+                })?;
+            resolved.push((account.name.clone(), identity));
+        }
+    }
+
+    let mut seen = Vec::<(String, usize, nssa::AccountId)>::new();
+    for (index, (account, identity)) in resolved.iter().enumerate() {
+        let account_id = identity.account_id();
+        if let Some((first_account, first_index, _)) =
+            seen.iter().find(|(_, _, seen_id)| *seen_id == account_id)
+        {
+            return Err(SpelTxError::DuplicateResolvedAccount {
+                first_account: first_account.clone(),
+                first_index: *first_index,
+                account: account.clone(),
+                index,
+            });
+        }
+        seen.push((account.clone(), index, account_id));
+    }
+
+    Ok(resolved.into_iter().map(|(_, identity)| identity).collect())
+}
+
+fn identity_can_sign(identity: &AccountIdentity) -> bool {
+    matches!(
+        identity,
+        AccountIdentity::Public(_)
+            | AccountIdentity::PublicKeycard { .. }
+            | AccountIdentity::PrivateOwned(_)
+            | AccountIdentity::PrivatePdaOwned(_)
+            | AccountIdentity::PrivateShared { .. }
+            | AccountIdentity::PrivatePdaShared { .. }
+    )
+}
+
+fn argument_parse_error(name: &str, error: ValueParseError) -> SpelTxError {
+    SpelTxError::ArgumentParse {
+        name: name.to_owned(),
+        path: error.path,
+        reason: error.reason,
+    }
+}
+
+fn pda_resolution_error(
+    account: &str,
+    seed_index: Option<usize>,
+    reason: impl Into<String>,
+) -> SpelTxError {
+    SpelTxError::PdaResolution {
+        account: account.to_owned(),
+        seed_index,
+        reason: reason.into(),
+    }
+}
+
+fn invalid_idl(
+    instruction: &IdlInstruction,
+    path: impl Into<String>,
+    reason: impl Into<String>,
+) -> SpelTxError {
+    SpelTxError::InvalidIdl {
+        instruction: instruction.name.clone(),
+        path: path.into(),
+        reason: reason.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use nssa_core::{encryption::ViewingPublicKey, NullifierPublicKey};
+    use risc0_zkvm::serde::Deserializer;
+    use serde::Deserialize;
+    use spel_framework_core::{
+        idl::{IdlAccountItem, IdlArg, IdlPda, IdlSeed, IdlType},
+        pda::{compute_pda, compute_private_pda_with_identifier, seed_from_str},
+    };
+
+    use super::*;
+
+    fn program_id() -> ProgramId {
+        [17; 8]
+    }
+
+    fn make_idl(instructions: Vec<IdlInstruction>) -> SpelIdl {
+        let mut idl = SpelIdl::new("resolver-test");
+        idl.instructions = instructions;
+        idl
+    }
+
+    fn instruction(name: &str, accounts: Vec<IdlAccountItem>, args: Vec<IdlArg>) -> IdlInstruction {
+        IdlInstruction {
+            name: name.to_string(),
+            accounts,
+            args,
+            discriminator: None,
+            execution: None,
+            variant: None,
+        }
+    }
+
+    fn account(name: &str) -> IdlAccountItem {
+        IdlAccountItem {
+            name: name.to_string(),
+            writable: false,
+            signer: false,
+            init: false,
+            owner: None,
+            pda: None,
+            rest: false,
+            visibility: vec![],
+        }
+    }
+
+    fn pda_account(name: &str, private: bool, seeds: Vec<IdlSeed>) -> IdlAccountItem {
+        let mut account = account(name);
+        account.pda = Some(IdlPda { seeds, private });
+        account
+    }
+
+    fn arg(name: &str, type_: IdlType) -> IdlArg {
+        IdlArg {
+            name: name.to_string(),
+            type_,
+        }
+    }
+
+    fn public_identity(byte: u8) -> AccountIdentity {
+        AccountIdentity::Public(nssa::AccountId::new([byte; 32]))
+    }
+
+    fn identity_variants() -> Vec<AccountIdentity> {
+        let vpk = ViewingPublicKey::from_seed(&[11; 32], &[12; 32]);
+        vec![
+            AccountIdentity::Public(nssa::AccountId::new([1; 32])),
+            AccountIdentity::PublicNoSign(nssa::AccountId::new([2; 32])),
+            AccountIdentity::PublicKeycard {
+                account_id: nssa::AccountId::new([3; 32]),
+                key_path: "m/44'/60'/0'/0/0".to_string(),
+            },
+            AccountIdentity::PrivateOwned(nssa::AccountId::new([4; 32])),
+            AccountIdentity::PrivateForeign {
+                npk: NullifierPublicKey([5; 32]),
+                vpk: vpk.clone(),
+                identifier: 5,
+            },
+            AccountIdentity::PrivatePdaOwned(nssa::AccountId::new([6; 32])),
+            AccountIdentity::PrivatePdaForeign {
+                account_id: nssa::AccountId::new([7; 32]),
+                npk: NullifierPublicKey([7; 32]),
+                vpk: vpk.clone(),
+                identifier: 7,
+            },
+            AccountIdentity::PrivateShared {
+                nsk: [8; 32],
+                npk: NullifierPublicKey([8; 32]),
+                vpk: vpk.clone(),
+                identifier: 8,
+            },
+            AccountIdentity::PrivatePdaShared {
+                account_id: nssa::AccountId::new([9; 32]),
+                nsk: [9; 32],
+                npk: NullifierPublicKey([9; 32]),
+                vpk,
+                identifier: 9,
+            },
+        ]
+    }
+
+    #[test]
+    fn applies_public_and_private_identity_path_rules_to_all_wallet_variants() {
+        let idl = make_idl(vec![instruction(
+            "execute",
+            vec![account("account")],
+            vec![],
+        )]);
+        let identities = identity_variants();
+
+        for identity in identities.iter().take(3) {
+            assert!(resolve_public_instruction(
+                SpelInstructionRequest {
+                    idl: &idl,
+                    instruction: "execute",
+                    accounts: BTreeMap::from([("account".to_string(), vec![identity.clone()])]),
+                    arguments: BTreeMap::new(),
+                },
+                program_id(),
+            )
+            .is_ok());
+        }
+
+        for identity in identities.iter().skip(3) {
+            let error = resolve_public_instruction(
+                SpelInstructionRequest {
+                    idl: &idl,
+                    instruction: "execute",
+                    accounts: BTreeMap::from([("account".to_string(), vec![identity.clone()])]),
+                    arguments: BTreeMap::new(),
+                },
+                program_id(),
+            )
+            .err()
+            .expect("public resolution must reject a private identity");
+            assert!(matches!(
+                error,
+                SpelTxError::InvalidAccount {
+                    ref account,
+                    index: 0,
+                    ..
+                } if account == "account"
+            ));
+        }
+
+        for identity in identities {
+            assert!(resolve(
+                SpelInstructionRequest {
+                    idl: &idl,
+                    instruction: "execute",
+                    accounts: BTreeMap::from([("account".to_string(), vec![identity])]),
+                    arguments: BTreeMap::new(),
+                },
+                program_id(),
+                ResolverPath::Private,
+            )
+            .is_ok());
+        }
+    }
+
+    #[test]
+    fn applies_the_signer_intent_matrix_to_all_wallet_variants() {
+        let mut signer = account("signer");
+        signer.signer = true;
+        let idl = make_idl(vec![instruction("execute", vec![signer], vec![])]);
+
+        for (index, identity) in identity_variants().into_iter().enumerate() {
+            let result = resolve(
+                SpelInstructionRequest {
+                    idl: &idl,
+                    instruction: "execute",
+                    accounts: BTreeMap::from([("signer".to_string(), vec![identity])]),
+                    arguments: BTreeMap::new(),
+                },
+                program_id(),
+                ResolverPath::Private,
+            );
+            let accepted = matches!(index, 0 | 2 | 3 | 5 | 7 | 8);
+            assert_eq!(result.is_ok(), accepted, "identity variant {index}");
+            if !accepted {
+                assert!(matches!(
+                    result,
+                    Err(SpelTxError::InvalidAccount {
+                        ref account,
+                        index: 0,
+                        ..
+                    }) if account == "signer"
+                ));
+            }
+        }
+    }
+
+    #[test]
+    fn resolves_in_idl_order_with_public_pda_and_rest_accounts() {
+        let payer = public_identity(1);
+        let member_one = public_identity(2);
+        let member_two = public_identity(3);
+        let state_seed = seed_from_str("state");
+        let expected_state =
+            AccountIdentity::PublicNoSign(compute_pda(&program_id(), &[&state_seed]));
+
+        let mut rest = account("members");
+        rest.rest = true;
+        let idl = make_idl(vec![
+            instruction("ignored", vec![], vec![]),
+            instruction(
+                "execute",
+                vec![
+                    account("payer"),
+                    pda_account(
+                        "state",
+                        false,
+                        vec![IdlSeed::Const {
+                            value: "state".to_string(),
+                        }],
+                    ),
+                    rest,
+                ],
+                vec![arg("amount", IdlType::Primitive("u32".to_string()))],
+            ),
+        ]);
+        let accounts = BTreeMap::from([
+            (
+                "members".to_string(),
+                vec![member_one.clone(), member_two.clone()],
+            ),
+            ("payer".to_string(), vec![payer.clone()]),
+        ]);
+        let arguments = BTreeMap::from([("amount".to_string(), "42".to_string())]);
+
+        let resolved = resolve_public_instruction(
+            SpelInstructionRequest {
+                idl: &idl,
+                instruction: "execute",
+                accounts,
+                arguments,
+            },
+            program_id(),
+        )
+        .unwrap();
+
+        assert_eq!(resolved.program_id(), program_id());
+        assert_eq!(
+            resolved.accounts(),
+            &[payer, expected_state, member_one, member_two]
+        );
+        assert_eq!(resolved.instruction_data(), &[1, 42]);
+    }
+
+    #[test]
+    fn permits_empty_rest_inputs_and_rejects_malformed_rest_layouts() {
+        let mut rest = account("remaining");
+        rest.rest = true;
+        let idl = make_idl(vec![instruction("execute", vec![rest], vec![])]);
+
+        for accounts in [
+            BTreeMap::new(),
+            BTreeMap::from([("remaining".to_string(), vec![])]),
+        ] {
+            let resolved = resolve_public_instruction(
+                SpelInstructionRequest {
+                    idl: &idl,
+                    instruction: "execute",
+                    accounts,
+                    arguments: BTreeMap::new(),
+                },
+                program_id(),
+            )
+            .unwrap();
+            assert!(resolved.accounts().is_empty());
+            assert_eq!(resolved.instruction_data(), &[0]);
+        }
+
+        let unknown = resolve_public_instruction(
+            SpelInstructionRequest {
+                idl: &idl,
+                instruction: "execute",
+                accounts: BTreeMap::from([("unknown".to_string(), vec![])]),
+                arguments: BTreeMap::new(),
+            },
+            program_id(),
+        )
+        .err()
+        .expect("resolver must reject unknown account input");
+        assert!(matches!(
+            unknown,
+            SpelTxError::UnexpectedAccount { ref name } if name == "unknown"
+        ));
+
+        let mut malformed_rest = account("remaining");
+        malformed_rest.rest = true;
+        let malformed_idl = make_idl(vec![instruction(
+            "malformed",
+            vec![malformed_rest, account("after")],
+            vec![],
+        )]);
+        let malformed = resolve_public_instruction(
+            SpelInstructionRequest {
+                idl: &malformed_idl,
+                instruction: "malformed",
+                accounts: BTreeMap::new(),
+                arguments: BTreeMap::new(),
+            },
+            program_id(),
+        )
+        .err()
+        .expect("resolver must reject non-final rest account");
+        assert!(matches!(
+            malformed,
+            SpelTxError::InvalidIdl {
+                ref instruction,
+                ref path,
+                ..
+            } if instruction == "malformed" && path == "accounts[0]"
+        ));
+    }
+
+    #[test]
+    fn rejects_malformed_selected_idl_shapes_before_caller_input() {
+        let mut signer_pda = pda_account(
+            "state",
+            false,
+            vec![IdlSeed::Const {
+                value: "state".to_string(),
+            }],
+        );
+        signer_pda.signer = true;
+        let signer_pda_idl = make_idl(vec![instruction("bad-pda", vec![signer_pda], vec![])]);
+        let signer_pda_error = resolve_public_instruction(
+            SpelInstructionRequest {
+                idl: &signer_pda_idl,
+                instruction: "bad-pda",
+                accounts: BTreeMap::new(),
+                arguments: BTreeMap::new(),
+            },
+            program_id(),
+        )
+        .err()
+        .expect("resolver must reject a signer PDA");
+        assert!(matches!(
+            signer_pda_error,
+            SpelTxError::InvalidIdl {
+                ref instruction,
+                ref path,
+                ..
+            } if instruction == "bad-pda" && path == "accounts[0]"
+        ));
+
+        let unsupported_type_idl = make_idl(vec![instruction(
+            "bad-type",
+            vec![],
+            vec![arg(
+                "value",
+                IdlType::Defined {
+                    defined: "Custom".to_string(),
+                },
+            )],
+        )]);
+        let unsupported_type = resolve_public_instruction(
+            SpelInstructionRequest {
+                idl: &unsupported_type_idl,
+                instruction: "bad-type",
+                accounts: BTreeMap::new(),
+                arguments: BTreeMap::new(),
+            },
+            program_id(),
+        )
+        .err()
+        .expect("resolver must reject defined instruction argument types");
+        assert!(matches!(
+            unsupported_type,
+            SpelTxError::InvalidIdl {
+                ref instruction,
+                ref path,
+                ..
+            } if instruction == "bad-type" && path == "args[0]"
+        ));
+
+        let mut private_pda = pda_account(
+            "state",
+            true,
+            vec![IdlSeed::Const {
+                value: "state".to_string(),
+            }],
+        );
+        private_pda.writable = true;
+        let private_reuse_idl = make_idl(vec![instruction(
+            "private-reuse",
+            vec![private_pda],
+            vec![],
+        )]);
+        let private_reuse = resolve(
+            SpelInstructionRequest {
+                idl: &private_reuse_idl,
+                instruction: "private-reuse",
+                accounts: BTreeMap::new(),
+                arguments: BTreeMap::new(),
+            },
+            program_id(),
+            ResolverPath::Private,
+        )
+        .err()
+        .expect("top-level private PDA reuse is unsupported");
+        assert!(matches!(
+            private_reuse,
+            SpelTxError::InvalidIdl {
+                ref instruction,
+                ref path,
+                ..
+            } if instruction == "private-reuse" && path == "accounts[0]"
+        ));
+    }
+
+    #[test]
+    fn resolves_exact_account_seed_name_before_id_alias() {
+        let owner = public_identity(1);
+        let literal_owner_id = public_identity(2);
+        let idl = make_idl(vec![instruction(
+            "derive",
+            vec![
+                account("owner"),
+                account("owner.id"),
+                pda_account(
+                    "state",
+                    false,
+                    vec![IdlSeed::Account {
+                        path: "owner.id".to_string(),
+                    }],
+                ),
+            ],
+            vec![],
+        )]);
+        let owner_id_seed = literal_owner_id.account_id().into_value();
+        let expected = compute_pda(&program_id(), &[&owner_id_seed]);
+
+        let resolved = resolve_public_instruction(
+            SpelInstructionRequest {
+                idl: &idl,
+                instruction: "derive",
+                accounts: BTreeMap::from([
+                    ("owner".to_string(), vec![owner.clone()]),
+                    ("owner.id".to_string(), vec![literal_owner_id.clone()]),
+                ]),
+                arguments: BTreeMap::new(),
+            },
+            program_id(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            resolved.accounts(),
+            &[
+                owner,
+                literal_owner_id,
+                AccountIdentity::PublicNoSign(expected),
+            ]
+        );
+    }
+
+    #[test]
+    fn ignores_malformed_unselected_instructions() {
+        let idl = make_idl(vec![
+            instruction("broken", vec![pda_account("bad", false, vec![])], vec![]),
+            instruction("ready", vec![], vec![]),
+        ]);
+
+        let resolved = resolve_public_instruction(
+            SpelInstructionRequest {
+                idl: &idl,
+                instruction: "ready",
+                accounts: BTreeMap::new(),
+                arguments: BTreeMap::new(),
+            },
+            program_id(),
+        )
+        .unwrap();
+
+        assert_eq!(resolved.instruction_data(), &[1]);
+    }
+
+    #[test]
+    fn reports_exact_instruction_selection_errors() {
+        let duplicate_idl = make_idl(vec![
+            instruction("same", vec![], vec![]),
+            instruction("same", vec![], vec![]),
+        ]);
+        let ambiguous = resolve_public_instruction(
+            SpelInstructionRequest {
+                idl: &duplicate_idl,
+                instruction: "same",
+                accounts: BTreeMap::new(),
+                arguments: BTreeMap::new(),
+            },
+            program_id(),
+        )
+        .err()
+        .expect("resolver must reject invalid input");
+        assert!(matches!(
+            ambiguous,
+            SpelTxError::AmbiguousInstruction {
+                ref instruction,
+                matches: 2,
+            } if instruction == "same"
+        ));
+
+        let missing = resolve_public_instruction(
+            SpelInstructionRequest {
+                idl: &duplicate_idl,
+                instruction: "other",
+                accounts: BTreeMap::new(),
+                arguments: BTreeMap::new(),
+            },
+            program_id(),
+        )
+        .err()
+        .expect("resolver must reject invalid input");
+        assert!(matches!(
+            missing,
+            SpelTxError::UnknownInstruction { ref instruction } if instruction == "other"
+        ));
+    }
+
+    #[test]
+    fn validates_account_input_keys_and_counts() {
+        let idl = make_idl(vec![instruction(
+            "execute",
+            vec![
+                account("payer"),
+                pda_account(
+                    "state",
+                    false,
+                    vec![IdlSeed::Const {
+                        value: "state".to_string(),
+                    }],
+                ),
+            ],
+            vec![],
+        )]);
+
+        let missing = resolve_public_instruction(
+            SpelInstructionRequest {
+                idl: &idl,
+                instruction: "execute",
+                accounts: BTreeMap::new(),
+                arguments: BTreeMap::new(),
+            },
+            program_id(),
+        )
+        .err()
+        .expect("resolver must reject invalid input");
+        assert!(matches!(missing, SpelTxError::MissingAccount { ref name } if name == "payer"));
+
+        let public_pda_input = resolve_public_instruction(
+            SpelInstructionRequest {
+                idl: &idl,
+                instruction: "execute",
+                accounts: BTreeMap::from([("state".to_string(), vec![public_identity(1)])]),
+                arguments: BTreeMap::new(),
+            },
+            program_id(),
+        )
+        .err()
+        .expect("resolver must reject invalid input");
+        assert!(matches!(
+            public_pda_input,
+            SpelTxError::UnexpectedAccount { ref name } if name == "state"
+        ));
+
+        let invalid_count = resolve_public_instruction(
+            SpelInstructionRequest {
+                idl: &idl,
+                instruction: "execute",
+                accounts: BTreeMap::from([("payer".to_string(), vec![])]),
+                arguments: BTreeMap::new(),
+            },
+            program_id(),
+        )
+        .err()
+        .expect("resolver must reject invalid input");
+        assert!(matches!(
+            invalid_count,
+            SpelTxError::InvalidAccountCount {
+                ref name,
+                expected: 1,
+                actual: 0,
+            } if name == "payer"
+        ));
+    }
+
+    #[test]
+    fn validates_identity_intent_and_duplicate_resolved_accounts() {
+        let private_identity = AccountIdentity::PrivateOwned(nssa::AccountId::new([1; 32]));
+        let idl = make_idl(vec![instruction("execute", vec![account("payer")], vec![])]);
+        let public_error = resolve_public_instruction(
+            SpelInstructionRequest {
+                idl: &idl,
+                instruction: "execute",
+                accounts: BTreeMap::from([("payer".to_string(), vec![private_identity])]),
+                arguments: BTreeMap::new(),
+            },
+            program_id(),
+        )
+        .err()
+        .expect("resolver must reject invalid input");
+        assert!(matches!(
+            public_error,
+            SpelTxError::InvalidAccount {
+                ref account,
+                index: 0,
+                ..
+            } if account == "payer"
+        ));
+
+        let mut initialized = account("new_account");
+        initialized.init = true;
+        initialized.writable = true;
+        let init_idl = make_idl(vec![instruction("init", vec![initialized], vec![])]);
+        let init_error = resolve_public_instruction(
+            SpelInstructionRequest {
+                idl: &init_idl,
+                instruction: "init",
+                accounts: BTreeMap::from([(
+                    "new_account".to_string(),
+                    vec![AccountIdentity::PublicNoSign(nssa::AccountId::new([2; 32]))],
+                )]),
+                arguments: BTreeMap::new(),
+            },
+            program_id(),
+        )
+        .err()
+        .expect("resolver must reject invalid input");
+        assert!(matches!(
+            init_error,
+            SpelTxError::InvalidAccount {
+                ref account,
+                index: 0,
+                ..
+            } if account == "new_account"
+        ));
+
+        let mut rest = account("remaining");
+        rest.rest = true;
+        let duplicate_idl = make_idl(vec![instruction(
+            "duplicate",
+            vec![account("first"), rest],
+            vec![],
+        )]);
+        let duplicate = public_identity(7);
+        let duplicate_error = resolve_public_instruction(
+            SpelInstructionRequest {
+                idl: &duplicate_idl,
+                instruction: "duplicate",
+                accounts: BTreeMap::from([
+                    ("first".to_string(), vec![duplicate.clone()]),
+                    ("remaining".to_string(), vec![duplicate]),
+                ]),
+                arguments: BTreeMap::new(),
+            },
+            program_id(),
+        )
+        .err()
+        .expect("resolver must reject invalid input");
+        assert!(matches!(
+            duplicate_error,
+            SpelTxError::DuplicateResolvedAccount {
+                ref first_account,
+                first_index: 0,
+                ref account,
+                index: 1,
+            } if first_account == "first" && account == "remaining"
+        ));
+    }
+
+    #[test]
+    fn private_resolution_accepts_private_non_pda_and_checks_private_pda_identity() {
+        let owned = AccountIdentity::PrivateOwned(nssa::AccountId::new([4; 32]));
+        let non_pda_idl = make_idl(vec![instruction("private", vec![account("owner")], vec![])]);
+        let resolved = resolve(
+            SpelInstructionRequest {
+                idl: &non_pda_idl,
+                instruction: "private",
+                accounts: BTreeMap::from([("owner".to_string(), vec![owned.clone()])]),
+                arguments: BTreeMap::new(),
+            },
+            program_id(),
+            ResolverPath::Private,
+        )
+        .unwrap();
+        assert_eq!(resolved.accounts, vec![owned]);
+
+        let mut private_pda = pda_account(
+            "vault",
+            true,
+            vec![IdlSeed::Const {
+                value: "vault".to_string(),
+            }],
+        );
+        private_pda.init = true;
+        private_pda.writable = true;
+        let private_pda_idl = make_idl(vec![instruction("create", vec![private_pda], vec![])]);
+        let seed = seed_from_str("vault");
+        let npk = NullifierPublicKey([5; 32]);
+        let identifier = 9;
+        let account_id =
+            compute_private_pda_with_identifier(&program_id(), &[&seed], &npk, identifier);
+        let identity = AccountIdentity::PrivatePdaForeign {
+            account_id,
+            npk,
+            vpk: ViewingPublicKey::from_seed(&[6; 32], &[7; 32]),
+            identifier,
+        };
+
+        let missing = resolve(
+            SpelInstructionRequest {
+                idl: &private_pda_idl,
+                instruction: "create",
+                accounts: BTreeMap::new(),
+                arguments: BTreeMap::new(),
+            },
+            program_id(),
+            ResolverPath::Private,
+        )
+        .err()
+        .expect("private PDA input is required");
+        assert!(matches!(missing, SpelTxError::MissingAccount { ref name } if name == "vault"));
+
+        let invalid_count = resolve(
+            SpelInstructionRequest {
+                idl: &private_pda_idl,
+                instruction: "create",
+                accounts: BTreeMap::from([(
+                    "vault".to_string(),
+                    vec![identity.clone(), identity.clone()],
+                )]),
+                arguments: BTreeMap::new(),
+            },
+            program_id(),
+            ResolverPath::Private,
+        )
+        .err()
+        .expect("private PDA input must have exactly one identity");
+        assert!(matches!(
+            invalid_count,
+            SpelTxError::InvalidAccountCount {
+                ref name,
+                expected: 1,
+                actual: 2,
+            } if name == "vault"
+        ));
+
+        let unsupported_identity = resolve(
+            SpelInstructionRequest {
+                idl: &private_pda_idl,
+                instruction: "create",
+                accounts: BTreeMap::from([(
+                    "vault".to_string(),
+                    vec![AccountIdentity::PrivatePdaOwned(account_id)],
+                )]),
+                arguments: BTreeMap::new(),
+            },
+            program_id(),
+            ResolverPath::Private,
+        )
+        .err()
+        .expect("owned private PDA initialization is unsupported");
+        assert!(matches!(
+            unsupported_identity,
+            SpelTxError::InvalidAccount {
+                ref account,
+                index: 0,
+                ..
+            } if account == "vault"
+        ));
+
+        let resolved = resolve(
+            SpelInstructionRequest {
+                idl: &private_pda_idl,
+                instruction: "create",
+                accounts: BTreeMap::from([("vault".to_string(), vec![identity.clone()])]),
+                arguments: BTreeMap::new(),
+            },
+            program_id(),
+            ResolverPath::Private,
+        )
+        .unwrap();
+        assert_eq!(resolved.accounts, vec![identity]);
+
+        let mismatch = resolve(
+            SpelInstructionRequest {
+                idl: &private_pda_idl,
+                instruction: "create",
+                accounts: BTreeMap::from([(
+                    "vault".to_string(),
+                    vec![AccountIdentity::PrivatePdaForeign {
+                        account_id: nssa::AccountId::new([8; 32]),
+                        npk: NullifierPublicKey([5; 32]),
+                        vpk: ViewingPublicKey::from_seed(&[6; 32], &[7; 32]),
+                        identifier,
+                    }],
+                )]),
+                arguments: BTreeMap::new(),
+            },
+            program_id(),
+            ResolverPath::Private,
+        )
+        .err()
+        .expect("resolver must reject invalid input");
+        assert!(matches!(
+            mismatch,
+            SpelTxError::InvalidAccount {
+                ref account,
+                index: 0,
+                ..
+            } if account == "vault"
+        ));
+    }
+
+    #[test]
+    fn resolves_pda_dependencies_and_rejects_cycles_and_empty_seed_lists() {
+        let idl = make_idl(vec![instruction(
+            "derive",
+            vec![
+                account("payer"),
+                pda_account(
+                    "second",
+                    false,
+                    vec![
+                        IdlSeed::Account {
+                            path: "first".to_string(),
+                        },
+                        IdlSeed::Account {
+                            path: "payer.id".to_string(),
+                        },
+                        IdlSeed::Arg {
+                            path: "sequence".to_string(),
+                        },
+                    ],
+                ),
+                pda_account(
+                    "first",
+                    false,
+                    vec![IdlSeed::Const {
+                        value: "first".to_string(),
+                    }],
+                ),
+            ],
+            vec![arg("sequence", IdlType::Primitive("u16".to_string()))],
+        )]);
+        let payer = public_identity(3);
+        let first_seed = seed_from_str("first");
+        let first = compute_pda(&program_id(), &[&first_seed]);
+        let first_value = first.into_value();
+        let payer_value = payer.account_id().into_value();
+        let mut sequence_seed = [0; 32];
+        sequence_seed[..2].copy_from_slice(&513_u16.to_le_bytes());
+        let second = compute_pda(&program_id(), &[&first_value, &payer_value, &sequence_seed]);
+
+        let resolved = resolve_public_instruction(
+            SpelInstructionRequest {
+                idl: &idl,
+                instruction: "derive",
+                accounts: BTreeMap::from([("payer".to_string(), vec![payer.clone()])]),
+                arguments: BTreeMap::from([("sequence".to_string(), "513".to_string())]),
+            },
+            program_id(),
+        )
+        .unwrap();
+        assert_eq!(
+            resolved.accounts(),
+            &[
+                payer,
+                AccountIdentity::PublicNoSign(second),
+                AccountIdentity::PublicNoSign(first),
+            ]
+        );
+
+        let cycle_idl = make_idl(vec![instruction(
+            "cycle",
+            vec![
+                pda_account(
+                    "a",
+                    false,
+                    vec![IdlSeed::Account {
+                        path: "b".to_string(),
+                    }],
+                ),
+                pda_account(
+                    "b",
+                    false,
+                    vec![IdlSeed::Account {
+                        path: "a".to_string(),
+                    }],
+                ),
+            ],
+            vec![],
+        )]);
+        let cycle = resolve_public_instruction(
+            SpelInstructionRequest {
+                idl: &cycle_idl,
+                instruction: "cycle",
+                accounts: BTreeMap::new(),
+                arguments: BTreeMap::new(),
+            },
+            program_id(),
+        )
+        .err()
+        .expect("resolver must reject invalid input");
+        assert!(matches!(
+            cycle,
+            SpelTxError::PdaResolution {
+                ref account,
+                seed_index: Some(0),
+                ..
+            } if account == "b"
+        ));
+
+        let malformed_idl = make_idl(vec![instruction(
+            "empty",
+            vec![pda_account("pda", false, vec![])],
+            vec![],
+        )]);
+        let malformed = resolve_public_instruction(
+            SpelInstructionRequest {
+                idl: &malformed_idl,
+                instruction: "empty",
+                accounts: BTreeMap::new(),
+                arguments: BTreeMap::new(),
+            },
+            program_id(),
+        )
+        .err()
+        .expect("resolver must reject invalid input");
+        assert!(matches!(
+            malformed,
+            SpelTxError::PdaResolution {
+                ref account,
+                seed_index: None,
+                ..
+            } if account == "pda"
+        ));
+
+        let unknown_seed_idl = make_idl(vec![instruction(
+            "unknown-seed",
+            vec![
+                account("payer"),
+                pda_account(
+                    "state",
+                    false,
+                    vec![IdlSeed::Arg {
+                        path: "missing".to_string(),
+                    }],
+                ),
+            ],
+            vec![],
+        )]);
+        let unknown_seed = resolve_public_instruction(
+            SpelInstructionRequest {
+                idl: &unknown_seed_idl,
+                instruction: "unknown-seed",
+                accounts: BTreeMap::new(),
+                arguments: BTreeMap::new(),
+            },
+            program_id(),
+        )
+        .err()
+        .expect("resolver must reject an unknown PDA seed argument");
+        assert!(matches!(
+            unknown_seed,
+            SpelTxError::PdaResolution {
+                ref account,
+                seed_index: Some(0),
+                ..
+            } if account == "state"
+        ));
+    }
+
+    #[test]
+    fn serializes_canonical_arguments_in_idl_order() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        enum TestInstruction {
+            Ignored,
+            Execute {
+                bytes: [u8; 3],
+                values: Vec<u32>,
+                enabled: Option<bool>,
+                maximum: u128,
+            },
+        }
+
+        let idl = make_idl(vec![
+            instruction("ignored", vec![], vec![]),
+            instruction(
+                "execute",
+                vec![],
+                vec![
+                    arg(
+                        "bytes",
+                        IdlType::Array {
+                            array: (Box::new(IdlType::Primitive("u8".to_string())), 3),
+                        },
+                    ),
+                    arg(
+                        "values",
+                        IdlType::Vec {
+                            vec: Box::new(IdlType::Primitive("u32".to_string())),
+                        },
+                    ),
+                    arg(
+                        "enabled",
+                        IdlType::Option {
+                            option: Box::new(IdlType::Primitive("bool".to_string())),
+                        },
+                    ),
+                    arg("maximum", IdlType::Primitive("u128".to_string())),
+                ],
+            ),
+        ]);
+        let resolved = resolve_public_instruction(
+            SpelInstructionRequest {
+                idl: &idl,
+                instruction: "execute",
+                accounts: BTreeMap::new(),
+                arguments: BTreeMap::from([
+                    ("values".to_string(), "[4,5]".to_string()),
+                    (
+                        "maximum".to_string(),
+                        "+340282366920938463463374607431768211455".to_string(),
+                    ),
+                    ("enabled".to_string(), "true".to_string()),
+                    ("bytes".to_string(), "[1,2,3]".to_string()),
+                ]),
+            },
+            program_id(),
+        )
+        .unwrap();
+        let instruction =
+            TestInstruction::deserialize(&mut Deserializer::new(resolved.instruction_data()))
+                .unwrap();
+
+        assert_eq!(
+            instruction,
+            TestInstruction::Execute {
+                bytes: [1, 2, 3],
+                values: vec![4, 5],
+                enabled: Some(true),
+                maximum: u128::MAX,
+            }
+        );
+    }
+
+    #[test]
+    fn reports_nested_argument_parse_paths() {
+        let idl = make_idl(vec![instruction(
+            "execute",
+            vec![],
+            vec![arg(
+                "values",
+                IdlType::Vec {
+                    vec: Box::new(IdlType::Primitive("u32".to_string())),
+                },
+            )],
+        )]);
+        let error = resolve_public_instruction(
+            SpelInstructionRequest {
+                idl: &idl,
+                instruction: "execute",
+                accounts: BTreeMap::new(),
+                arguments: BTreeMap::from([("values".to_string(), "[1,\"bad\"]".to_string())]),
+            },
+            program_id(),
+        )
+        .err()
+        .expect("resolver must reject invalid input");
+
+        assert!(matches!(
+            error,
+            SpelTxError::ArgumentParse {
+                ref name,
+                path: ref actual_path,
+                ..
+            } if name == "values" && actual_path == &[1]
+        ));
+    }
+}

--- a/spel-cli/src/tx/resolution.rs
+++ b/spel-cli/src/tx/resolution.rs
@@ -127,6 +127,38 @@ pub enum SpelTxError {
         /// Number of matching instruction declarations.
         matches: usize,
     },
+    /// A public instruction builder was requested from a private program binding.
+    #[error("public instruction requires a public program binding")]
+    PublicProgramRequired,
+    /// A private instruction builder was requested from a public program binding.
+    #[error("private instruction requires a private program binding")]
+    PrivateProgramRequired,
+    /// A named fluent input matches neither an account nor an argument.
+    #[error("unknown input `{name}`")]
+    UnknownInput {
+        /// Exact caller-supplied input name.
+        name: String,
+    },
+    /// A named fluent input matches both an account and an argument.
+    #[error("ambiguous input `{name}`")]
+    AmbiguousInput {
+        /// Exact caller-supplied input name.
+        name: String,
+    },
+    /// A named fluent input was supplied more than once.
+    #[error("duplicate input `{name}`")]
+    DuplicateInput {
+        /// Exact caller-supplied input name.
+        name: String,
+    },
+    /// A fluent input has a shape incompatible with its selected IDL position.
+    #[error("invalid input `{name}`: {reason}")]
+    InvalidInput {
+        /// Exact caller-supplied input name.
+        name: String,
+        /// Redacted, human-readable explanation.
+        reason: String,
+    },
     /// The selected IDL instruction has an unsupported or malformed shape.
     #[error("invalid IDL for instruction `{instruction}` at `{path}`: {reason}")]
     InvalidIdl {
@@ -294,12 +326,21 @@ pub fn resolve_private_instruction(
     request: SpelInstructionRequest<'_>,
     program: ProgramWithDependencies,
 ) -> Result<ResolvedPrivateInstruction, SpelTxError> {
-    let resolved = resolve(request, program.program.id(), ResolverPath::Private)?;
+    let (accounts, instruction_data) =
+        resolve_private_instruction_parts(request, program.program.id())?;
     Ok(ResolvedPrivateInstruction {
         program,
-        accounts: resolved.accounts,
-        instruction_data: resolved.instruction_data,
+        accounts,
+        instruction_data,
     })
+}
+
+pub(crate) fn resolve_private_instruction_parts(
+    request: SpelInstructionRequest<'_>,
+    program_id: ProgramId,
+) -> Result<(Vec<AccountIdentity>, InstructionData), SpelTxError> {
+    let resolved = resolve(request, program_id, ResolverPath::Private)?;
+    Ok((resolved.accounts, resolved.instruction_data))
 }
 
 enum ResolverPath {
@@ -329,9 +370,8 @@ fn resolve(
         accounts: inputs,
         arguments: raw_arguments,
     } = request;
-    let (instruction_index, instruction) = select_instruction(idl, instruction_name)?;
-
-    validate_selected_instruction(instruction, path.is_private())?;
+    let (instruction_index, instruction) =
+        select_and_validate_instruction(idl, instruction_name, path.is_private())?;
     validate_account_inputs(instruction, &inputs)?;
     let arguments = parse_arguments(instruction, &raw_arguments)?;
     validate_identities(instruction, &inputs, path.is_private())?;
@@ -368,6 +408,16 @@ fn resolve(
         accounts,
         instruction_data,
     })
+}
+
+pub(crate) fn select_and_validate_instruction<'a>(
+    idl: &'a SpelIdl,
+    instruction: &str,
+    private_path: bool,
+) -> Result<(usize, &'a IdlInstruction), SpelTxError> {
+    let (index, selected) = select_instruction(idl, instruction)?;
+    validate_selected_instruction(selected, private_path)?;
+    Ok((index, selected))
 }
 
 fn select_instruction<'a>(

--- a/spel-cli/src/tx/runtime.rs
+++ b/spel-cli/src/tx/runtime.rs
@@ -1,0 +1,1200 @@
+//! Ergonomic runtime-IDL transaction builder selection.
+//!
+//! The public types in this module are re-exported from [`crate::tx`]. They
+//! select and validate an IDL instruction without invoking CLI code or owning
+//! Wallet transaction submission.
+
+use std::collections::BTreeMap;
+
+use nssa::{
+    privacy_preserving_transaction::circuit::ProgramWithDependencies, AccountId,
+    PrivacyPreservingTransaction, PublicTransaction,
+};
+use nssa_core::{program::ProgramId, NullifierPublicKey, SharedSecretKey};
+use serde_json::Value;
+use spel_framework_core::idl::{IdlAccountItem, IdlInstruction, SpelIdl};
+use thiserror::Error;
+use wallet::{AccountIdentity, ExecutionFailureKind, WalletCore};
+
+use crate::hex::hex_encode;
+
+use super::resolution::{
+    resolve_private_instruction, resolve_private_instruction_parts, resolve_public_instruction,
+    select_and_validate_instruction, ResolvedPrivateInstruction, ResolvedPublicInstruction,
+    SpelInstructionRequest, SpelTxError,
+};
+
+/// Runtime-IDL entry point for binding a program and selecting instructions.
+///
+/// ```no_run
+/// use nssa_core::program::ProgramId;
+/// use spel::tx::SpelProgram;
+/// use spel_framework_core::idl::SpelIdl;
+///
+/// fn select(idl: &SpelIdl, program_id: ProgramId) {
+///     let _builder = SpelProgram::new(idl).program(program_id).public("transfer");
+/// }
+/// ```
+#[must_use = "bind a program and select an instruction to create a transaction builder"]
+pub struct SpelProgram<'idl> {
+    idl: &'idl SpelIdl,
+}
+
+impl<'idl> SpelProgram<'idl> {
+    /// Creates an entry point for instructions declared in `idl`.
+    pub const fn new(idl: &'idl SpelIdl) -> Self {
+        Self { idl }
+    }
+
+    /// Binds a public program ID or borrowed private program for reusable instruction selection.
+    pub fn program<'program>(
+        &self,
+        program: impl Into<SpelProgramBinding<'program>>,
+    ) -> BoundSpelProgram<'idl, 'program> {
+        BoundSpelProgram {
+            idl: self.idl,
+            binding: program.into(),
+        }
+    }
+}
+
+/// Public or private program material bound to a [`SpelProgram`].
+#[non_exhaustive]
+pub enum SpelProgramBinding<'program> {
+    /// A public program ID.
+    Public(ProgramId),
+    /// A privacy-preserving program and its dependency binaries.
+    Private(&'program ProgramWithDependencies),
+}
+
+impl From<ProgramId> for SpelProgramBinding<'_> {
+    fn from(program_id: ProgramId) -> Self {
+        Self::Public(program_id)
+    }
+}
+
+impl<'program> From<&'program ProgramWithDependencies> for SpelProgramBinding<'program> {
+    fn from(program: &'program ProgramWithDependencies) -> Self {
+        Self::Private(program)
+    }
+}
+
+/// Failure returned while resolving or building a runtime-IDL instruction.
+#[non_exhaustive]
+#[derive(Debug, Error)]
+pub enum SpelBuildError {
+    /// The selected instruction could not be resolved from its IDL inputs.
+    #[error("failed to resolve instruction: {0}")]
+    Resolution(#[from] SpelTxError),
+    /// An inferred public signer or initialized account has no local Wallet signing key.
+    #[error("missing public signing key for account `{account}`")]
+    MissingPublicSigningKey {
+        /// Exact IDL account name whose inferred public signing key is absent.
+        account: String,
+    },
+    /// Wallet transaction construction failed.
+    #[error("failed to build wallet transaction: {0}")]
+    Wallet(#[from] ExecutionFailureKind),
+}
+
+/// One named runtime-IDL account or argument input.
+///
+/// Account variants are accepted only for IDL account names. Scalar values are
+/// passed to the existing argument parser, while [`Self::Json`] provides
+/// canonical JSON for container arguments.
+pub enum SpelInput {
+    /// One account ID whose public signing intent is inferred from the IDL account flags.
+    AccountId(AccountId),
+    /// One explicit Wallet account identity.
+    AccountIdentity(AccountIdentity),
+    /// Ordered account IDs for one trailing rest account.
+    AccountIds(Vec<AccountId>),
+    /// Ordered explicit Wallet identities for one trailing rest account.
+    AccountIdentities(Vec<AccountIdentity>),
+    /// CLI-compatible scalar or container argument text.
+    ArgumentText(String),
+    /// Canonical JSON for an IDL argument.
+    Json(Value),
+}
+
+impl From<AccountId> for SpelInput {
+    fn from(account_id: AccountId) -> Self {
+        Self::AccountId(account_id)
+    }
+}
+
+impl From<AccountIdentity> for SpelInput {
+    fn from(identity: AccountIdentity) -> Self {
+        Self::AccountIdentity(identity)
+    }
+}
+
+impl From<Vec<AccountId>> for SpelInput {
+    fn from(account_ids: Vec<AccountId>) -> Self {
+        Self::AccountIds(account_ids)
+    }
+}
+
+impl From<Vec<AccountIdentity>> for SpelInput {
+    fn from(identities: Vec<AccountIdentity>) -> Self {
+        Self::AccountIdentities(identities)
+    }
+}
+
+impl From<String> for SpelInput {
+    fn from(value: String) -> Self {
+        Self::ArgumentText(value)
+    }
+}
+
+impl From<&str> for SpelInput {
+    fn from(value: &str) -> Self {
+        Self::ArgumentText(value.to_owned())
+    }
+}
+
+impl From<Value> for SpelInput {
+    fn from(value: Value) -> Self {
+        Self::Json(value)
+    }
+}
+
+impl From<ProgramId> for SpelInput {
+    fn from(program_id: ProgramId) -> Self {
+        Self::ArgumentText(
+            program_id
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(","),
+        )
+    }
+}
+
+impl From<NullifierPublicKey> for SpelInput {
+    fn from(public_key: NullifierPublicKey) -> Self {
+        Self::ArgumentText(hex_encode(&public_key.0))
+    }
+}
+
+macro_rules! argument_text_from {
+    ($($type:ty),+ $(,)?) => {
+        $(
+            impl From<$type> for SpelInput {
+                fn from(value: $type) -> Self {
+                    Self::ArgumentText(value.to_string())
+                }
+            }
+        )+
+    };
+}
+
+argument_text_from!(bool, u8, u16, u32, u64, u128, i8, i16, i32, i64, i128);
+
+/// A reusable IDL and program binding that creates public or private builders.
+#[must_use = "select a public or private instruction from this bound program"]
+pub struct BoundSpelProgram<'idl, 'program> {
+    idl: &'idl SpelIdl,
+    binding: SpelProgramBinding<'program>,
+}
+
+impl<'idl, 'program> BoundSpelProgram<'idl, 'program> {
+    /// Selects a public instruction and validates its static IDL shape.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SpelTxError::PublicProgramRequired`] when this binding is
+    /// private, or a selection/IDL error when `instruction` is invalid.
+    pub fn public(&self, instruction: &str) -> Result<PublicInstructionBuilder<'idl>, SpelTxError> {
+        let SpelProgramBinding::Public(program_id) = self.binding else {
+            return Err(SpelTxError::PublicProgramRequired);
+        };
+        let (_, selected) = select_and_validate_instruction(self.idl, instruction, false)?;
+        Ok(PublicInstructionBuilder {
+            idl: self.idl,
+            instruction: selected,
+            program_id,
+            inputs: InstructionInputs::default(),
+        })
+    }
+
+    /// Selects a privacy-preserving instruction and validates its static IDL shape.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SpelTxError::PrivateProgramRequired`] when this binding is
+    /// public, or a selection/IDL error when `instruction` is invalid.
+    pub fn private(
+        &self,
+        instruction: &str,
+    ) -> Result<PrivateInstructionBuilder<'idl, 'program>, SpelTxError> {
+        let SpelProgramBinding::Private(program) = self.binding else {
+            return Err(SpelTxError::PrivateProgramRequired);
+        };
+        let (_, selected) = select_and_validate_instruction(self.idl, instruction, true)?;
+        Ok(PrivateInstructionBuilder {
+            idl: self.idl,
+            instruction: selected,
+            program,
+            inputs: InstructionInputs::default(),
+        })
+    }
+}
+
+#[derive(Default)]
+struct InstructionInputs {
+    accounts: BTreeMap<String, Vec<AccountIdentity>>,
+    arguments: BTreeMap<String, String>,
+    inferred_public_signers: Vec<InferredPublicSigner>,
+}
+
+struct InferredPublicSigner {
+    account: String,
+    account_id: AccountId,
+}
+
+impl InstructionInputs {
+    fn into_request<'idl>(
+        self,
+        idl: &'idl SpelIdl,
+        instruction: &'idl IdlInstruction,
+    ) -> (SpelInstructionRequest<'idl>, Vec<InferredPublicSigner>) {
+        (
+            SpelInstructionRequest {
+                idl,
+                instruction: &instruction.name,
+                accounts: self.accounts,
+                arguments: self.arguments,
+            },
+            self.inferred_public_signers,
+        )
+    }
+
+    fn insert(
+        &mut self,
+        instruction: &IdlInstruction,
+        name: String,
+        input: SpelInput,
+    ) -> Result<(), SpelTxError> {
+        if self.accounts.contains_key(&name) || self.arguments.contains_key(&name) {
+            return Err(SpelTxError::DuplicateInput { name });
+        }
+
+        let account = instruction
+            .accounts
+            .iter()
+            .find(|account| account.name == name);
+        let argument = instruction
+            .args
+            .iter()
+            .find(|argument| argument.name == name);
+
+        match (account, argument) {
+            (None, None) => Err(SpelTxError::UnknownInput { name }),
+            (Some(_), Some(_)) => Err(SpelTxError::AmbiguousInput { name }),
+            (Some(account), None) => self.insert_account(name, account, input),
+            (None, Some(_)) => self.insert_argument(name, input),
+        }
+    }
+
+    fn insert_all<I>(&mut self, instruction: &IdlInstruction, inputs: I) -> Result<(), SpelTxError>
+    where
+        I: IntoIterator<Item = (String, SpelInput)>,
+    {
+        for (name, input) in inputs {
+            self.insert(instruction, name, input)?;
+        }
+        Ok(())
+    }
+
+    fn insert_account(
+        &mut self,
+        name: String,
+        account: &IdlAccountItem,
+        input: SpelInput,
+    ) -> Result<(), SpelTxError> {
+        match &account.pda {
+            Some(pda) if !pda.private => {
+                Err(invalid_input(name, "public PDA is derived from the IDL"))
+            },
+            Some(_) => {
+                let SpelInput::AccountIdentity(identity) = input else {
+                    return Err(invalid_input(
+                        name,
+                        "private PDA requires an explicit account identity",
+                    ));
+                };
+                self.accounts.insert(name, vec![identity]);
+                Ok(())
+            },
+            None if account.rest => {
+                let identities = match input {
+                    SpelInput::AccountIds(account_ids) => account_ids
+                        .into_iter()
+                        .map(|account_id| self.infer_account_identity(account, account_id))
+                        .collect(),
+                    SpelInput::AccountIdentities(identities) => identities,
+                    _ => {
+                        return Err(invalid_input(
+                            name,
+                            "rest account requires an account ID or identity vector",
+                        ));
+                    },
+                };
+                self.accounts.insert(name, identities);
+                Ok(())
+            },
+            None => {
+                let identity = match input {
+                    SpelInput::AccountId(account_id) => {
+                        self.infer_account_identity(account, account_id)
+                    },
+                    SpelInput::AccountIdentity(identity) => identity,
+                    _ => {
+                        return Err(invalid_input(
+                            name,
+                            "fixed account requires an account ID or account identity",
+                        ));
+                    },
+                };
+                self.accounts.insert(name, vec![identity]);
+                Ok(())
+            },
+        }
+    }
+
+    fn insert_argument(&mut self, name: String, input: SpelInput) -> Result<(), SpelTxError> {
+        let value = match input {
+            SpelInput::ArgumentText(value) => value,
+            SpelInput::Json(value) => serde_json::to_string(&value).map_err(|_error| {
+                invalid_input(name.clone(), "json input could not be serialized")
+            })?,
+            _ => {
+                return Err(invalid_input(name, "argument requires text or JSON input"));
+            },
+        };
+        self.arguments.insert(name, value);
+        Ok(())
+    }
+
+    fn infer_account_identity(
+        &mut self,
+        account: &IdlAccountItem,
+        account_id: AccountId,
+    ) -> AccountIdentity {
+        if requires_public_signing(account) {
+            self.inferred_public_signers.push(InferredPublicSigner {
+                account: account.name.clone(),
+                account_id,
+            });
+            AccountIdentity::Public(account_id)
+        } else {
+            AccountIdentity::PublicNoSign(account_id)
+        }
+    }
+}
+
+fn requires_public_signing(account: &IdlAccountItem) -> bool {
+    account.signer || account.init
+}
+
+fn invalid_input(name: String, reason: &'static str) -> SpelTxError {
+    SpelTxError::InvalidInput {
+        name,
+        reason: reason.to_owned(),
+    }
+}
+
+fn preflight_inferred_public_signers(
+    wallet: &WalletCore,
+    inferred_public_signers: &[InferredPublicSigner],
+) -> Result<(), SpelBuildError> {
+    for signer in inferred_public_signers {
+        if wallet
+            .get_account_public_signing_key(signer.account_id)
+            .is_none()
+        {
+            return Err(SpelBuildError::MissingPublicSigningKey {
+                account: signer.account.clone(),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// A selected public instruction awaiting named inputs.
+#[must_use = "provide inputs, resolve, or build the selected public instruction"]
+pub struct PublicInstructionBuilder<'idl> {
+    idl: &'idl SpelIdl,
+    instruction: &'idl IdlInstruction,
+    program_id: ProgramId,
+    inputs: InstructionInputs,
+}
+
+impl PublicInstructionBuilder<'_> {
+    /// Adds one named account or argument input.
+    ///
+    /// Bare account IDs infer public signing intent from IDL `signer` and
+    /// non-PDA `init` flags. Use [`AccountIdentity`] when that inference is not
+    /// appropriate, and [`SpelInput::Json`] for canonical container arguments.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SpelTxError`] when `name` is unknown, ambiguous, duplicated,
+    /// or incompatible with the selected IDL position.
+    pub fn input(
+        mut self,
+        name: impl Into<String>,
+        input: impl Into<SpelInput>,
+    ) -> Result<Self, SpelTxError> {
+        self.inputs
+            .insert(self.instruction, name.into(), input.into())?;
+        Ok(self)
+    }
+
+    /// Adds a dynamic collection of named inputs.
+    ///
+    /// This is equivalent to repeated [`Self::input`] calls and accepts owned
+    /// entries from standard maps or vectors.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first [`SpelTxError`] produced by the equivalent
+    /// [`Self::input`] call.
+    pub fn inputs<I>(mut self, inputs: I) -> Result<Self, SpelTxError>
+    where
+        I: IntoIterator<Item = (String, SpelInput)>,
+    {
+        self.inputs.insert_all(self.instruction, inputs)?;
+        Ok(self)
+    }
+
+    /// Resolves named inputs into direct public Wallet build inputs.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SpelTxError`] from the existing resolver when required inputs,
+    /// argument parsing, account identities, PDAs, duplicate accounts, or
+    /// instruction serialization are invalid.
+    pub fn resolve(self) -> Result<ResolvedPublicInstruction, SpelTxError> {
+        let Self {
+            idl,
+            instruction,
+            program_id,
+            inputs,
+        } = self;
+        let (request, _) = inputs.into_request(idl, instruction);
+        resolve_public_instruction(request, program_id)
+    }
+
+    /// Resolves and builds a native public Wallet transaction without submitting it.
+    ///
+    /// Bare account IDs inferred as public signers or initialized accounts must
+    /// have a local Wallet signing key. Explicit [`AccountIdentity`] inputs
+    /// remain a direct Wallet contract.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SpelBuildError::Resolution`] for invalid selected-IDL inputs,
+    /// [`SpelBuildError::MissingPublicSigningKey`] for a missing inferred key,
+    /// or [`SpelBuildError::Wallet`] when Wallet construction fails.
+    pub async fn build(self, wallet: &WalletCore) -> Result<PublicTransaction, SpelBuildError> {
+        let Self {
+            idl,
+            instruction,
+            program_id,
+            inputs,
+        } = self;
+        let (request, inferred_public_signers) = inputs.into_request(idl, instruction);
+        let resolved = resolve_public_instruction(request, program_id)?;
+        preflight_inferred_public_signers(wallet, &inferred_public_signers)?;
+        let (program_id, accounts, instruction_data) = resolved.into_parts();
+
+        Ok(wallet
+            .build_pub_tx(accounts, instruction_data, program_id)
+            .await?)
+    }
+}
+
+/// A selected privacy-preserving instruction awaiting named inputs.
+#[must_use = "provide inputs, resolve, or build the selected private instruction"]
+pub struct PrivateInstructionBuilder<'idl, 'program> {
+    idl: &'idl SpelIdl,
+    instruction: &'idl IdlInstruction,
+    program: &'program ProgramWithDependencies,
+    inputs: InstructionInputs,
+}
+
+impl PrivateInstructionBuilder<'_, '_> {
+    /// Adds one named account or argument input.
+    ///
+    /// Uses the same input classification rules as
+    /// [`PublicInstructionBuilder::input`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SpelTxError`] when `name` is unknown, ambiguous, duplicated,
+    /// or incompatible with the selected IDL position.
+    pub fn input(
+        mut self,
+        name: impl Into<String>,
+        input: impl Into<SpelInput>,
+    ) -> Result<Self, SpelTxError> {
+        self.inputs
+            .insert(self.instruction, name.into(), input.into())?;
+        Ok(self)
+    }
+
+    /// Adds a dynamic collection of named inputs.
+    ///
+    /// This is equivalent to repeated [`Self::input`] calls and accepts owned
+    /// entries from standard maps or vectors.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first [`SpelTxError`] produced by the equivalent
+    /// [`Self::input`] call.
+    pub fn inputs<I>(mut self, inputs: I) -> Result<Self, SpelTxError>
+    where
+        I: IntoIterator<Item = (String, SpelInput)>,
+    {
+        self.inputs.insert_all(self.instruction, inputs)?;
+        Ok(self)
+    }
+
+    /// Resolves named inputs into direct privacy-preserving Wallet build inputs.
+    ///
+    /// This clones the caller-provided program only because
+    /// [`ResolvedPrivateInstruction`] preserves the established owning result
+    /// contract. The later `build` path uses the original borrow instead.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SpelTxError`] from the existing resolver when required inputs,
+    /// argument parsing, account identities, PDAs, duplicate accounts, or
+    /// instruction serialization are invalid.
+    pub fn resolve(self) -> Result<ResolvedPrivateInstruction, SpelTxError> {
+        let Self {
+            idl,
+            instruction,
+            program,
+            inputs,
+        } = self;
+        let (request, _) = inputs.into_request(idl, instruction);
+        resolve_private_instruction(request, program.to_owned())
+    }
+
+    /// Resolves and builds a native privacy-preserving Wallet transaction without submitting it.
+    ///
+    /// Bare account IDs inferred as public signers or initialized accounts must
+    /// have a local Wallet signing key. Explicit [`AccountIdentity`] inputs
+    /// remain a direct Wallet contract.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`SpelBuildError::Resolution`] for invalid selected-IDL inputs,
+    /// [`SpelBuildError::MissingPublicSigningKey`] for a missing inferred key,
+    /// or [`SpelBuildError::Wallet`] when Wallet construction fails.
+    pub async fn build(
+        self,
+        wallet: &WalletCore,
+    ) -> Result<(PrivacyPreservingTransaction, Vec<SharedSecretKey>), SpelBuildError> {
+        let Self {
+            idl,
+            instruction,
+            program,
+            inputs,
+        } = self;
+        let (request, inferred_public_signers) = inputs.into_request(idl, instruction);
+        let (accounts, instruction_data) =
+            resolve_private_instruction_parts(request, program.program.id())?;
+        preflight_inferred_public_signers(wallet, &inferred_public_signers)?;
+
+        Ok(wallet
+            .build_privacy_preserving_tx(accounts, instruction_data, program)
+            .await?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        borrow::Cow,
+        collections::{BTreeMap, HashMap},
+    };
+
+    use nssa::{
+        privacy_preserving_transaction::circuit::ProgramWithDependencies, program::Program,
+        AccountId,
+    };
+    use nssa_core::{encryption::ViewingPublicKey, NullifierPublicKey};
+    use serde_json::json;
+    use spel_framework_core::idl::{
+        IdlAccountItem, IdlArg, IdlInstruction, IdlPda, IdlSeed, IdlType,
+    };
+
+    use super::*;
+
+    fn idl(instructions: Vec<IdlInstruction>) -> SpelIdl {
+        let mut idl = SpelIdl::new("runtime-test");
+        idl.instructions = instructions;
+        idl
+    }
+
+    fn instruction(name: &str) -> IdlInstruction {
+        instruction_with_inputs(name, vec![], vec![])
+    }
+
+    fn instruction_with_inputs(
+        name: &str,
+        accounts: Vec<IdlAccountItem>,
+        args: Vec<IdlArg>,
+    ) -> IdlInstruction {
+        IdlInstruction {
+            name: name.to_string(),
+            accounts,
+            args,
+            discriminator: None,
+            execution: None,
+            variant: None,
+        }
+    }
+
+    fn account(name: &str) -> IdlAccountItem {
+        IdlAccountItem {
+            name: name.to_string(),
+            writable: false,
+            signer: false,
+            init: false,
+            owner: None,
+            pda: None,
+            rest: false,
+            visibility: vec![],
+        }
+    }
+
+    fn pda_account(name: &str, private: bool) -> IdlAccountItem {
+        let mut account = account(name);
+        account.pda = Some(IdlPda {
+            seeds: vec![IdlSeed::Const {
+                value: "state".to_string(),
+            }],
+            private,
+        });
+        account
+    }
+
+    fn argument(name: &str, type_: IdlType) -> IdlArg {
+        IdlArg {
+            name: name.to_string(),
+            type_,
+        }
+    }
+
+    fn private_program() -> ProgramWithDependencies {
+        ProgramWithDependencies::new(
+            Program::new_unchecked([9; 8], Cow::Borrowed(&[])),
+            HashMap::new(),
+        )
+    }
+
+    fn temporary_wallet() -> (WalletCore, tempfile::TempDir) {
+        let wallet_home = tempfile::tempdir().expect("temporary Wallet directory must initialize");
+        let (wallet, _) = WalletCore::new_init_storage(
+            wallet_home.path().join("wallet-config.json"),
+            wallet_home.path().join("storage.json"),
+            None,
+            "runtime-test-password",
+        )
+        .expect("temporary Wallet must initialize");
+        (wallet, wallet_home)
+    }
+
+    #[test]
+    fn bound_public_program_reuses_selection_for_multiple_instructions() {
+        let idl = idl(vec![instruction("first"), instruction("second")]);
+        let program_id: ProgramId = [1; 8];
+        let bound = SpelProgram::new(&idl).program(program_id);
+
+        assert!(bound.public("first").is_ok());
+        assert!(bound.public("second").is_ok());
+    }
+
+    #[test]
+    fn temporary_bound_private_program_keeps_original_program_borrow() {
+        let idl = idl(vec![instruction("execute")]);
+        let program = private_program();
+
+        assert!(SpelProgram::new(&idl)
+            .program(&program)
+            .private("execute")
+            .is_ok());
+    }
+
+    #[test]
+    fn public_and_private_selection_reject_incompatible_program_bindings() {
+        let idl = idl(vec![instruction("execute")]);
+        let program = private_program();
+        let public_program_id: ProgramId = [1; 8];
+
+        assert!(matches!(
+            SpelProgram::new(&idl).program(&program).public("execute"),
+            Err(SpelTxError::PublicProgramRequired)
+        ));
+        assert!(matches!(
+            SpelProgram::new(&idl)
+                .program(public_program_id)
+                .private("execute"),
+            Err(SpelTxError::PrivateProgramRequired)
+        ));
+    }
+
+    #[test]
+    fn selection_rejects_invalid_static_idl_before_input_collection() {
+        let mut invalid = instruction("execute");
+        invalid.args.push(IdlArg {
+            name: String::new(),
+            type_: IdlType::Primitive("u8".to_string()),
+        });
+        let idl = idl(vec![invalid]);
+        let program_id: ProgramId = [1; 8];
+
+        assert!(matches!(
+            SpelProgram::new(&idl).program(program_id).public("execute"),
+            Err(SpelTxError::InvalidIdl { ref path, .. }) if path == "args[0]"
+        ));
+    }
+
+    #[test]
+    fn input_classifies_fixed_rest_and_argument_values() {
+        let mut signer = account("signer");
+        signer.signer = true;
+        let mut initialized = account("initialized");
+        initialized.init = true;
+        initialized.writable = true;
+        let reader = account("reader");
+        let mut members = account("members");
+        members.rest = true;
+        let idl = idl(vec![instruction_with_inputs(
+            "execute",
+            vec![signer, initialized, reader, members],
+            vec![
+                argument("amount", IdlType::Primitive("u128".to_string())),
+                argument(
+                    "bytes",
+                    IdlType::Vec {
+                        vec: Box::new(IdlType::Primitive("u8".to_string())),
+                    },
+                ),
+            ],
+        )]);
+        let explicit = AccountIdentity::PublicNoSign(AccountId::new([3; 32]));
+
+        let builder = SpelProgram::new(&idl)
+            .program([1; 8])
+            .public("execute")
+            .expect("test IDL must select")
+            .input("signer", AccountId::new([1; 32]))
+            .expect("signer input must classify")
+            .input("initialized", AccountId::new([2; 32]))
+            .expect("initialized input must classify")
+            .input("reader", explicit.clone())
+            .expect("explicit identity must classify")
+            .input(
+                "members",
+                vec![AccountId::new([4; 32]), AccountId::new([5; 32])],
+            )
+            .expect("rest account IDs must classify")
+            .input("amount", 42_u128)
+            .expect("scalar argument must classify")
+            .input("bytes", json!([1, 2, 3]))
+            .expect("JSON argument must classify");
+
+        assert_eq!(
+            builder.inputs.accounts["signer"],
+            vec![AccountIdentity::Public(AccountId::new([1; 32]))]
+        );
+        assert_eq!(
+            builder.inputs.accounts["initialized"],
+            vec![AccountIdentity::Public(AccountId::new([2; 32]))]
+        );
+        assert_eq!(builder.inputs.accounts["reader"], vec![explicit]);
+        assert_eq!(
+            builder.inputs.accounts["members"],
+            vec![
+                AccountIdentity::PublicNoSign(AccountId::new([4; 32])),
+                AccountIdentity::PublicNoSign(AccountId::new([5; 32])),
+            ]
+        );
+        assert_eq!(builder.inputs.arguments["amount"], "42");
+        assert_eq!(builder.inputs.arguments["bytes"], "[1,2,3]");
+        assert_eq!(
+            builder
+                .inputs
+                .inferred_public_signers
+                .iter()
+                .map(|signer| signer.account.as_str())
+                .collect::<Vec<_>>(),
+            ["signer", "initialized"]
+        );
+    }
+
+    #[test]
+    fn input_conversions_preserve_existing_argument_text_formats() {
+        fn assert_argument_text(input: SpelInput, expected: &str) {
+            let SpelInput::ArgumentText(value) = input else {
+                panic!("input must convert to argument text");
+            };
+            assert_eq!(value, expected);
+        }
+
+        assert_argument_text(SpelInput::from(true), "true");
+        assert_argument_text(SpelInput::from(-42_i128), "-42");
+        assert_argument_text(SpelInput::from("text"), "text");
+        assert_argument_text(SpelInput::from([1, 2, 3, 4, 5, 6, 7, 8]), "1,2,3,4,5,6,7,8");
+        assert_argument_text(
+            SpelInput::from(NullifierPublicKey([0xab; 32])),
+            &"ab".repeat(32),
+        );
+        assert!(matches!(
+            SpelInput::from(json!([1, 2, 3])),
+            SpelInput::Json(_)
+        ));
+    }
+
+    #[test]
+    fn input_reports_wrapper_name_and_shape_errors() {
+        let fixed = account("fixed");
+        let shared = account("shared");
+        let public_pda = pda_account("state", false);
+        let mut rest = account("rest");
+        rest.rest = true;
+        let idl = idl(vec![instruction_with_inputs(
+            "execute",
+            vec![fixed, shared, public_pda, rest],
+            vec![
+                argument("value", IdlType::Primitive("u8".to_string())),
+                argument("shared", IdlType::Primitive("u8".to_string())),
+            ],
+        )]);
+
+        let select = || {
+            SpelProgram::new(&idl)
+                .program([1; 8])
+                .public("execute")
+                .expect("test IDL must select")
+        };
+
+        assert!(matches!(
+            select().input("missing", 1_u8),
+            Err(SpelTxError::UnknownInput { ref name }) if name == "missing"
+        ));
+        assert!(matches!(
+            select().input("shared", 1_u8),
+            Err(SpelTxError::AmbiguousInput { ref name }) if name == "shared"
+        ));
+        assert!(matches!(
+            select().input("fixed", vec![AccountId::new([1; 32])]),
+            Err(SpelTxError::InvalidInput { ref name, .. }) if name == "fixed"
+        ));
+        assert!(matches!(
+            select().input("rest", AccountId::new([1; 32])),
+            Err(SpelTxError::InvalidInput { ref name, .. }) if name == "rest"
+        ));
+        assert!(matches!(
+            select().input("state", AccountId::new([1; 32])),
+            Err(SpelTxError::InvalidInput { ref name, .. }) if name == "state"
+        ));
+        assert!(matches!(
+            select().input("value", AccountId::new([1; 32])),
+            Err(SpelTxError::InvalidInput { ref name, .. }) if name == "value"
+        ));
+
+        let builder = select()
+            .input("value", 1_u8)
+            .expect("first input must classify");
+        assert!(matches!(
+            builder.input("value", 2_u8),
+            Err(SpelTxError::DuplicateInput { ref name }) if name == "value"
+        ));
+    }
+
+    #[test]
+    fn inputs_matches_repeated_input_calls_and_rejects_duplicate_batch_names() {
+        let payer = account("payer");
+        let mut rest = account("rest");
+        rest.rest = true;
+        let idl = idl(vec![instruction_with_inputs(
+            "execute",
+            vec![payer, rest],
+            vec![argument("value", IdlType::Primitive("u8".to_string()))],
+        )]);
+        let select = || {
+            SpelProgram::new(&idl)
+                .program([1; 8])
+                .public("execute")
+                .expect("test IDL must select")
+        };
+
+        let repeated = select()
+            .input("payer", AccountId::new([1; 32]))
+            .expect("payer must classify")
+            .input("rest", vec![AccountId::new([2; 32])])
+            .expect("rest must classify")
+            .input("value", 3_u8)
+            .expect("argument must classify");
+        let batched = select()
+            .inputs(BTreeMap::from([
+                (
+                    "payer".to_string(),
+                    SpelInput::from(AccountId::new([1; 32])),
+                ),
+                (
+                    "rest".to_string(),
+                    SpelInput::from(vec![AccountId::new([2; 32])]),
+                ),
+                ("value".to_string(), SpelInput::from(3_u8)),
+            ]))
+            .expect("batch inputs must classify");
+
+        assert_eq!(repeated.inputs.accounts, batched.inputs.accounts);
+        assert_eq!(repeated.inputs.arguments, batched.inputs.arguments);
+        assert!(matches!(
+            select().inputs(vec![
+                ("value".to_string(), SpelInput::from(1_u8)),
+                ("value".to_string(), SpelInput::from(2_u8)),
+            ]),
+            Err(SpelTxError::DuplicateInput { ref name }) if name == "value"
+        ));
+    }
+
+    #[test]
+    fn private_inputs_require_an_explicit_identity_for_private_pdas() {
+        let mut private_pda = pda_account("state", true);
+        private_pda.init = true;
+        private_pda.writable = true;
+        let idl = idl(vec![instruction_with_inputs(
+            "execute",
+            vec![private_pda],
+            vec![argument("value", IdlType::Primitive("u8".to_string()))],
+        )]);
+        let program = private_program();
+        let identity = AccountIdentity::PrivatePdaForeign {
+            account_id: AccountId::new([1; 32]),
+            npk: NullifierPublicKey([2; 32]),
+            vpk: ViewingPublicKey::from_seed(&[3; 32], &[4; 32]),
+            identifier: 5,
+        };
+        let select = || {
+            SpelProgram::new(&idl)
+                .program(&program)
+                .private("execute")
+                .expect("test IDL must select")
+        };
+
+        assert!(matches!(
+            select().input("state", AccountId::new([1; 32])),
+            Err(SpelTxError::InvalidInput { ref name, .. }) if name == "state"
+        ));
+        let builder = select()
+            .inputs(BTreeMap::from([
+                ("state".to_string(), SpelInput::from(identity.clone())),
+                ("value".to_string(), SpelInput::from(7_u8)),
+            ]))
+            .expect("explicit private PDA identity must classify");
+
+        assert_eq!(builder.inputs.accounts["state"], vec![identity]);
+        assert_eq!(builder.inputs.arguments["value"], "7");
+    }
+
+    #[test]
+    fn public_resolve_matches_direct_resolution_and_defers_argument_parsing() {
+        let mut payer = account("payer");
+        payer.signer = true;
+        let recipient = account("recipient");
+        let idl = idl(vec![instruction_with_inputs(
+            "transfer",
+            vec![payer, recipient],
+            vec![argument("amount", IdlType::Primitive("u8".to_string()))],
+        )]);
+        let program_id = [1; 8];
+        let payer_id = AccountId::new([1; 32]);
+        let recipient_identity = AccountIdentity::PublicNoSign(AccountId::new([2; 32]));
+        let direct = resolve_public_instruction(
+            SpelInstructionRequest {
+                idl: &idl,
+                instruction: "transfer",
+                accounts: BTreeMap::from([
+                    ("payer".to_string(), vec![AccountIdentity::Public(payer_id)]),
+                    ("recipient".to_string(), vec![recipient_identity.clone()]),
+                ]),
+                arguments: BTreeMap::from([("amount".to_string(), "7".to_string())]),
+            },
+            program_id,
+        )
+        .expect("direct request must resolve");
+        let fluent = SpelProgram::new(&idl)
+            .program(program_id)
+            .public("transfer")
+            .expect("test IDL must select")
+            .input("payer", payer_id)
+            .expect("payer must classify")
+            .input("recipient", recipient_identity)
+            .expect("recipient must classify")
+            .input("amount", 7_u8)
+            .expect("amount must classify")
+            .resolve()
+            .expect("fluent request must resolve");
+
+        assert_eq!(fluent.program_id(), direct.program_id());
+        assert_eq!(fluent.accounts(), direct.accounts());
+        assert_eq!(fluent.instruction_data(), direct.instruction_data());
+        assert!(matches!(
+            SpelProgram::new(&idl)
+                .program(program_id)
+                .public("transfer")
+                .expect("test IDL must select")
+                .input("payer", payer_id)
+                .expect("payer must classify")
+                .input("recipient", AccountIdentity::PublicNoSign(AccountId::new([2; 32])))
+                .expect("recipient must classify")
+                .input("amount", "not a number")
+                .expect("argument text must classify")
+                .resolve(),
+            Err(SpelTxError::ArgumentParse { ref name, ref path, .. })
+                if name == "amount" && path.is_empty()
+        ));
+    }
+
+    #[test]
+    fn private_resolve_matches_direct_resolution_and_preserves_program_borrow() {
+        let idl = idl(vec![instruction_with_inputs(
+            "transfer",
+            vec![account("owner")],
+            vec![argument("amount", IdlType::Primitive("u8".to_string()))],
+        )]);
+        let program = private_program();
+        let identity = AccountIdentity::PrivateOwned(AccountId::new([3; 32]));
+        let direct = resolve_private_instruction(
+            SpelInstructionRequest {
+                idl: &idl,
+                instruction: "transfer",
+                accounts: BTreeMap::from([("owner".to_string(), vec![identity.clone()])]),
+                arguments: BTreeMap::from([("amount".to_string(), "9".to_string())]),
+            },
+            program.clone(),
+        )
+        .expect("direct request must resolve");
+        let fluent = SpelProgram::new(&idl)
+            .program(&program)
+            .private("transfer")
+            .expect("test IDL must select")
+            .input("owner", identity)
+            .expect("owner must classify")
+            .input("amount", 9_u8)
+            .expect("amount must classify")
+            .resolve()
+            .expect("fluent request must resolve");
+
+        assert_eq!(fluent.program().program.id(), direct.program().program.id());
+        assert_eq!(fluent.accounts(), direct.accounts());
+        assert_eq!(fluent.instruction_data(), direct.instruction_data());
+        assert_eq!(program.program.id(), fluent.program().program.id());
+    }
+
+    #[tokio::test]
+    async fn public_build_returns_native_transaction_without_accounts() {
+        let idl = idl(vec![instruction("initialize")]);
+        let program_id: ProgramId = [1; 8];
+        let (wallet, _wallet_home) = temporary_wallet();
+
+        let transaction = SpelProgram::new(&idl)
+            .program(program_id)
+            .public("initialize")
+            .expect("test IDL must select")
+            .build(&wallet)
+            .await
+            .expect("empty public instruction must build without a sequencer");
+
+        assert_eq!(transaction.message.program_id, program_id);
+        assert!(transaction.message.account_ids.is_empty());
+        assert!(transaction.message.nonces.is_empty());
+    }
+
+    #[tokio::test]
+    async fn public_build_wraps_resolver_error_before_wallet_access() {
+        let idl = idl(vec![instruction_with_inputs(
+            "initialize",
+            vec![account("owner")],
+            vec![],
+        )]);
+        let (wallet, _wallet_home) = temporary_wallet();
+
+        let result = SpelProgram::new(&idl)
+            .program([1; 8])
+            .public("initialize")
+            .expect("test IDL must select")
+            .build(&wallet)
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(SpelBuildError::Resolution(SpelTxError::MissingAccount { ref name }))
+                if name == "owner"
+        ));
+    }
+
+    #[tokio::test]
+    async fn public_build_reports_missing_key_for_inferred_signer() {
+        let mut authority = account("authority");
+        authority.signer = true;
+        let idl = idl(vec![instruction_with_inputs(
+            "initialize",
+            vec![authority],
+            vec![],
+        )]);
+        let (wallet, _wallet_home) = temporary_wallet();
+
+        let result = SpelProgram::new(&idl)
+            .program([1; 8])
+            .public("initialize")
+            .expect("test IDL must select")
+            .input("authority", AccountId::new([1; 32]))
+            .expect("bare signer must classify")
+            .build(&wallet)
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(SpelBuildError::MissingPublicSigningKey { ref account })
+                if account == "authority"
+        ));
+    }
+
+    #[tokio::test]
+    async fn public_build_reports_missing_key_for_inferred_initialized_account() {
+        let mut state = account("state");
+        state.init = true;
+        state.writable = true;
+        let idl = idl(vec![instruction_with_inputs(
+            "initialize",
+            vec![state],
+            vec![],
+        )]);
+        let (wallet, _wallet_home) = temporary_wallet();
+
+        let result = SpelProgram::new(&idl)
+            .program([1; 8])
+            .public("initialize")
+            .expect("test IDL must select")
+            .input("state", AccountId::new([2; 32]))
+            .expect("bare initialized account must classify")
+            .build(&wallet)
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(SpelBuildError::MissingPublicSigningKey { ref account }) if account == "state"
+        ));
+    }
+}

--- a/spel-cli/src/tx/value.rs
+++ b/spel-cli/src/tx/value.rs
@@ -1,0 +1,868 @@
+use crate::{
+    parse::{parse_program_id, parse_value, ParsedValue},
+    serialize::SerializeError,
+};
+use nssa::AccountId;
+use nssa_core::{program::ProgramId, NullifierPublicKey};
+use serde::ser::{SerializeSeq, SerializeTuple, SerializeTupleVariant};
+use serde::Serialize;
+use serde_json::Value;
+use spel_framework_core::{idl::IdlType, pda::parse_bytes32};
+
+#[derive(Debug)]
+pub(crate) struct ValueParseError {
+    pub(crate) path: Vec<usize>,
+    pub(crate) reason: String,
+}
+
+impl ValueParseError {
+    fn new(path: Vec<usize>, reason: impl Into<String>) -> Self {
+        Self {
+            path,
+            reason: reason.into(),
+        }
+    }
+}
+
+pub(crate) enum ArgumentValue {
+    Bool(bool),
+    U8(u8),
+    U16(u16),
+    U32(u32),
+    U64(u64),
+    U128(u128),
+    I8(i8),
+    I16(i16),
+    I32(i32),
+    I64(i64),
+    I128(i128),
+    String(String),
+    AccountId(AccountId),
+    ProgramId(ProgramId),
+    NullifierPublicKey(NullifierPublicKey),
+    Array(Vec<Self>),
+    Vec(Vec<Self>),
+    Option(Option<Box<Self>>),
+}
+
+impl ArgumentValue {
+    pub(crate) fn seed_bytes(&self, ty: &IdlType) -> Result<[u8; 32], &'static str> {
+        match (self, ty) {
+            (Self::Array(values), IdlType::Array { array })
+                if matches!(array.0.as_ref(), IdlType::Primitive(primitive) if primitive == "u8")
+                    && (1..=32).contains(&array.1) =>
+            {
+                let mut seed = [0; 32];
+                for (index, value) in values.iter().enumerate() {
+                    let Self::U8(value) = value else {
+                        return Err("unsupported argument type for PDA seed");
+                    };
+                    seed[index] = *value;
+                }
+                Ok(seed)
+            },
+            (Self::U8(value), IdlType::Primitive(primitive)) if primitive == "u8" => {
+                Ok(pad_seed(&value.to_le_bytes()))
+            },
+            (Self::U16(value), IdlType::Primitive(primitive)) if primitive == "u16" => {
+                Ok(pad_seed(&value.to_le_bytes()))
+            },
+            (Self::U32(value), IdlType::Primitive(primitive)) if primitive == "u32" => {
+                Ok(pad_seed(&value.to_le_bytes()))
+            },
+            (Self::U64(value), IdlType::Primitive(primitive)) if primitive == "u64" => {
+                Ok(pad_seed(&value.to_le_bytes()))
+            },
+            (Self::U128(value), IdlType::Primitive(primitive)) if primitive == "u128" => {
+                Ok(pad_seed(&value.to_le_bytes()))
+            },
+            (Self::String(value), IdlType::Primitive(primitive))
+                if matches!(primitive.as_str(), "string" | "String") =>
+            {
+                if value.len() > 32 {
+                    return Err("string argument exceeds 32 bytes for PDA seed");
+                }
+                Ok(pad_seed(value.as_bytes()))
+            },
+            (Self::AccountId(value), IdlType::Primitive(primitive))
+                if primitive == "account_id" =>
+            {
+                Ok(*value.value())
+            },
+            (Self::ProgramId(value), IdlType::Primitive(primitive))
+                if primitive == "program_id" =>
+            {
+                let mut seed = [0; 32];
+                for (index, word) in value.iter().enumerate() {
+                    seed[index * 4..(index + 1) * 4].copy_from_slice(&word.to_le_bytes());
+                }
+                Ok(seed)
+            },
+            _ => Err("unsupported argument type for PDA seed"),
+        }
+    }
+}
+
+impl Serialize for ArgumentValue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Bool(value) => serializer.serialize_bool(*value),
+            Self::U8(value) => serializer.serialize_u8(*value),
+            Self::U16(value) => serializer.serialize_u16(*value),
+            Self::U32(value) => serializer.serialize_u32(*value),
+            Self::U64(value) => serializer.serialize_u64(*value),
+            Self::U128(value) => serializer.serialize_u128(*value),
+            Self::I8(value) => serializer.serialize_i8(*value),
+            Self::I16(value) => serializer.serialize_i16(*value),
+            Self::I32(value) => serializer.serialize_i32(*value),
+            Self::I64(value) => serializer.serialize_i64(*value),
+            Self::I128(value) => serializer.serialize_i128(*value),
+            Self::String(value) => serializer.serialize_str(value),
+            Self::AccountId(value) => value.serialize(serializer),
+            Self::ProgramId(value) => value.serialize(serializer),
+            Self::NullifierPublicKey(value) => value.serialize(serializer),
+            Self::Array(values) => {
+                let mut tuple = serializer.serialize_tuple(values.len())?;
+                for value in values {
+                    tuple.serialize_element(value)?;
+                }
+                tuple.end()
+            },
+            Self::Vec(values) => {
+                let mut sequence = serializer.serialize_seq(Some(values.len()))?;
+                for value in values {
+                    sequence.serialize_element(value)?;
+                }
+                sequence.end()
+            },
+            Self::Option(None) => serializer.serialize_none(),
+            Self::Option(Some(value)) => serializer.serialize_some(value),
+        }
+    }
+}
+
+pub(crate) fn validate_type(ty: &IdlType) -> Result<(), String> {
+    match ty {
+        IdlType::Primitive(primitive) if is_supported_primitive(primitive) => Ok(()),
+        IdlType::Primitive(_) => Err("unsupported instruction argument primitive".to_string()),
+        IdlType::Array { array } => validate_type(&array.0),
+        IdlType::Vec { vec } => validate_type(vec),
+        IdlType::Option { option } if matches!(option.as_ref(), IdlType::Option { .. }) => {
+            Err("immediate nested option is unsupported".to_string())
+        },
+        IdlType::Option { option } => validate_type(option),
+        IdlType::Defined { .. } => {
+            Err("defined instruction argument types are unsupported".to_string())
+        },
+    }
+}
+
+pub(crate) fn validate_seed_type(ty: &IdlType) -> Result<(), &'static str> {
+    match ty {
+        IdlType::Array { array }
+            if matches!(array.0.as_ref(), IdlType::Primitive(primitive) if primitive == "u8")
+                && (1..=32).contains(&array.1) =>
+        {
+            Ok(())
+        },
+        IdlType::Primitive(primitive)
+            if matches!(
+                primitive.as_str(),
+                "u8" | "u16"
+                    | "u32"
+                    | "u64"
+                    | "u128"
+                    | "string"
+                    | "String"
+                    | "account_id"
+                    | "program_id"
+            ) =>
+        {
+            Ok(())
+        },
+        _ => Err("unsupported argument type for PDA seed"),
+    }
+}
+
+pub(crate) fn parse_argument(raw: &str, ty: &IdlType) -> Result<ArgumentValue, ValueParseError> {
+    match ty {
+        IdlType::Array { .. } | IdlType::Vec { .. } | IdlType::Option { .. } => {
+            match serde_json::from_str(raw) {
+                Ok(value) => match parse_json_value(&value, ty, vec![]) {
+                    Ok(value) => Ok(value),
+                    Err(json_error) => parse_legacy_argument(raw, ty).or(Err(json_error)),
+                },
+                Err(_) => parse_legacy_argument(raw, ty),
+            }
+        },
+        _ => parse_scalar(raw, ty, vec![]),
+    }
+}
+
+pub(crate) fn serialize_instruction(
+    variant_index: u32,
+    fields: &[&ArgumentValue],
+) -> Result<Vec<u32>, SerializeError> {
+    let instruction = SerializedInstruction {
+        variant_index,
+        fields,
+    };
+
+    risc0_zkvm::serde::to_vec(&instruction)
+        .map_err(|error| SerializeError::Risc0(error.to_string()))
+}
+
+fn parse_json_value(
+    value: &Value,
+    ty: &IdlType,
+    path: Vec<usize>,
+) -> Result<ArgumentValue, ValueParseError> {
+    match ty {
+        IdlType::Primitive(primitive) => parse_json_primitive(value, primitive, path),
+        IdlType::Array { array } => {
+            let values = value
+                .as_array()
+                .ok_or_else(|| ValueParseError::new(path.clone(), "expected JSON array"))?;
+            if values.len() != array.1 {
+                return Err(ValueParseError::new(
+                    path,
+                    "JSON array has an unexpected length",
+                ));
+            }
+
+            let mut parsed = Vec::with_capacity(values.len());
+            for (index, value) in values.iter().enumerate() {
+                let mut nested_path = path.clone();
+                nested_path.push(index);
+                parsed.push(parse_json_value(value, &array.0, nested_path)?);
+            }
+            Ok(ArgumentValue::Array(parsed))
+        },
+        IdlType::Vec { vec } => {
+            let values = value
+                .as_array()
+                .ok_or_else(|| ValueParseError::new(path.clone(), "expected JSON array"))?;
+            let mut parsed = Vec::with_capacity(values.len());
+            for (index, value) in values.iter().enumerate() {
+                let mut nested_path = path.clone();
+                nested_path.push(index);
+                parsed.push(parse_json_value(value, vec, nested_path)?);
+            }
+            Ok(ArgumentValue::Vec(parsed))
+        },
+        IdlType::Option { option } if value.is_null() => Ok(ArgumentValue::Option(None)),
+        IdlType::Option { option } => Ok(ArgumentValue::Option(Some(Box::new(parse_json_value(
+            value, option, path,
+        )?)))),
+        IdlType::Defined { .. } => Err(ValueParseError::new(
+            path,
+            "defined instruction argument types are unsupported",
+        )),
+    }
+}
+
+fn parse_json_primitive(
+    value: &Value,
+    primitive: &str,
+    path: Vec<usize>,
+) -> Result<ArgumentValue, ValueParseError> {
+    match primitive {
+        "bool" => value
+            .as_bool()
+            .map(ArgumentValue::Bool)
+            .ok_or_else(|| ValueParseError::new(path, "expected JSON boolean")),
+        "string" | "String" | "account_id" | "program_id" | "nullifier_public_key" => value
+            .as_str()
+            .ok_or_else(|| ValueParseError::new(path.clone(), "expected JSON string"))
+            .and_then(|raw| parse_primitive(raw, primitive, path)),
+        primitive if is_integer_primitive(primitive) => value
+            .as_number()
+            .ok_or_else(|| ValueParseError::new(path.clone(), "expected JSON integer"))
+            .and_then(|number| parse_primitive(&number.to_string(), primitive, path)),
+        _ => Err(ValueParseError::new(
+            path,
+            "unsupported instruction argument primitive",
+        )),
+    }
+}
+
+fn parse_scalar(
+    raw: &str,
+    ty: &IdlType,
+    path: Vec<usize>,
+) -> Result<ArgumentValue, ValueParseError> {
+    let IdlType::Primitive(primitive) = ty else {
+        return Err(ValueParseError::new(
+            path,
+            "expected instruction argument primitive",
+        ));
+    };
+    parse_primitive(raw, primitive, path)
+}
+
+fn parse_legacy_argument(raw: &str, ty: &IdlType) -> Result<ArgumentValue, ValueParseError> {
+    match ty {
+        IdlType::Array { .. } | IdlType::Vec { .. } => {
+            let value = parse_value(raw, ty)
+                .map_err(|_| invalid_legacy_value(legacy_error_path(raw, ty)))?;
+            argument_value_from_cli(value, ty)
+        },
+        IdlType::Option { option } => {
+            if matches!(raw, "none" | "null") || raw.is_empty() {
+                return Ok(ArgumentValue::Option(None));
+            }
+            parse_argument(raw, option).map(|value| ArgumentValue::Option(Some(Box::new(value))))
+        },
+        IdlType::Primitive(_) | IdlType::Defined { .. } => Err(invalid_legacy_value(vec![])),
+    }
+}
+
+fn invalid_legacy_value(path: Vec<usize>) -> ValueParseError {
+    ValueParseError::new(path, "invalid legacy CLI value")
+}
+
+fn legacy_error_path(raw: &str, ty: &IdlType) -> Vec<usize> {
+    match ty {
+        IdlType::Array { array } if matches!(array.0.as_ref(), IdlType::Primitive(primitive) if primitive == "u32") => {
+            csv_error_path(raw, Some(array.1), |value| value.parse::<u32>().is_ok())
+        },
+        IdlType::Vec { vec } => match vec.as_ref() {
+            IdlType::Primitive(primitive) if primitive == "u8" => {
+                csv_error_path(raw, None, |value| value.parse::<u8>().is_ok())
+            },
+            IdlType::Primitive(primitive) if primitive == "u32" => {
+                csv_error_path(raw, None, |value| value.parse::<u32>().is_ok())
+            },
+            IdlType::Array { array } if matches!(array.0.as_ref(), IdlType::Primitive(primitive) if primitive == "u8") => {
+                csv_error_path(raw, None, |value| {
+                    legacy_byte_array_is_valid(value, array.1)
+                })
+            },
+            _ => Vec::new(),
+        },
+        IdlType::Primitive(_) | IdlType::Option { .. } | IdlType::Defined { .. } => Vec::new(),
+        IdlType::Array { .. } => Vec::new(),
+    }
+}
+
+fn csv_error_path<F>(raw: &str, expected_len: Option<usize>, is_valid: F) -> Vec<usize>
+where
+    F: Fn(&str) -> bool,
+{
+    let values: Vec<_> = raw.split(',').map(str::trim).collect();
+    if expected_len.is_some_and(|expected_len| values.len() != expected_len) {
+        return Vec::new();
+    }
+    values
+        .into_iter()
+        .position(|value| !is_valid(value))
+        .map_or_else(Vec::new, |index| vec![index])
+}
+
+fn legacy_byte_array_is_valid(raw: &str, element_len: usize) -> bool {
+    if element_len == 32 {
+        return crate::hex::decode_bytes_32(raw).is_ok();
+    }
+
+    let hex = raw
+        .strip_prefix("0x")
+        .or_else(|| raw.strip_prefix("0X"))
+        .unwrap_or(raw);
+    crate::hex::hex_decode(hex).is_ok_and(|bytes| bytes.len() == element_len)
+}
+
+fn argument_value_from_cli(
+    value: ParsedValue,
+    ty: &IdlType,
+) -> Result<ArgumentValue, ValueParseError> {
+    match (value, ty) {
+        (ParsedValue::ByteArray(value), IdlType::Array { array })
+            if matches!(array.0.as_ref(), IdlType::Primitive(primitive) if primitive == "u8")
+                && value.len() == array.1 =>
+        {
+            Ok(ArgumentValue::Array(
+                value.into_iter().map(ArgumentValue::U8).collect(),
+            ))
+        },
+        (ParsedValue::U32Array(value), IdlType::Array { array })
+            if matches!(array.0.as_ref(), IdlType::Primitive(primitive) if primitive == "u32")
+                && value.len() == array.1 =>
+        {
+            Ok(ArgumentValue::Array(
+                value.into_iter().map(ArgumentValue::U32).collect(),
+            ))
+        },
+        (ParsedValue::ByteArray(value), IdlType::Vec { vec }) if matches!(vec.as_ref(), IdlType::Primitive(primitive) if primitive == "u8") => {
+            Ok(ArgumentValue::Vec(
+                value.into_iter().map(ArgumentValue::U8).collect(),
+            ))
+        },
+        (ParsedValue::Raw(value), IdlType::Vec { vec })
+            if value.is_empty()
+                && matches!(vec.as_ref(), IdlType::Primitive(primitive) if primitive == "u32") =>
+        {
+            Ok(ArgumentValue::Vec(Vec::new()))
+        },
+        (ParsedValue::Raw(value), ty) => Err(invalid_legacy_value(legacy_error_path(&value, ty))),
+        (ParsedValue::U32Array(value), IdlType::Vec { vec }) if matches!(vec.as_ref(), IdlType::Primitive(primitive) if primitive == "u32") => {
+            Ok(ArgumentValue::Vec(
+                value.into_iter().map(ArgumentValue::U32).collect(),
+            ))
+        },
+        (ParsedValue::ByteArrayVec(values), IdlType::Vec { vec }) => {
+            let IdlType::Array { array } = vec.as_ref() else {
+                return Err(invalid_legacy_value(vec![]));
+            };
+            if !matches!(array.0.as_ref(), IdlType::Primitive(primitive) if primitive == "u8")
+                || values.iter().any(|value| value.len() != array.1)
+            {
+                return Err(invalid_legacy_value(vec![]));
+            }
+            Ok(ArgumentValue::Vec(
+                values
+                    .into_iter()
+                    .map(|value| {
+                        ArgumentValue::Array(value.into_iter().map(ArgumentValue::U8).collect())
+                    })
+                    .collect(),
+            ))
+        },
+        _ => Err(invalid_legacy_value(vec![])),
+    }
+}
+
+fn parse_primitive(
+    raw: &str,
+    primitive: &str,
+    path: Vec<usize>,
+) -> Result<ArgumentValue, ValueParseError> {
+    macro_rules! parse_unsigned {
+        ($ty:ty, $variant:ident) => {{
+            if !is_decimal(raw, false) {
+                return Err(ValueParseError::new(
+                    path,
+                    "invalid unsigned decimal integer",
+                ));
+            }
+            raw.parse::<$ty>()
+                .map(ArgumentValue::$variant)
+                .map_err(|_| ValueParseError::new(path, "integer is outside the supported range"))
+        }};
+    }
+
+    macro_rules! parse_signed {
+        ($ty:ty, $variant:ident) => {{
+            if !is_decimal(raw, true) {
+                return Err(ValueParseError::new(path, "invalid signed decimal integer"));
+            }
+            raw.parse::<$ty>()
+                .map(ArgumentValue::$variant)
+                .map_err(|_| ValueParseError::new(path, "integer is outside the supported range"))
+        }};
+    }
+
+    match primitive {
+        "bool" => match raw {
+            "true" | "1" | "yes" => Ok(ArgumentValue::Bool(true)),
+            "false" | "0" | "no" => Ok(ArgumentValue::Bool(false)),
+            _ => Err(ValueParseError::new(path, "invalid boolean")),
+        },
+        "u8" => parse_unsigned!(u8, U8),
+        "u16" => parse_unsigned!(u16, U16),
+        "u32" => parse_unsigned!(u32, U32),
+        "u64" => parse_unsigned!(u64, U64),
+        "u128" => parse_unsigned!(u128, U128),
+        "i8" => parse_signed!(i8, I8),
+        "i16" => parse_signed!(i16, I16),
+        "i32" => parse_signed!(i32, I32),
+        "i64" => parse_signed!(i64, I64),
+        "i128" => parse_signed!(i128, I128),
+        "string" | "String" => Ok(ArgumentValue::String(raw.to_owned())),
+        "account_id" => parse_bytes32(raw)
+            .map(AccountId::new)
+            .map(ArgumentValue::AccountId)
+            .map_err(|_| ValueParseError::new(path, "invalid account ID")),
+        "program_id" => parse_program_id(raw)
+            .map(ArgumentValue::ProgramId)
+            .map_err(|_| ValueParseError::new(path, "invalid program ID")),
+        "nullifier_public_key" => parse_bytes32(raw)
+            .map(NullifierPublicKey)
+            .map(ArgumentValue::NullifierPublicKey)
+            .map_err(|_| ValueParseError::new(path, "invalid nullifier public key")),
+        _ => Err(ValueParseError::new(
+            path,
+            "unsupported instruction argument primitive",
+        )),
+    }
+}
+
+fn is_supported_primitive(primitive: &str) -> bool {
+    matches!(
+        primitive,
+        "bool"
+            | "u8"
+            | "u16"
+            | "u32"
+            | "u64"
+            | "u128"
+            | "i8"
+            | "i16"
+            | "i32"
+            | "i64"
+            | "i128"
+            | "string"
+            | "String"
+            | "account_id"
+            | "program_id"
+            | "nullifier_public_key"
+    )
+}
+
+fn is_integer_primitive(primitive: &str) -> bool {
+    matches!(
+        primitive,
+        "u8" | "u16" | "u32" | "u64" | "u128" | "i8" | "i16" | "i32" | "i64" | "i128"
+    )
+}
+
+fn is_decimal(raw: &str, signed: bool) -> bool {
+    let digits = if signed {
+        raw.strip_prefix('+')
+            .or_else(|| raw.strip_prefix('-'))
+            .unwrap_or(raw)
+    } else {
+        raw.strip_prefix('+').unwrap_or(raw)
+    };
+    !digits.is_empty() && digits.bytes().all(|byte| byte.is_ascii_digit())
+}
+
+fn pad_seed(value: &[u8]) -> [u8; 32] {
+    let mut seed = [0; 32];
+    seed[..value.len()].copy_from_slice(value);
+    seed
+}
+
+struct SerializedInstruction<'a> {
+    variant_index: u32,
+    fields: &'a [&'a ArgumentValue],
+}
+
+impl Serialize for SerializedInstruction<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut instruction =
+            serializer.serialize_tuple_variant("", self.variant_index, "", self.fields.len())?;
+        for field in self.fields {
+            instruction.serialize_field(field)?;
+        }
+        instruction.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nssa::AccountId;
+    use risc0_zkvm::serde::Deserializer;
+    use serde::Deserialize;
+
+    use super::*;
+
+    fn primitive(name: &str) -> IdlType {
+        IdlType::Primitive(name.to_string())
+    }
+
+    fn array(element: IdlType, len: usize) -> IdlType {
+        IdlType::Array {
+            array: (Box::new(element), len),
+        }
+    }
+
+    fn vector(element: IdlType) -> IdlType {
+        IdlType::Vec {
+            vec: Box::new(element),
+        }
+    }
+
+    fn option(element: IdlType) -> IdlType {
+        IdlType::Option {
+            option: Box::new(element),
+        }
+    }
+
+    #[test]
+    fn parses_every_supported_scalar_primitive() {
+        for (raw, name) in [
+            ("true", "bool"),
+            ("+1", "u8"),
+            ("+1", "u16"),
+            ("+1", "u32"),
+            ("+1", "u64"),
+            ("+1", "u128"),
+            ("-1", "i8"),
+            ("-1", "i16"),
+            ("-1", "i32"),
+            ("-1", "i64"),
+            ("-1", "i128"),
+        ] {
+            assert!(parse_argument(raw, &primitive(name)).is_ok(), "{name}");
+        }
+        assert!(parse_argument("raw string", &primitive("string")).is_ok());
+        assert!(parse_argument("raw string", &primitive("String")).is_ok());
+        assert!(parse_argument(&"11".repeat(32), &primitive("account_id")).is_ok());
+        assert!(parse_argument(&"01000000".repeat(8), &primitive("program_id")).is_ok());
+        assert!(parse_argument(&"22".repeat(32), &primitive("nullifier_public_key")).is_ok());
+
+        assert!(parse_argument("maybe", &primitive("bool")).is_err());
+        assert!(parse_argument(" 1", &primitive("u32")).is_err());
+        assert!(parse_argument("0x10", &primitive("u32")).is_err());
+    }
+
+    #[test]
+    fn accepts_cli_boolean_aliases() {
+        for (raw, expected) in [("1", true), ("yes", true), ("0", false), ("no", false)] {
+            assert!(matches!(
+                parse_argument(raw, &primitive("bool")),
+                Ok(ArgumentValue::Bool(value)) if value == expected
+            ));
+        }
+    }
+
+    #[test]
+    fn accepts_cli_program_id_aliases() {
+        let bytes = [0x11; 32];
+        let expected = parse_program_id(&format!("0x{}", "11".repeat(32))).unwrap();
+        let inputs = [
+            format!("0x{}", "11".repeat(32)),
+            AccountId::new(bytes).to_string(),
+        ];
+
+        for input in inputs {
+            assert!(matches!(
+                parse_argument(&input, &primitive("program_id")),
+                Ok(ArgumentValue::ProgramId(value)) if value == expected
+            ));
+        }
+    }
+
+    #[test]
+    fn accepts_cli_array_vector_and_option_forms() {
+        let byte_array = array(primitive("u8"), 3);
+        let parsed = parse_argument("abc", &byte_array).unwrap();
+        assert!(matches!(
+            parsed,
+            ArgumentValue::Array(values)
+                if matches!(values.as_slice(), [
+                    ArgumentValue::U8(b'a'),
+                    ArgumentValue::U8(b'b'),
+                    ArgumentValue::U8(b'c'),
+                ])
+        ));
+
+        let word_array = array(primitive("u32"), 3);
+        let parsed = parse_argument("1, 2, 3", &word_array).unwrap();
+        assert!(matches!(
+            parsed,
+            ArgumentValue::Array(values)
+                if matches!(values.as_slice(), [
+                    ArgumentValue::U32(1),
+                    ArgumentValue::U32(2),
+                    ArgumentValue::U32(3),
+                ])
+        ));
+
+        let byte_vector = vector(primitive("u8"));
+        let parsed = parse_argument("1, 2, 3", &byte_vector).unwrap();
+        assert!(matches!(
+            parsed,
+            ArgumentValue::Vec(values)
+                if matches!(values.as_slice(), [
+                    ArgumentValue::U8(1),
+                    ArgumentValue::U8(2),
+                    ArgumentValue::U8(3),
+                ])
+        ));
+
+        let word_vector = vector(primitive("u32"));
+        let parsed = parse_argument("1, 2, 3", &word_vector).unwrap();
+        assert!(matches!(
+            parsed,
+            ArgumentValue::Vec(values)
+                if matches!(values.as_slice(), [
+                    ArgumentValue::U32(1),
+                    ArgumentValue::U32(2),
+                    ArgumentValue::U32(3),
+                ])
+        ));
+
+        let byte_array_vector = vector(array(primitive("u8"), 2));
+        let parsed = parse_argument("0102,0304", &byte_array_vector).unwrap();
+        let ArgumentValue::Vec(values) = parsed else {
+            panic!("expected byte-array vector");
+        };
+        let [ArgumentValue::Array(first), ArgumentValue::Array(second)] = values.as_slice() else {
+            panic!("expected two byte arrays");
+        };
+        assert!(matches!(
+            first.as_slice(),
+            [ArgumentValue::U8(1), ArgumentValue::U8(2)]
+        ));
+        assert!(matches!(
+            second.as_slice(),
+            [ArgumentValue::U8(3), ArgumentValue::U8(4)]
+        ));
+
+        let optional_byte = option(primitive("u8"));
+        assert!(matches!(
+            parse_argument("1", &optional_byte),
+            Ok(ArgumentValue::Option(Some(value))) if matches!(*value, ArgumentValue::U8(1))
+        ));
+        for raw in ["none", ""] {
+            assert!(matches!(
+                parse_argument(raw, &optional_byte),
+                Ok(ArgumentValue::Option(None))
+            ));
+        }
+    }
+
+    #[test]
+    fn rejects_partially_invalid_cli_csv() {
+        for ty in [vector(primitive("u8")), vector(primitive("u32"))] {
+            assert!(parse_argument("1,invalid,3", &ty).is_err());
+        }
+    }
+
+    #[test]
+    fn preserves_legacy_csv_error_paths() {
+        let cases = [
+            ("1,invalid,3", vector(primitive("u8"))),
+            ("1,invalid,3", vector(primitive("u32"))),
+            ("1,invalid,3", array(primitive("u32"), 3)),
+            ("0102,invalid", vector(array(primitive("u8"), 2))),
+        ];
+
+        for (raw, ty) in cases {
+            let Err(error) = parse_argument(raw, &ty) else {
+                panic!("expected invalid legacy CSV: {raw}");
+            };
+            assert_eq!(error.path, vec![1], "{raw}");
+            assert_eq!(error.reason, "invalid legacy CLI value");
+        }
+    }
+
+    #[test]
+    fn serializes_cli_and_json_container_forms_identically() {
+        let bytes = vector(primitive("u8"));
+        let cli_value = parse_argument("1, 2, 3", &bytes).unwrap();
+        let json_value = parse_argument("[1, 2, 3]", &bytes).unwrap();
+
+        assert_eq!(
+            serialize_instruction(0, &[&cli_value]).unwrap(),
+            serialize_instruction(0, &[&json_value]).unwrap(),
+        );
+    }
+
+    #[test]
+    fn serializes_cli_parser_forms_identically() {
+        fn assert_matches_cli(raw: &str, ty: IdlType) {
+            let cli_value = parse_value(raw, &ty).unwrap();
+            let cli_words = crate::serialize::serialize_to_risc0(0, &[(&ty, &cli_value)]).unwrap();
+            let resolver_value = parse_argument(raw, &ty).unwrap();
+            assert_eq!(
+                serialize_instruction(0, &[&resolver_value]).unwrap(),
+                cli_words,
+                "{raw}"
+            );
+        }
+
+        assert_matches_cli("yes", primitive("bool"));
+        assert_matches_cli("abc", array(primitive("u8"), 3));
+        assert_matches_cli("1, 2, 3", array(primitive("u32"), 3));
+        assert_matches_cli("1, 2, 3", vector(primitive("u8")));
+        assert_matches_cli("1, 2, 3", vector(primitive("u32")));
+        assert_matches_cli("", vector(primitive("u32")));
+        assert_matches_cli("0102,0304", vector(array(primitive("u8"), 2)));
+        assert_matches_cli("1", option(primitive("u8")));
+        assert_matches_cli("1,2,3,4,5,6,7,8", primitive("program_id"));
+    }
+
+    #[test]
+    fn serializes_id_like_primitives_with_their_upstream_shapes() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        enum TestInstruction {
+            Execute {
+                account_id: AccountId,
+                program_id: ProgramId,
+                nullifier_public_key: NullifierPublicKey,
+                signed: i128,
+            },
+        }
+
+        let account_id = parse_argument(&"11".repeat(32), &primitive("account_id")).unwrap();
+        let program_id = parse_argument("1,2,3,4,5,6,7,8", &primitive("program_id")).unwrap();
+        let nullifier_public_key =
+            parse_argument(&"22".repeat(32), &primitive("nullifier_public_key")).unwrap();
+        let signed = parse_argument(
+            "-170141183460469231731687303715884105728",
+            &primitive("i128"),
+        )
+        .unwrap();
+        let words = serialize_instruction(
+            0,
+            &[&account_id, &program_id, &nullifier_public_key, &signed],
+        )
+        .unwrap();
+        let decoded = TestInstruction::deserialize(&mut Deserializer::new(words.as_ref())).unwrap();
+
+        assert_eq!(
+            decoded,
+            TestInstruction::Execute {
+                account_id: AccountId::new([0x11; 32]),
+                program_id: [1, 2, 3, 4, 5, 6, 7, 8],
+                nullifier_public_key: NullifierPublicKey([0x22; 32]),
+                signed: i128::MIN,
+            }
+        );
+    }
+
+    #[test]
+    fn validates_and_encodes_pda_seed_argument_types() {
+        let unsigned = primitive("u16");
+        let value = parse_argument("513", &unsigned).unwrap();
+        let seed = value.seed_bytes(&unsigned).unwrap();
+        assert_eq!(&seed[..2], &513_u16.to_le_bytes());
+        assert!(seed[2..].iter().all(|byte| *byte == 0));
+
+        let byte_array = IdlType::Array {
+            array: (Box::new(primitive("u8")), 3),
+        };
+        let value = parse_argument("[1,2,3]", &byte_array).unwrap();
+        assert_eq!(value.seed_bytes(&byte_array).unwrap()[..3], [1, 2, 3]);
+
+        let program = primitive("program_id");
+        let value = parse_argument("1,2,3,4,5,6,7,8", &program).unwrap();
+        let seed = value.seed_bytes(&program).unwrap();
+        assert_eq!(&seed[..4], &1_u32.to_le_bytes());
+        assert_eq!(&seed[28..], &8_u32.to_le_bytes());
+
+        let signed = primitive("i8");
+        let value = parse_argument("-1", &signed).unwrap();
+        assert!(validate_seed_type(&signed).is_err());
+        assert!(value.seed_bytes(&signed).is_err());
+
+        let long_string = primitive("string");
+        let value = parse_argument(&"x".repeat(33), &long_string).unwrap();
+        assert!(value.seed_bytes(&long_string).is_err());
+
+        let nested_option = IdlType::Option {
+            option: Box::new(IdlType::Option {
+                option: Box::new(primitive("u8")),
+            }),
+        };
+        assert!(validate_type(&nested_option).is_err());
+    }
+}

--- a/spel-cli/tests/runtime_idl_wallet_smoke.rs
+++ b/spel-cli/tests/runtime_idl_wallet_smoke.rs
@@ -1,0 +1,104 @@
+use std::{env, error::Error, fs, io, time::Duration};
+
+use common::HashType;
+use nssa::{
+    privacy_preserving_transaction::circuit::ProgramWithDependencies, program::Program, AccountId,
+};
+use sequencer_service_rpc::RpcClient as _;
+use spel::tx::SpelProgram;
+use spel_framework_core::{idl::SpelIdl, pda::parse_bytes32};
+use tokio::time::sleep;
+use wallet::{AccountIdentity, WalletCore};
+
+const IDL_ENV: &str = "SPEL_RUNTIME_IDL_SMOKE_IDL";
+const GUEST_BIN_ENV: &str = "SPEL_RUNTIME_IDL_SMOKE_GUEST_BIN";
+const PUBLIC_ACCOUNT_ENV: &str = "SPEL_RUNTIME_IDL_SMOKE_PUBLIC_ACCOUNT";
+const PRIVATE_ACCOUNT_ENV: &str = "SPEL_RUNTIME_IDL_SMOKE_PRIVATE_ACCOUNT";
+const BLOCK_INTERVAL: Duration = Duration::from_secs(20);
+
+type TestResult<T = ()> = Result<T, Box<dyn Error>>;
+
+fn required_env(name: &str) -> TestResult<String> {
+    Ok(env::var(name)?)
+}
+
+fn account_id(name: &str) -> TestResult<AccountId> {
+    let value = required_env(name)?;
+    Ok(AccountId::new(
+        parse_bytes32(&value).map_err(io::Error::other)?,
+    ))
+}
+
+#[expect(
+    clippy::panic_in_result_fn,
+    reason = "assertions produce clearer failures for this integration test"
+)]
+#[tokio::test]
+#[ignore = "requires scripts/smoke-test-privacy.sh"]
+async fn runtime_idl_builds_do_not_submit_or_change_state() -> TestResult {
+    // Arrange
+    let idl = serde_json::from_slice::<SpelIdl>(&fs::read(required_env(IDL_ENV)?)?)?;
+    let program = Program::new(fs::read(required_env(GUEST_BIN_ENV)?)?.into())?;
+    let public_program_id = program.id();
+    let private_program = ProgramWithDependencies::from(program);
+    let public_account = account_id(PUBLIC_ACCOUNT_ENV)?;
+    let private_account = account_id(PRIVATE_ACCOUNT_ENV)?;
+    let wallet = WalletCore::from_env()?;
+    let public_state_before = wallet.sequencer_client.get_account(public_account).await?;
+    let private_commitment_before = wallet
+        .get_private_account_commitment(private_account)
+        .ok_or_else(|| io::Error::other("private account commitment is unavailable"))?;
+
+    // Act
+    let public_transaction = SpelProgram::new(&idl)
+        .program(public_program_id)
+        .public("greet")?
+        .input("account", public_account)?
+        .input("greeting", "72,101,108,108,111,32,80,117,98,108,105,99")?
+        .build(&wallet)
+        .await?;
+    let (private_transaction, _) = SpelProgram::new(&idl)
+        .program(&private_program)
+        .private("greet")?
+        .input("account", AccountIdentity::PrivateOwned(private_account))?
+        .input(
+            "greeting",
+            "72,101,108,108,111,32,80,114,105,118,97,116,101",
+        )?
+        .build(&wallet)
+        .await?;
+    let public_hash = HashType(public_transaction.hash());
+    let private_hash = HashType(private_transaction.hash());
+
+    sleep(BLOCK_INTERVAL).await;
+
+    // Assert
+    assert!(
+        wallet
+            .sequencer_client
+            .get_transaction(public_hash)
+            .await?
+            .is_none(),
+        "public build submitted a transaction"
+    );
+    assert!(
+        wallet
+            .sequencer_client
+            .get_transaction(private_hash)
+            .await?
+            .is_none(),
+        "private build submitted a transaction"
+    );
+    assert_eq!(
+        wallet.sequencer_client.get_account(public_account).await?,
+        public_state_before,
+        "public build changed account state"
+    );
+    assert_eq!(
+        wallet.get_private_account_commitment(private_account),
+        Some(private_commitment_before),
+        "private build changed Wallet account state"
+    );
+
+    Ok(())
+}

--- a/spel-ffi-compile-test/Cargo.toml
+++ b/spel-ffi-compile-test/Cargo.toml
@@ -8,11 +8,11 @@ publish = false
 spel-client-gen = { path = "../spel-client-gen" }
 
 [dependencies]
-nssa        = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", package = "lee" }
-nssa_core   = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", package = "lee_core" }
-common      = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0" }
-sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["client"] }
-wallet      = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0" }
+nssa        = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "0400899fe9b4a059ef919e6db5284c1dfbd43ab8", package = "lee" }
+nssa_core   = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "0400899fe9b4a059ef919e6db5284c1dfbd43ab8", package = "lee_core" }
+common      = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "0400899fe9b4a059ef919e6db5284c1dfbd43ab8" }
+sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "0400899fe9b4a059ef919e6db5284c1dfbd43ab8", features = ["client"] }
+wallet      = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "0400899fe9b4a059ef919e6db5284c1dfbd43ab8" }
 serde_json  = "1"
 serde       = { version = "1", features = ["derive"] }
 borsh       = "1.5"

--- a/spel-framework-core/Cargo.toml
+++ b/spel-framework-core/Cargo.toml
@@ -14,7 +14,7 @@ idl-gen = ["dep:syn", "dep:proc-macro2", "dep:toml"]
 host = ["dep:nssa"]
 
 [dependencies]
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["host"], package = "lee_core" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "0400899fe9b4a059ef919e6db5284c1dfbd43ab8", features = ["host"], package = "lee_core" }
 borsh = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
@@ -22,7 +22,7 @@ serde_json = "1.0"
 sha2 = "0.10"
 base58 = { version = "0.2", optional = true }
 
-nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", optional = true, package = "lee" }
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "0400899fe9b4a059ef919e6db5284c1dfbd43ab8", optional = true, package = "lee" }
 
 syn = { version = "2.0", features = ["full", "extra-traits"], optional = true }
 proc-macro2 = { version = "1.0", optional = true }

--- a/spel-framework-core/src/pda.rs
+++ b/spel-framework-core/src/pda.rs
@@ -3,7 +3,7 @@
 use base58::FromBase58;
 use nssa_core::account::AccountId;
 use nssa_core::program::{PdaSeed, ProgramId};
-use nssa_core::NullifierPublicKey;
+use nssa_core::{Identifier, NullifierPublicKey};
 use sha2::{Digest, Sha256};
 
 /// Trait for converting a value into a 32-byte PDA seed.
@@ -73,19 +73,7 @@ pub fn seed_from_str(s: &str) -> [u8; 32] {
 ///
 /// Panics if `seeds` is empty.
 pub fn compute_pda(program_id: &ProgramId, seeds: &[&[u8; 32]]) -> AccountId {
-    assert!(!seeds.is_empty(), "PDA requires at least one seed");
-
-    let combined = if seeds.len() == 1 {
-        *seeds[0]
-    } else {
-        let mut hasher = Sha256::new();
-        for seed in seeds {
-            hasher.update(seed);
-        }
-        hasher.finalize().into()
-    };
-
-    let pda_seed = PdaSeed::new(combined);
+    let pda_seed = PdaSeed::new(combine_pda_seeds(seeds));
     AccountId::for_public_pda(program_id, &pda_seed)
 }
 
@@ -94,7 +82,9 @@ pub fn compute_pda(program_id: &ProgramId, seeds: &[&[u8; 32]]) -> AccountId {
 ///
 /// The seed combining logic mirrors [`compute_pda`]; the difference is the final
 /// derivation calls `AccountId::for_private_pda`, which includes the `npk` in the
-/// hash so each controller group gets a unique address for the same seed.
+/// hash so each controller group gets a unique address for the same seed. This
+/// compatibility helper uses identifier `0`; use [`compute_private_pda_with_identifier`]
+/// for a different identifier.
 ///
 /// # Panics
 ///
@@ -104,9 +94,30 @@ pub fn compute_private_pda(
     seeds: &[&[u8; 32]],
     npk: &NullifierPublicKey,
 ) -> AccountId {
+    compute_private_pda_with_identifier(program_id, seeds, npk, 0)
+}
+
+/// Derive a **private** PDA `AccountId` with an explicit private-account identifier.
+///
+/// This uses the same seed composition as [`compute_pda`] and [`compute_private_pda`].
+///
+/// # Panics
+///
+/// Panics if `seeds` is empty.
+pub fn compute_private_pda_with_identifier(
+    program_id: &ProgramId,
+    seeds: &[&[u8; 32]],
+    npk: &NullifierPublicKey,
+    identifier: Identifier,
+) -> AccountId {
+    let pda_seed = PdaSeed::new(combine_pda_seeds(seeds));
+    AccountId::for_private_pda(program_id, &pda_seed, npk, identifier)
+}
+
+fn combine_pda_seeds(seeds: &[&[u8; 32]]) -> [u8; 32] {
     assert!(!seeds.is_empty(), "PDA requires at least one seed");
 
-    let combined = if seeds.len() == 1 {
+    if seeds.len() == 1 {
         *seeds[0]
     } else {
         let mut hasher = Sha256::new();
@@ -114,12 +125,7 @@ pub fn compute_private_pda(
             hasher.update(seed);
         }
         hasher.finalize().into()
-    };
-
-    let pda_seed = PdaSeed::new(combined);
-    // lez-core-v0.2.0 added a u128 `identifier` to private-PDA derivation; default
-    // to 0 (the common case) until callers need to pass a specific identifier.
-    AccountId::for_private_pda(program_id, &pda_seed, npk, 0)
+    }
 }
 
 /// Compute a PDA from a program ID and multiple [`ToSeed`] values.
@@ -304,6 +310,21 @@ mod tests {
         let single = compute_pda(&program_id, &[&seed]);
         let multi = compute_pda(&program_id, &[&seed, &[0u8; 32]]);
         assert_ne!(single, multi);
+    }
+
+    #[test]
+    fn test_compute_private_pda_with_identifier() {
+        let program_id: ProgramId = [1u32; 8];
+        let seed = seed_from_str("private");
+        let npk = NullifierPublicKey([2u8; 32]);
+        let identifier = 7;
+
+        let actual = compute_private_pda_with_identifier(&program_id, &[&seed], &npk, identifier);
+        let expected =
+            AccountId::for_private_pda(&program_id, &PdaSeed::new(seed), &npk, identifier);
+
+        assert_eq!(actual, expected);
+        assert_ne!(actual, compute_private_pda(&program_id, &[&seed], &npk));
     }
 
     #[test]

--- a/spel-framework/Cargo.toml
+++ b/spel-framework/Cargo.toml
@@ -11,8 +11,8 @@ host = ["dep:nssa", "spel-framework-core/host"]
 [dependencies]
 spel-framework-core = { path = "../spel-framework-core" }
 spel-framework-macros = { path = "../spel-framework-macros" }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["host"], package = "lee_core" }
-nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", optional = true, package = "lee" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "0400899fe9b4a059ef919e6db5284c1dfbd43ab8", features = ["host"], package = "lee_core" }
+nssa = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "0400899fe9b4a059ef919e6db5284c1dfbd43ab8", optional = true, package = "lee" }
 borsh = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 

--- a/test-modules/test_modules_ffi/Cargo.toml
+++ b/test-modules/test_modules_ffi/Cargo.toml
@@ -7,11 +7,11 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-nssa        = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", package = "lee" }
-nssa_core   = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", package = "lee_core" }
-common      = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0" }
-sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["client"] }
-wallet      = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0" }
+nssa        = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "0400899fe9b4a059ef919e6db5284c1dfbd43ab8", package = "lee" }
+nssa_core   = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "0400899fe9b4a059ef919e6db5284c1dfbd43ab8", package = "lee_core" }
+common      = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "0400899fe9b4a059ef919e6db5284c1dfbd43ab8" }
+sequencer_service_rpc = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "0400899fe9b4a059ef919e6db5284c1dfbd43ab8", features = ["client"] }
+wallet      = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "0400899fe9b4a059ef919e6db5284c1dfbd43ab8" }
 spel-framework-core = { path = "../../spel-framework-core" }
 serde_json  = "1"
 serde       = { version = "1", features = ["derive"] }

--- a/tests/e2e/fixture_program/Cargo.lock
+++ b/tests/e2e/fixture_program/Cargo.lock
@@ -1040,7 +1040,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 [[package]]
 name = "lee_core"
 version = "0.1.0"
-source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?tag=lez-core-v0.2.0#fb8cbac40e0bda4f152415ff4f181cdc6bca6d4a"
+source = "git+https://github.com/logos-blockchain/logos-execution-zone.git?rev=0400899fe9b4a059ef919e6db5284c1dfbd43ab8#0400899fe9b4a059ef919e6db5284c1dfbd43ab8"
 dependencies = [
  "base58",
  "borsh",

--- a/tests/e2e/fixture_program/Cargo.toml
+++ b/tests/e2e/fixture_program/Cargo.toml
@@ -8,6 +8,6 @@ publish = false
 
 [dependencies]
 spel-framework = { path = "../../../spel-framework" }
-nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", tag = "v0.2.0", features = ["host"], package = "lee_core" }
+nssa_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git", rev = "0400899fe9b4a059ef919e6db5284c1dfbd43ab8", features = ["host"], package = "lee_core" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
## 🎯 Purpose

Implement #245 with an ergonomic runtime-IDL transaction-building API in
`spel::tx`. Applications bind a public or private program once, provide named
IDL inputs, and receive native Wallet transaction types.

The new builder API prepares transactions only. It does not submit, poll,
confirm, print, or change CLI behavior; the application submits through
WalletCore.

## ⚙️ Approach

- [x] Add `SpelProgram`, reusable program bindings, public/private instruction
  builders, `SpelInput`, and structured build errors under `spel::tx`.
- [x] Reuse the existing resolver for IDL validation, account/PDA resolution,
  argument parsing, identity checks, duplicate detection, and serialization.
- [x] Accept named scalar, JSON, account, and rest-account inputs; preserve
  established CLI-compatible argument formats while adding canonical JSON.
- [x] Delegate directly to `WalletCore::build_pub_tx` and
  `WalletCore::build_privacy_preserving_tx`, returning their native results
  without a transaction, Wallet, send, or confirmation wrapper.
- [x] Add preflight errors only for bare IDs inferred as public signer or
  initialized accounts; explicit `AccountIdentity` values remain a Wallet
  contract.
- [x] Document the high-level API beside the direct resolver escape hatch and
  add hermetic plus sequencer-backed build-only coverage.
- [x] Run the build-only check before existing privacy smoke CLI submissions;
  use the existing `--lez-rev` option for commit-pinned LEZ smoke inputs.

## 🧪 How to Test

Run from the repository root:

```sh
cargo fmt --all -- --check
cargo test -p spel
cargo clippy -p spel --all-targets
cargo build -p spel
cargo run -p spel -- init --help
bash -n scripts/smoke-test-privacy.sh
```

Run `scripts/smoke-test-privacy.sh` in its existing LEZ smoke environment. It
executes the ignored runtime-IDL integration test, verifies build-only public
and private transactions do not reach the sequencer or change relevant state,
then runs the existing public and privacy-preserving CLI submission checks.

## 🔗 Dependencies

- [SPEL PR #248](https://github.com/logos-co/spel/pull/248) provides the resolver API this branch extends.
- [LEZ PR #614](https://github.com/logos-blockchain/logos-execution-zone/pull/614) provides the WalletCore build-only methods pinned by this branch until a compatible release tag is available.

## 🔜 Future Work

- Adopt the resolver inside CLI internals in a separate behavior-preserving change.
- Consider CLI behavior or dry-run changes only after internal adoption is complete.
- Add generic private-PDA reuse or update only when WalletCore exposes the required binding contract with end-to-end coverage.
- Propose additional input conversions or public dry-run metadata separately.

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments
