### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,42 @@
+## v0.6.0 (2026-07-15)
+
+### 💥 Breaking Changes
+
+- **Upgrade to LEZ v0.2.0.** The Logos Execution Zone dependency moves to `v0.2.0`: the
+  `nssa` / `nssa_core` crates are now `lee` / `lee_core`, and public transactions are signed
+  over the `/LEE/v0.3` preimage the live testnet accepts. The wallet-home environment
+  variable is **renamed `NSSA_WALLET_HOME_DIR` → `LEE_WALLET_HOME_DIR`** — update any
+  scripts, CI, or FFI callers. (#238)
+
+### ✨ Features
+
+- **`Vec<String>` instruction arguments** — repeat a flag (`--tag a --tag b`) to build a
+  `Vec<String>` argument for an instruction. (#189)
+
+### 🐛 Fixes
+
+- **LEZ v0.2.0 compatibility.** SPEL now builds against LEZ v0.2.0 and its public
+  transactions are accepted by the live testnet — fixing both the `nssa_core`-not-found
+  build break and the `InvalidSignature` rejection on public transactions. Verified
+  end-to-end against `https://testnet.lez.logos.co/`. (#238; closes #234, #237, #247)
+- **Deterministic IDL output.** Account helper types are emitted in a stable, name-sorted
+  order, so the generated IDL is byte-identical across runs (previously randomized by
+  `HashSet` iteration order — a source of spurious diffs and flaky committed-IDL checks).
+  (#232)
+- **Hardened ProgramId parsing.** `parse_program_id` now rejects `Public/`/`Private/`
+  account ids and non-canonical base58 rather than silently reinterpreting them as a
+  ProgramId, so a mistyped or wrong-encoding value errors instead of building a transaction
+  against the wrong program. (#250; closes #243)
+
+### ✅ Also resolved (fixed by the LEZ v0.2.0 upgrade)
+
+- Wallet storage schema now matches the `wallet` CLI — SPEL reads `storage.json` created by
+  the wallet without a deserialization error. (closes #235)
+- Guest builds no longer pull `bonsai-sdk → reqwest → rustls → ring`; riscv32
+  cross-compilation of programs using `spel-framework` is clean. (closes #165)
+
+---
+
 ## v0.5.0 (2026-06-01)
 
 ### ✨ Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6818,7 +6818,7 @@ dependencies = [
 
 [[package]]
 name = "spel"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base58",
  "borsh",
@@ -6839,7 +6839,7 @@ dependencies = [
 
 [[package]]
 name = "spel-client-gen"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "pretty_assertions",
  "serde",
@@ -6869,7 +6869,7 @@ dependencies = [
 
 [[package]]
 name = "spel-framework"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "borsh",
  "lee",
@@ -6882,7 +6882,7 @@ dependencies = [
 
 [[package]]
 name = "spel-framework-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base58",
  "borsh",
@@ -6899,7 +6899,7 @@ dependencies = [
 
 [[package]]
 name = "spel-framework-macros"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/spel-cli/Cargo.toml
+++ b/spel-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spel"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Generic IDL-driven CLI for SPEL programs"
 

--- a/spel-client-gen/Cargo.toml
+++ b/spel-client-gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spel-client-gen"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Generate typed Rust client and C FFI bindings from SPEL program IDL"
 license = "MIT"

--- a/spel-framework-core/Cargo.toml
+++ b/spel-framework-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spel-framework-core"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Core types for the SPEL program framework"
 

--- a/spel-framework-macros/Cargo.toml
+++ b/spel-framework-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spel-framework-macros"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Proc macros for the SPEL program framework"
 

--- a/spel-framework/Cargo.toml
+++ b/spel-framework/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spel-framework"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 description = "Developer framework for building SPEL programs (like Anchor for Solana)"
 


### PR DESCRIPTION
Release **v0.6.0**. Merging this PR triggers `publish.yml`, which tags `v0.6.0` and creates the GitHub Release.

Bumps the 5 workspace crates `0.5.0 → 0.6.0` and adds a curated CHANGELOG entry (replacing the auto-generated one, which duplicated #238 and lacked context).

## Highlights
- 💥 **Breaking:** upgrade to LEZ v0.2.0 (`nssa/nssa_core` → `lee/lee_core`; env var `NSSA_WALLET_HOME_DIR` → `LEE_WALLET_HOME_DIR`) — #238
- ✨ `Vec<String>` instruction args — #189
- 🐛 Deterministic IDL output (#232); hardened ProgramId parsing (#250/#243)

Closes #234, #237, #247, #235, #165, #243. Verified live against `https://testnet.lez.logos.co/`, and validated by the `lez-multisig` e2e suite building green against this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)