### PR TITLE
fix(release): embed CHANGELOG entry in GitHub Release body

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,21 +25,38 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Extracted version: $VERSION"
 
+      - name: Build release notes from CHANGELOG
+        id: notes
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          # Extract this version's section: from "## vX.Y.Z ..." up to (but not
+          # including) the next "## v..." heading.
+          awk -v ver="v${VERSION}" '
+            $0 ~ ("^## " ver "( |$)") { f=1; print; next }
+            f && /^## v[0-9]/        { exit }
+            f                        { print }
+          ' CHANGELOG.md > release-notes.md
+          # Fallback if the section is missing/empty (e.g. changelog not updated).
+          if [ ! -s release-notes.md ]; then
+            printf '## v%s\n\nSee [CHANGELOG.md](https://github.com/logos-co/spel/blob/main/CHANGELOG.md) for details.\n' "$VERSION" > release-notes.md
+          fi
+          # Append the install snippet (single-quoted echoes keep the ``` fences literal).
+          {
+            echo ""
+            echo "---"
+            echo ""
+            echo "**Installation** (Cargo.toml):"
+            echo '```toml'
+            echo "spel-framework = { git = \"https://github.com/logos-co/spel.git\", tag = \"v${VERSION}\" }"
+            echo '```'
+          } >> release-notes.md
+          echo "Release notes:"; cat release-notes.md
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ steps.version.outputs.version }}
           name: v${{ steps.version.outputs.version }}
-          body: |
-            ## v${{ steps.version.outputs.version }}
-
-            See [CHANGELOG.md](https://github.com/logos-co/spel/blob/main/CHANGELOG.md) for full details.
-
-            ---
-
-            **Installation** (Cargo.toml):
-            ```toml
-            spel-framework = { git = "https://github.com/logos-co/spel.git", tag = "v${{ steps.version.outputs.version }}" }
-            ```
+          body_path: release-notes.md
           draft: false
           prerelease: false


### PR DESCRIPTION
## Problem
`publish.yml` created the GitHub Release with a **hardcoded stub** body — `## vX.Y.Z / See CHANGELOG.md for full details` + an install snippet — so Release pages never showed the actual notes (as seen on the v0.6.0 release, which I've since patched by hand). `release.yml` builds a nice categorized body, but `publish.yml` (which actually creates the Release) ignored it.

## Fix
Add a step that extracts the released version's section from `CHANGELOG.md` (the source of truth — from `## vX.Y.Z` up to the next `## v…` heading) into `release-notes.md`, appends the install snippet, and passes it via `body_path`. Falls back to the old stub if the section is missing/empty.

Validated: the awk extraction pulls the exact v0.6.0 section (39 lines, stops before v0.5.0); `publish.yml` is valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)