### PR TITLE
fix(idl-gen): skip path-dep source files the consumer edition cannot re-lex

### DIFF
--- a/spel-cli/src/generate_idl.rs
+++ b/spel-cli/src/generate_idl.rs
@@ -170,7 +170,7 @@ mod tests {
 
     impl Drop for TempDir {
         fn drop(&mut self) {
-            let _ = fs::remove_dir_all(&self.0);
+            fs::remove_dir_all(&self.0).ok();
         }
     }
 
@@ -823,7 +823,8 @@ pub mod token {
         );
         assert_eq!(dep_result.dirs.len(), 1);
 
-        let idl = generate_idl_from_file_with_deps(&program, &dep_result.dirs).unwrap();
+        let idl =
+            generate_idl_from_file_with_deps(&program, &dep_result.dirs, &mut |_| {}).unwrap();
 
         assert_eq!(idl.name, "token");
         assert_eq!(idl.instructions.len(), 4);
@@ -906,7 +907,8 @@ pub mod token {
             "unexpected warnings: {:?}",
             dep_result.warnings
         );
-        let idl = generate_idl_from_file_with_deps(&program, &dep_result.dirs).unwrap();
+        let idl =
+            generate_idl_from_file_with_deps(&program, &dep_result.dirs, &mut |_| {}).unwrap();
 
         let account_names: Vec<&str> = idl.accounts.iter().map(|a| a.name.as_str()).collect();
         assert!(
@@ -964,7 +966,8 @@ pub mod token {
             "unexpected warnings: {:?}",
             dep_result.warnings
         );
-        let idl = generate_idl_from_file_with_deps(&program, &dep_result.dirs).unwrap();
+        let idl =
+            generate_idl_from_file_with_deps(&program, &dep_result.dirs, &mut |_| {}).unwrap();
 
         let account_names: Vec<&str> = idl.accounts.iter().map(|a| a.name.as_str()).collect();
         assert!(
@@ -1014,7 +1017,8 @@ pub mod token {
             "unexpected warnings: {:?}",
             dep_result.warnings
         );
-        let idl = generate_idl_from_file_with_deps(&program, &dep_result.dirs).unwrap();
+        let idl =
+            generate_idl_from_file_with_deps(&program, &dep_result.dirs, &mut |_| {}).unwrap();
 
         let account_names: Vec<&str> = idl.accounts.iter().map(|a| a.name.as_str()).collect();
         assert!(
@@ -1054,7 +1058,7 @@ pub mod token {
         );
 
         // Passing no dep dirs replicates the old single-file behaviour
-        let idl = generate_idl_from_file_with_deps(&program, &[]).unwrap();
+        let idl = generate_idl_from_file_with_deps(&program, &[], &mut |_| {}).unwrap();
         assert!(
             idl.accounts.is_empty(),
             "expected no accounts without dep scanning, got {:?}",
@@ -1110,7 +1114,8 @@ pub mod test_helpers {
             "unexpected warnings: {:?}",
             dep_result.warnings
         );
-        let idl = generate_idl_from_file_with_deps(&program, &dep_result.dirs).unwrap();
+        let idl =
+            generate_idl_from_file_with_deps(&program, &dep_result.dirs, &mut |_| {}).unwrap();
 
         let account_names: Vec<&str> = idl.accounts.iter().map(|a| a.name.as_str()).collect();
         assert!(
@@ -1164,7 +1169,8 @@ pub mod experimental {
         );
 
         let dep_result = find_path_dep_dirs(&program);
-        let idl = generate_idl_from_file_with_deps(&program, &dep_result.dirs).unwrap();
+        let idl =
+            generate_idl_from_file_with_deps(&program, &dep_result.dirs, &mut |_| {}).unwrap();
 
         let account_names: Vec<&str> = idl.accounts.iter().map(|a| a.name.as_str()).collect();
         assert!(
@@ -1218,7 +1224,8 @@ pub mod debug {
         );
 
         let dep_result = find_path_dep_dirs(&program);
-        let idl = generate_idl_from_file_with_deps(&program, &dep_result.dirs).unwrap();
+        let idl =
+            generate_idl_from_file_with_deps(&program, &dep_result.dirs, &mut |_| {}).unwrap();
 
         let account_names: Vec<&str> = idl.accounts.iter().map(|a| a.name.as_str()).collect();
         assert!(
@@ -1270,7 +1277,8 @@ pub struct TestOnlyStruct { pub fake: u64 }
         );
 
         let dep_result = find_path_dep_dirs(&program);
-        let idl = generate_idl_from_file_with_deps(&program, &dep_result.dirs).unwrap();
+        let idl =
+            generate_idl_from_file_with_deps(&program, &dep_result.dirs, &mut |_| {}).unwrap();
 
         let account_names: Vec<&str> = idl.accounts.iter().map(|a| a.name.as_str()).collect();
         assert!(
@@ -1322,7 +1330,8 @@ pub struct ProdOnlyStruct { pub secret: u64 }
         );
 
         let dep_result = find_path_dep_dirs(&program);
-        let idl = generate_idl_from_file_with_deps(&program, &dep_result.dirs).unwrap();
+        let idl =
+            generate_idl_from_file_with_deps(&program, &dep_result.dirs, &mut |_| {}).unwrap();
 
         let account_names: Vec<&str> = idl.accounts.iter().map(|a| a.name.as_str()).collect();
         assert!(
@@ -1394,7 +1403,8 @@ pub struct CoreAccount { pub balance: u128 }
             dep_result.dirs
         );
 
-        let idl = generate_idl_from_file_with_deps(&program, &dep_result.dirs).unwrap();
+        let idl =
+            generate_idl_from_file_with_deps(&program, &dep_result.dirs, &mut |_| {}).unwrap();
 
         let account_names: Vec<&str> = idl.accounts.iter().map(|a| a.name.as_str()).collect();
         assert!(

--- a/spel-cli/src/lib.rs
+++ b/spel-cli/src/lib.rs
@@ -319,7 +319,11 @@ pub async fn run() {
                     for w in &dep_result.warnings {
                         eprintln!("{}", w);
                     }
-                    match generate_idl_from_file_with_deps(&sources[0], &dep_result.dirs) {
+                    match generate_idl_from_file_with_deps(
+                        &sources[0],
+                        &dep_result.dirs,
+                        &mut |w| eprintln!("{w}"),
+                    ) {
                         Ok(idl) => println!("{}", serde_json::to_string_pretty(&idl).unwrap()),
                         Err(e) => {
                             eprintln!("Error: {}", e);
@@ -334,7 +338,9 @@ pub async fn run() {
                         for w in &dep_result.warnings {
                             eprintln!("{}", w);
                         }
-                        match generate_idl_from_file_with_deps(source, &dep_result.dirs) {
+                        match generate_idl_from_file_with_deps(source, &dep_result.dirs, &mut |w| {
+                            eprintln!("{w}")
+                        }) {
                             Ok(idl) => {
                                 let out_name = format!("{}-idl.json", idl.name);
                                 match fs::write(

--- a/spel-framework-core/src/idl_gen.rs
+++ b/spel-framework-core/src/idl_gen.rs
@@ -259,6 +259,30 @@ pub fn collect_items_from_crate_dirs(dirs: &[PathBuf]) -> (Vec<syn::Item>, Vec<P
     (items, files_read)
 }
 
+/// True when the text contains a macro metavariable glued to a string
+/// literal (e.g. ark-ff 0.3.0's `stringify!($Fp"({})")`). That shape is
+/// legal in the defining crate's own pre-2021 edition, but re-lexed as raw
+/// source under a 2021+ edition rustc's lexer queues a fatal "unknown
+/// prefix" error as a side effect even though the parse error itself is
+/// caught by the caller. Files like this cannot carry usable
+/// `#[account_type]` items, so they are skipped instead of parsed.
+fn has_metavar_glued_literal(content: &str) -> bool {
+    let bytes = content.as_bytes();
+    let mut i = 0;
+    while let Some(off) = content[i..].find('$') {
+        let start = i + off + 1;
+        let mut j = start;
+        while j < bytes.len() && (bytes[j].is_ascii_alphanumeric() || bytes[j] == b'_') {
+            j += 1;
+        }
+        if j > start && j < bytes.len() && bytes[j] == b'"' && !bytes[start].is_ascii_digit() {
+            return true;
+        }
+        i = start;
+    }
+    false
+}
+
 /// Parse a single Rust source file and append its items to `out`, following
 /// external `mod` declarations to their corresponding files.
 fn collect_items_from_source_file(
@@ -280,6 +304,9 @@ fn collect_items_from_source_file(
         Err(_) => return,
     };
     files_read.push(path.to_path_buf());
+    if has_metavar_glued_literal(&content) {
+        return;
+    }
     let file = match syn::parse_file(&content) {
         Ok(f) => f,
         Err(_) => return,
@@ -1065,6 +1092,42 @@ fn _find_crate_manifest<F: FnMut(String)>(start: &Path, on_warning: &mut F) -> O
 mod tests {
     use super::*;
     use crate::idl::{IdlSeed, IdlType, SpelIdl};
+
+    #[test]
+    fn metavar_glued_literal_is_detected() {
+        // The exact shape from ark-ff-0.3.0 src/fields/macros.rs:615.
+        assert!(has_metavar_glued_literal(
+            r#"write!(f, stringify!($Fp"({})"), self.into_repr())"#
+        ));
+        // A metavariable not glued to a quote is fine.
+        assert!(!has_metavar_glued_literal(
+            "macro_rules! m { ($x:ident) => { $x } }"
+        ));
+        // A bare dollar, a digit after the dollar, and plain code are fine.
+        assert!(!has_metavar_glued_literal("let price = \"$\";"));
+        assert!(!has_metavar_glued_literal("fn account_type_free() {}"));
+    }
+
+    #[test]
+    fn landmine_file_contributes_no_items_but_is_tracked() {
+        let dir = std::env::temp_dir().join("spel_idl_gen_landmine_fixture_up");
+        std::fs::create_dir_all(dir.join("src")).unwrap();
+        std::fs::write(
+            dir.join("src").join("lib.rs"),
+            concat!(
+                "#[account_type]
+pub struct Hidden { pub x: u8 }
+",
+                "macro_rules! m { () => { stringify!($Fp\"({})\") } }
+",
+            ),
+        )
+        .unwrap();
+        let (items, files) = collect_items_from_crate_dirs(std::slice::from_ref(&dir));
+        assert_eq!(files.len(), 1, "the file must still be change-tracked");
+        assert!(items.is_empty(), "a landmine file must be skipped whole");
+        std::fs::remove_dir_all(&dir).ok();
+    }
 
     fn ok(src: &str) -> SpelIdl {
         generate_idl_from_str(src, "<test>").expect("IDL generation failed")

--- a/spel-framework-core/src/idl_gen.rs
+++ b/spel-framework-core/src/idl_gen.rs
@@ -17,6 +17,9 @@ use crate::idl::{IdlAccountItem, IdlArg, IdlInstruction, IdlPda, IdlSeed, SpelId
 
 use crate::account_types::{collect_account_types, syn_type_to_idl_type};
 
+mod unlexable;
+use unlexable::has_metavar_glued_literal;
+
 /// Error type returned by [`generate_idl_from_file`].
 #[derive(Debug)]
 pub enum IdlGenError {
@@ -57,8 +60,14 @@ impl From<syn::Error> for IdlGenError {
 ///
 /// The path is resolved relative to the current working directory,
 /// which is the natural behavior for a CLI tool.
+///
+/// # Errors
+///
+/// `Err` on an unreadable or unparsable source file, a source without
+/// a `#[lez_program]` module, or a program module with no
+/// `#[instruction]` functions.
 pub fn generate_idl_from_file(source_path: &Path) -> Result<SpelIdl, IdlGenError> {
-    generate_idl_from_file_with_deps(source_path, &[])
+    generate_idl_from_file_with_deps(source_path, &[], &mut |_| {})
 }
 
 /// Parse a SPEL program source file and return its [`SpelIdl`], also scanning
@@ -69,12 +78,22 @@ pub fn generate_idl_from_file(source_path: &Path) -> Result<SpelIdl, IdlGenError
 /// that contains `src/lib.rs`).  Only local path-dependencies should be passed
 /// here — third-party registry or git crates are intentionally excluded to
 /// avoid pulling in unrelated type definitions.
-pub fn generate_idl_from_file_with_deps(
+///
+/// `on_warning` receives non-fatal notes from the dependency scan, currently
+/// the skip of a source file the consumer's edition cannot re-lex.
+///
+/// # Errors
+///
+/// Same surface as [`generate_idl_from_file`]: IO, parse, missing
+/// program module or no instructions. Dependency-scan problems are
+/// never errors, they arrive as warnings.
+pub fn generate_idl_from_file_with_deps<F: FnMut(String)>(
     source_path: &Path,
     dep_source_dirs: &[PathBuf],
+    on_warning: &mut F,
 ) -> Result<SpelIdl, IdlGenError> {
     let content = std::fs::read_to_string(source_path)?;
-    let (extra_items, _) = collect_items_from_crate_dirs(dep_source_dirs);
+    let (extra_items, _) = collect_items_from_crate_dirs(dep_source_dirs, on_warning);
     generate_idl_inner(&content, &source_path.display().to_string(), &extra_items)
 }
 
@@ -243,53 +262,48 @@ fn generate_idl_inner(
 /// avoid pulling in unrelated type definitions.
 ///
 /// Returns `(items, files_read)` where `files_read` lists every source file
-/// that was actually parsed.  Callers can use this list for change tracking
-/// (e.g. emitting `include_str!()` references so cargo rebuilds when
-/// path-dep sources change).
-pub fn collect_items_from_crate_dirs(dirs: &[PathBuf]) -> (Vec<syn::Item>, Vec<PathBuf>) {
+/// that was read.  A file skipped as unlexable stays in the list on purpose:
+/// change tracking must keep watching it so a fixed dependency retriggers
+/// the build.  Callers can use this list for change tracking (e.g. emitting
+/// `include_str!()` references so cargo rebuilds when path-dep sources
+/// change).
+///
+/// `on_warning` is called for non-fatal issues, currently the skip of a
+/// source file the consumer's edition cannot re-lex.
+pub fn collect_items_from_crate_dirs<F: FnMut(String)>(
+    dirs: &[PathBuf],
+    mut on_warning: F,
+) -> (Vec<syn::Item>, Vec<PathBuf>) {
     let mut items = Vec::new();
     let mut visited: HashSet<PathBuf> = HashSet::new();
     let mut files_read = Vec::new();
     for dir in dirs {
         let lib_rs = dir.join("src").join("lib.rs");
         if lib_rs.exists() {
-            collect_items_from_source_file(&lib_rs, &mut items, &mut visited, &mut files_read);
+            collect_items_from_source_file(
+                &lib_rs,
+                &mut items,
+                &mut visited,
+                &mut files_read,
+                &mut on_warning,
+            );
         }
     }
     (items, files_read)
 }
 
-/// True when the text contains a macro metavariable glued to a string
-/// literal (e.g. ark-ff 0.3.0's `stringify!($Fp"({})")`). That shape is
-/// legal in the defining crate's own pre-2021 edition, but re-lexed as raw
-/// source under a 2021+ edition rustc's lexer queues a fatal "unknown
-/// prefix" error as a side effect even though the parse error itself is
-/// caught by the caller. Files like this cannot carry usable
-/// `#[account_type]` items, so they are skipped instead of parsed.
-fn has_metavar_glued_literal(content: &str) -> bool {
-    let bytes = content.as_bytes();
-    let mut i = 0;
-    while let Some(off) = content[i..].find('$') {
-        let start = i + off + 1;
-        let mut j = start;
-        while j < bytes.len() && (bytes[j].is_ascii_alphanumeric() || bytes[j] == b'_') {
-            j += 1;
-        }
-        if j > start && j < bytes.len() && bytes[j] == b'"' && !bytes[start].is_ascii_digit() {
-            return true;
-        }
-        i = start;
-    }
-    false
-}
-
 /// Parse a single Rust source file and append its items to `out`, following
 /// external `mod` declarations to their corresponding files.
-fn collect_items_from_source_file(
+///
+/// A file the consumer's edition cannot re-lex is reported through
+/// `on_warning` and skipped instead of parsed, but still recorded in
+/// `files_read` for change tracking.
+fn collect_items_from_source_file<F: FnMut(String)>(
     path: &Path,
     out: &mut Vec<syn::Item>,
     visited: &mut HashSet<PathBuf>,
     files_read: &mut Vec<PathBuf>,
+    on_warning: &mut F,
 ) {
     let canonical = match path.canonicalize() {
         Ok(p) => p,
@@ -305,6 +319,12 @@ fn collect_items_from_source_file(
     };
     files_read.push(path.to_path_buf());
     if has_metavar_glued_literal(&content) {
+        on_warning(format!(
+            "skipping {}: a macro metavariable glued to a string literal cannot \
+            be re-lexed under the consumer's edition; any #[account_type] items \
+            in this file are not harvested",
+            path.display()
+        ));
         return;
     }
     let file = match syn::parse_file(&content) {
@@ -322,7 +342,14 @@ fn collect_items_from_source_file(
         path.parent().map(|p| p.join(stem))
     };
 
-    collect_items_recursive(&file.items, sub_base.as_deref(), out, visited, files_read);
+    collect_items_recursive(
+        &file.items,
+        sub_base.as_deref(),
+        out,
+        visited,
+        files_read,
+        on_warning,
+    );
 }
 
 /// Resolve the on-disk path for an external `mod` declaration.
@@ -367,12 +394,13 @@ fn mod_file_path(m: &syn::ItemMod, base_dir: &Path) -> Option<PathBuf> {
     None
 }
 
-fn collect_items_recursive(
+fn collect_items_recursive<F: FnMut(String)>(
     items: &[syn::Item],
     base_dir: Option<&Path>,
     out: &mut Vec<syn::Item>,
     visited: &mut HashSet<PathBuf>,
     files_read: &mut Vec<PathBuf>,
+    on_warning: &mut F,
 ) {
     for item in items {
         match item {
@@ -390,11 +418,18 @@ fn collect_items_recursive(
                     // so that any file-backed `mod` declarations inside it resolve
                     // relative to `base_dir/<mod_name>/` rather than `base_dir/`.
                     let inner_base = base_dir.map(|d| d.join(m.ident.to_string()));
-                    collect_items_recursive(inner, inner_base.as_deref(), out, visited, files_read);
+                    collect_items_recursive(
+                        inner,
+                        inner_base.as_deref(),
+                        out,
+                        visited,
+                        files_read,
+                        on_warning,
+                    );
                 } else if let Some(dir) = base_dir {
                     // External module file — locate and parse it.
                     if let Some(p) = mod_file_path(m, dir) {
-                        collect_items_from_source_file(&p, out, visited, files_read);
+                        collect_items_from_source_file(&p, out, visited, files_read, on_warning);
                     }
                 }
             },
@@ -1094,21 +1129,6 @@ mod tests {
     use crate::idl::{IdlSeed, IdlType, SpelIdl};
 
     #[test]
-    fn metavar_glued_literal_is_detected() {
-        // The exact shape from ark-ff-0.3.0 src/fields/macros.rs:615.
-        assert!(has_metavar_glued_literal(
-            r#"write!(f, stringify!($Fp"({})"), self.into_repr())"#
-        ));
-        // A metavariable not glued to a quote is fine.
-        assert!(!has_metavar_glued_literal(
-            "macro_rules! m { ($x:ident) => { $x } }"
-        ));
-        // A bare dollar, a digit after the dollar, and plain code are fine.
-        assert!(!has_metavar_glued_literal("let price = \"$\";"));
-        assert!(!has_metavar_glued_literal("fn account_type_free() {}"));
-    }
-
-    #[test]
     fn landmine_file_contributes_no_items_but_is_tracked() {
         let dir = std::env::temp_dir().join("spel_idl_gen_landmine_fixture_up");
         std::fs::create_dir_all(dir.join("src")).unwrap();
@@ -1123,9 +1143,52 @@ pub struct Hidden { pub x: u8 }
             ),
         )
         .unwrap();
-        let (items, files) = collect_items_from_crate_dirs(std::slice::from_ref(&dir));
+        let mut warnings = Vec::new();
+        let (items, files) =
+            collect_items_from_crate_dirs(std::slice::from_ref(&dir), &mut |w| warnings.push(w));
+        assert_eq!(warnings.len(), 1, "one skip, one warning: {warnings:?}");
+        assert!(warnings[0].contains("lib.rs") && warnings[0].contains("not harvested"));
         assert_eq!(files.len(), 1, "the file must still be change-tracked");
         assert!(items.is_empty(), "a landmine file must be skipped whole");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // The warning fires only on the landmine shape: an ordinary crate
+    // harvests silently.
+    #[test]
+    fn clean_crate_emits_no_warnings() {
+        let dir = std::env::temp_dir().join("spel_idl_gen_clean_fixture_up");
+        std::fs::create_dir_all(dir.join("src")).unwrap();
+        std::fs::write(
+            dir.join("src").join("lib.rs"),
+            "#[account_type]\npub struct Visible { pub x: u8 }\n",
+        )
+        .unwrap();
+        let mut warnings = Vec::new();
+        let (items, files) =
+            collect_items_from_crate_dirs(std::slice::from_ref(&dir), &mut |w| warnings.push(w));
+        assert!(warnings.is_empty(), "no skip, no warning: {warnings:?}");
+        assert_eq!(files.len(), 1);
+        assert!(!items.is_empty(), "the clean file must be harvested");
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // The scan is context-aware: a dollar-word quoted in a doc comment
+    // must not cost the file its account types.
+    #[test]
+    fn dollar_word_in_docs_does_not_drop_the_file() {
+        let dir = std::env::temp_dir().join("spel_idl_gen_dollarword_fixture_up");
+        std::fs::create_dir_all(dir.join("src")).unwrap();
+        std::fs::write(
+            dir.join("src").join("lib.rs"),
+            "/// Respects \"$PATH\" when resolving.\n#[account_type]\npub struct Visible { pub x: u8 }\n",
+        )
+        .unwrap();
+        let mut warnings = Vec::new();
+        let (items, _) =
+            collect_items_from_crate_dirs(std::slice::from_ref(&dir), &mut |w| warnings.push(w));
+        assert!(warnings.is_empty(), "no skip, no warning: {warnings:?}");
+        assert!(!items.is_empty(), "the file must be harvested");
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/spel-framework-core/src/idl_gen/unlexable.rs
+++ b/spel-framework-core/src/idl_gen/unlexable.rs
@@ -1,0 +1,232 @@
+//! Decides which dependency source files are unsafe to hand to
+//! `syn::parse_file`.
+//!
+//! Inside a proc macro, parsing routes through the compiler's lexer.
+//! Re-lexing a dependency's raw text under the consumer's edition can
+//! queue a fatal "unknown prefix" diagnostic as a side effect, aborting
+//! the consumer's build with an error that exists nowhere in the
+//! consumer's code, even though the parse error itself is caught.
+//! ark-ff 0.3.0 ships the trigger shape.
+//!
+//! The scan is byte-level but context-aware: a match inside a string
+//! literal or comment is ignored, those bytes never reach the lexer as
+//! tokens. The bias rule for everything the scan cannot classify is to
+//! treat it as code. The worst case of a spurious match is a skipped
+//! file, visible through the caller's warning. The worst case of a
+//! missed match is the fatal diagnostic coming back.
+
+// The scanner is a byte walk: every index is guarded by a bounds check
+// in the same expression or the enclosing loop condition, and this
+// code runs at build and CLI time, never in a guest.
+#![allow(clippy::indexing_slicing)]
+
+/// True when the text contains a macro metavariable glued to a string
+/// literal in code position (e.g. ark-ff 0.3.0's `stringify!($Fp"({})")`).
+/// That shape is legal in the defining crate's own pre-2021 edition, but
+/// re-lexed under a 2021+ edition it queues the fatal diagnostic this
+/// module exists to prevent. Files like this cannot carry usable
+/// `#[account_type]` items, so callers skip them instead of parsing.
+pub(crate) fn has_metavar_glued_literal(content: &str) -> bool {
+    let b = content.as_bytes();
+    let n = b.len();
+    let mut i = 0;
+    let mut prev_ident = false;
+    while i < n {
+        let was_ident = b[i].is_ascii_alphabetic() || b[i] == b'_';
+        match b[i] {
+            b'/' if i + 1 < n && b[i + 1] == b'/' => {
+                while i < n && b[i] != b'\n' {
+                    i += 1;
+                }
+            },
+            b'/' if i + 1 < n && b[i + 1] == b'*' => i = skip_block_comment(b, i),
+            b'"' => i = skip_string(b, i),
+            b'r' | b'b' if !prev_ident => match raw_or_byte_literal_end(b, i) {
+                Some(j) => i = j,
+                None => i += 1,
+            },
+            b'\'' => i = skip_char_or_lifetime(b, i),
+            b'$' => {
+                let start = i + 1;
+                let mut j = start;
+                while j < n && (b[j].is_ascii_alphanumeric() || b[j] == b'_') {
+                    j += 1;
+                }
+                if j > start && j < n && b[j] == b'"' && !b[start].is_ascii_digit() {
+                    return true;
+                }
+                i = start;
+            },
+            _ => i += 1,
+        }
+        prev_ident = was_ident;
+    }
+    false
+}
+
+/// Advance past a block comment starting at `/*`. Rust block comments
+/// nest. An unterminated comment runs to the end of the file.
+fn skip_block_comment(b: &[u8], mut i: usize) -> usize {
+    let n = b.len();
+    let mut depth = 1;
+    i += 2;
+    while i < n && depth > 0 {
+        if i + 1 < n && b[i] == b'/' && b[i + 1] == b'*' {
+            depth += 1;
+            i += 2;
+        } else if i + 1 < n && b[i] == b'*' && b[i + 1] == b'/' {
+            depth -= 1;
+            i += 2;
+        } else {
+            i += 1;
+        }
+    }
+    i
+}
+
+/// Advance past an ordinary string literal starting at its opening
+/// quote. A backslash escapes the next byte. Unterminated runs to the
+/// end of the file.
+fn skip_string(b: &[u8], mut i: usize) -> usize {
+    let n = b.len();
+    i += 1;
+    while i < n {
+        match b[i] {
+            b'\\' => i += 2,
+            b'"' => return i + 1,
+            _ => i += 1,
+        }
+    }
+    n
+}
+
+/// Advance past a raw string (`r"..."`, `r#"..."#`), byte string
+/// (`b"..."`), raw byte string (`br#"..."#`) or byte char (`b'...'`)
+/// starting at the `r` or `b`. `None` when the position is not a
+/// literal opener, e.g. a raw identifier like `r#match`.
+fn raw_or_byte_literal_end(b: &[u8], i: usize) -> Option<usize> {
+    let n = b.len();
+    match b[i] {
+        b'r' => raw_string_body(b, i + 1),
+        b'b' if i + 1 < n && b[i + 1] == b'r' => raw_string_body(b, i + 2),
+        b'b' if i + 1 < n && b[i + 1] == b'"' => Some(skip_string(b, i + 1)),
+        b'b' if i + 1 < n && b[i + 1] == b'\'' => Some(skip_char_or_lifetime(b, i + 1)),
+        _ => None,
+    }
+}
+
+/// The end of a raw-string body whose hashes start at `j`. Raw strings
+/// have no escapes: the body closes at a quote followed by the same
+/// number of hashes it opened with. `None` when there is no opening
+/// quote after the hashes.
+fn raw_string_body(b: &[u8], mut j: usize) -> Option<usize> {
+    let n = b.len();
+    let mut hashes = 0;
+    while j < n && b[j] == b'#' {
+        hashes += 1;
+        j += 1;
+    }
+    if j >= n || b[j] != b'"' {
+        return None;
+    }
+    j += 1;
+    while j < n {
+        if b[j] == b'"'
+            && j + 1 + hashes <= n
+            && b[j + 1..j + 1 + hashes].iter().all(|&c| c == b'#')
+        {
+            return Some(j + 1 + hashes);
+        }
+        j += 1;
+    }
+    Some(n)
+}
+
+/// Advance past a char literal, or just past the quote when it is a
+/// lifetime. A multi-byte char literal falls through to the lifetime
+/// case, which is safe: its bytes are then scanned as code.
+///
+/// The escape arm consumes quote, backslash and one escaped byte
+/// unconditionally, then scans plainly for the closing quote. No char
+/// escape contains a quote after its first escaped byte, and symmetric
+/// escape handling would overshoot the terminator of `'\\'`.
+fn skip_char_or_lifetime(b: &[u8], i: usize) -> usize {
+    let n = b.len();
+    if i + 1 < n && b[i + 1] == b'\\' {
+        let mut j = i + 3;
+        while j < n && b[j] != b'\'' {
+            j += 1;
+        }
+        return (j + 1).min(n);
+    }
+    if i + 2 < n && b[i + 2] == b'\'' {
+        return i + 3;
+    }
+    i + 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metavar_glued_literal_is_detected() {
+        // The exact shape from ark-ff-0.3.0 src/fields/macros.rs:615.
+        assert!(has_metavar_glued_literal(
+            r#"write!(f, stringify!($Fp"({})"), self.into_repr())"#
+        ));
+        // A metavariable not glued to a quote is fine.
+        assert!(!has_metavar_glued_literal(
+            "macro_rules! m { ($x:ident) => { $x } }"
+        ));
+        // A bare dollar, a digit after the dollar, and plain code are fine.
+        assert!(!has_metavar_glued_literal("let price = \"$\";"));
+        assert!(!has_metavar_glued_literal("fn account_type_free() {}"));
+    }
+
+    // A dollar-word glued to a quote inside a string literal or comment
+    // is inert: those bytes never reach the lexer as tokens, so the
+    // file must not be skipped over them.
+    #[test]
+    fn matches_inside_strings_and_comments_are_inert() {
+        // Line and doc comments.
+        assert!(!has_metavar_glued_literal(
+            "// pays in \"$HOME\"\nfn f() {}"
+        ));
+        assert!(!has_metavar_glued_literal(
+            "/// Respects \"$PATH\" when resolving.\npub fn g() {}"
+        ));
+        // Nested block comment.
+        assert!(!has_metavar_glued_literal(
+            r#"/* outer /* $X" */ inner */ fn f() {}"#
+        ));
+        // A string ending in a dollar-word.
+        assert!(!has_metavar_glued_literal(r#"let s = "price $USD";"#));
+        // Raw and byte strings.
+        assert!(!has_metavar_glued_literal(r##"let s = r#"$Fp"x"#;"##));
+        assert!(!has_metavar_glued_literal(r#"let v = b"price $USD";"#));
+    }
+
+    // String-lookalike syntax before a real landmine must not swallow
+    // it: each of these once misclassified means the fatal diagnostic
+    // comes back.
+    #[test]
+    fn code_position_matches_survive_string_lookalikes() {
+        // A quote inside a char literal is not a string opener.
+        assert!(has_metavar_glued_literal(
+            r#"let q = '"'; stringify!($Fp"({})")"#
+        ));
+        // '\\' terminates at its own closing quote.
+        assert!(has_metavar_glued_literal(
+            r#"let c = '\\'; stringify!($Fp"x")"#
+        ));
+        // A raw identifier is not a raw string.
+        assert!(has_metavar_glued_literal(
+            r##"fn r#match() {} stringify!($Fp"x")"##
+        ));
+        // A lifetime is not a char literal.
+        assert!(has_metavar_glued_literal(
+            r#"fn f<'a>(x: &'a u8) {} stringify!($Fp"x")"#
+        ));
+    }
+}

--- a/spel-framework-macros/src/lib.rs
+++ b/spel-framework-macros/src/lib.rs
@@ -2110,7 +2110,9 @@ fn expand_generate_idl(file_path: &str, span_token: &syn::LitStr) -> syn::Result
     let resolved_path_buf = std::path::Path::new(&resolved_path).to_path_buf();
     let dep_dirs = spel_framework_core::idl_gen::find_path_dep_dirs(&resolved_path_buf, |_| {});
     let (extra_items, dep_source_files) =
-        spel_framework_core::idl_gen::collect_items_from_crate_dirs(&dep_dirs);
+        spel_framework_core::idl_gen::collect_items_from_crate_dirs(&dep_dirs, |w| {
+            eprintln!("warning: {w}");
+        });
     all_items.extend(extra_items);
 
     let (accounts, types) = account_types::collect_account_types(&all_items);


### PR DESCRIPTION
## Description

`generate_idl!` walks path dependency sources with `syn::parse_file`. Inside a proc macro this routes through rustc's lexer. When a walked file contains a macro metavariable glued to a string literal, like `stringify!($Fp"({})")`, the lexer queues a fatal `prefix is unknown` error as a side effect. The walk catches the parse error and continues, but the build is already failed, with an error that points at the macro invocation and names a token that appears nowhere in the consumer's code. The shape is legal in editions before 2021. ark-ff 0.3.0 ships exactly this line (src/fields/macros.rs, line 615), so a pre-2021 path dependency can break a consumer that did nothing wrong.

Repro on current main: a program file, a `generate_idl!("program.rs")` bin, and an edition 2018 path dependency containing `write!(f, stringify!($Fp"({})"), self.0)` inside a `macro_rules!`. `cargo check` fails with `error: prefix 'Fp' is unknown`
pointing at the `generate_idl!` call. Changing that one line to `write!(f, "{}({})", stringify!($Fp), self.0)` makes the same project compile, so the metavariable to literal adjacency is the exact trigger.

## Changes

- `spel-framework-core/src/idl_gen.rs`: skip source files containing a macro metavariable glued to a string literal before parsing them. Such files cannot carry usable `#[account_type]` items.
- Two regression tests. `landmine_file_contributes_no_items_but_is_tracked` fails without the gate and passes with it.

## Checklist

- [x] Builds cleanly
- [x] Tests pass (`cargo test -p spel-framework-core --features idl-gen`, 112 passed)
- [ ] README updated if new features, CLI commands, or behaviour changed (bug fix only, no surface change)
- [x] New public methods have doc comments (the new helper is private and documented)
- [x] Branch is off `main` (not another feature branch)