### PR TITLE
feat(cli): teach init and CI the scaffold's framework git URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,6 +234,7 @@ jobs:
           LSSA_DIR: /tmp/lssa
           LEZ_TAG: ${{ needs.sequencer-setup.outputs.lez-tag }}
           SPEL_TAG: ${{ steps.spel-ref.outputs.SPEL_REF }}
+          SPEL_GIT: ${{ github.server_url }}/${{ github.repository }}.git
         run: |
           export PATH="/tmp/lssa/target/release:$PATH"
           scripts/smoke-test-privacy.sh /tmp/privacy-smoke
@@ -318,6 +319,7 @@ jobs:
           LSSA_DIR: /tmp/lssa
           LEZ_TAG: ${{ needs.sequencer-setup.outputs.lez-tag }}
           SPEL_TAG: ${{ steps.spel-ref.outputs.SPEL_REF }}
+          SPEL_GIT: ${{ github.server_url }}/${{ github.repository }}.git
         run: |
           export PATH="/tmp/lssa/target/release:$PATH"
           scripts/ffi-call-test.sh /tmp/ffi-call-test
@@ -389,6 +391,7 @@ jobs:
         env:
           LSSA_DIR: /tmp/lssa
           SPEL_TAG: ${{ steps.spel-ref.outputs.SPEL_REF }}
+          SPEL_GIT: ${{ github.server_url }}/${{ github.repository }}.git
         run: |
           export PATH="/tmp/lssa/target/release:$PATH"
           scripts/init-e2e-test.sh /tmp/init-e2e-test

--- a/scripts/ffi-call-test.sh
+++ b/scripts/ffi-call-test.sh
@@ -111,7 +111,11 @@ CLIENT_GEN_BIN="$SPEL_DIR/target/release/spel-client-gen"
 # ─── Step 1: Scaffold project ──────────────────────────────────────────────
 
 log "Step 1: Creating SPEL project (LEZ=${LEZ_TAG})..."
-"$SPEL_BIN" init --lez-tag "$LEZ_TAG" --spel-rev "$SPEL_TAG" "$PROJECT_NAME" 2>&1 | tee "$WORK_DIR/init.log" || { echo ''; echo '=== INIT LOG ==='; cat "$WORK_DIR/init.log"; echo '================='; fail "spel init failed"; }
+SPEL_GIT_ARGS=()
+if [ -n "${SPEL_GIT:-}" ]; then
+    SPEL_GIT_ARGS=(--spel-git "$SPEL_GIT")
+fi
+"$SPEL_BIN" init --lez-tag "$LEZ_TAG" --spel-rev "$SPEL_TAG" "${SPEL_GIT_ARGS[@]}" "$PROJECT_NAME" 2>&1 | tee "$WORK_DIR/init.log" || { echo ''; echo '=== INIT LOG ==='; cat "$WORK_DIR/init.log"; echo '================='; fail "spel init failed"; }
 cd "$PROJECT_NAME"
 
 # Regenerate lockfiles so the patch takes effect

--- a/scripts/init-e2e-test.sh
+++ b/scripts/init-e2e-test.sh
@@ -91,12 +91,16 @@ cd "$WORK_DIR"
 # On PRs, SPEL_TAG is set so the scaffolded project uses the PR's framework code.
 # On main pushes, SPEL_TAG is unset for true default testing.
 
-log "Step 1: spel init (LEZ=defaults${SPEL_TAG:+, SPEL=$SPEL_TAG})..."
+log "Step 1: spel init (LEZ=defaults${SPEL_TAG:+, SPEL=$SPEL_TAG}${SPEL_GIT:+, SPEL_GIT=$SPEL_GIT})..."
+SPEL_GIT_ARGS=()
+if [ -n "${SPEL_GIT:-}" ]; then
+    SPEL_GIT_ARGS=(--spel-git "$SPEL_GIT")
+fi
 if [ -n "${SPEL_TAG:-}" ]; then
-    "$SPEL_BIN" init --spel-rev "$SPEL_TAG" "$PROJECT_NAME" \
+    "$SPEL_BIN" init --spel-rev "$SPEL_TAG" "${SPEL_GIT_ARGS[@]}" "$PROJECT_NAME" \
         > "$WORK_DIR/init.log" 2>&1 || fail "spel init failed (see $WORK_DIR/init.log)"
 else
-    "$SPEL_BIN" init "$PROJECT_NAME" \
+    "$SPEL_BIN" init "${SPEL_GIT_ARGS[@]}" "$PROJECT_NAME" \
         > "$WORK_DIR/init.log" 2>&1 || fail "spel init failed (see $WORK_DIR/init.log)"
 fi
 cd "$PROJECT_NAME"

--- a/scripts/init-e2e-test.sh
+++ b/scripts/init-e2e-test.sh
@@ -89,7 +89,9 @@ cd "$WORK_DIR"
 # ─── Step 1: spel init — default LEZ, optional SPEL override ─────────────
 # Always uses DEFAULT LEZ resolution (no --lez-tag) to test init.rs defaults.
 # On PRs, SPEL_TAG is set so the scaffolded project uses the PR's framework code.
-# On main pushes, SPEL_TAG is unset for true default testing.
+# On main pushes, SPEL_TAG is unset so the default refs are tested.
+# SPEL_GIT is always set in CI (the repo's own URL) so forks test their own
+# code; only local runs without SPEL_GIT exercise the built-in default URL.
 
 log "Step 1: spel init (LEZ=defaults${SPEL_TAG:+, SPEL=$SPEL_TAG}${SPEL_GIT:+, SPEL_GIT=$SPEL_GIT})..."
 SPEL_GIT_ARGS=()

--- a/scripts/smoke-test-privacy.sh
+++ b/scripts/smoke-test-privacy.sh
@@ -147,7 +147,11 @@ log "  Using local spel: $SPEL_BIN"
 # ─── Step 1: Scaffold project ──────────────────────────────────────────────
 
 log "Step 1: Creating SPEL project (LEZ=${LEZ_TAG})..."
-"$SPEL_BIN" init --lez-tag "$LEZ_TAG" --spel-rev "$SPEL_TAG" "$PROJECT_NAME" \
+SPEL_GIT_ARGS=()
+if [ -n "${SPEL_GIT:-}" ]; then
+    SPEL_GIT_ARGS=(--spel-git "$SPEL_GIT")
+fi
+"$SPEL_BIN" init --lez-tag "$LEZ_TAG" --spel-rev "$SPEL_TAG" "${SPEL_GIT_ARGS[@]}" "$PROJECT_NAME" \
     > "$LOG_DIR/init.log" 2>&1 || fail "spel init failed (see $LOG_DIR/init.log)"
 cd "$PROJECT_NAME"
 log "  ✓ Project scaffolded"

--- a/spel-cli/src/init.rs
+++ b/spel-cli/src/init.rs
@@ -9,7 +9,11 @@ pub fn init_project(
     spel_tag: Option<&str>,
     lez_rev: Option<&str>,
     spel_rev: Option<&str>,
+    spel_git: Option<&str>,
 ) {
+    // The git URL the scaffolded project pulls the framework from. CI on a
+    // fork passes the fork's own URL so refs like refs/pull/N/head resolve.
+    let spel_git = spel_git.unwrap_or("https://github.com/logos-co/spel.git");
     let root = Path::new(name);
     if root.exists() {
         eprintln!("❌ Directory '{}' already exists", name);
@@ -122,7 +126,7 @@ nssa_core   = {{ git = "https://github.com/logos-blockchain/logos-execution-zone
 common      = {{ git = "https://github.com/logos-blockchain/logos-execution-zone.git", {lez_ref_ffi} }}
 sequencer_service_rpc = {{ git = "https://github.com/logos-blockchain/logos-execution-zone.git", {lez_ref_ffi}, features = ["client"] }}
 wallet      = {{ git = "https://github.com/logos-blockchain/logos-execution-zone.git", {lez_ref_ffi} }}
-spel-framework-core = {{ git = "https://github.com/logos-co/spel.git", {spel_ref_ffi} }}
+spel-framework-core = {{ git = "{spel_git}", {spel_ref_ffi} }}
 serde_json  = "1"
 serde       = {{ version = "1", features = ["derive"] }}
 borsh       = "1.5"
@@ -712,7 +716,7 @@ name = "{snake_name}"
 path = "src/bin/{snake_name}.rs"
 
 [dependencies]
-spel-framework = {{ git = "https://github.com/logos-co/spel.git", {spel_ref} }}
+spel-framework = {{ git = "{spel_git}", {spel_ref} }}
 nssa_core = {{ git = "https://github.com/logos-blockchain/logos-execution-zone.git", {lez_ref}, package = "lee_core" }}
 risc0-zkvm = {{ version = "=3.0.5", features = ["std"] }}
 {snake_name}_core = {{ path = "../../{snake_name}_core" }}
@@ -803,9 +807,9 @@ name = "{snake_name}_cli"
 path = "src/bin/{snake_name}_cli.rs"
 
 [dependencies]
-spel-framework = {{ git = "https://github.com/logos-co/spel.git", {spel_ref} }}
+spel-framework = {{ git = "{spel_git}", {spel_ref} }}
 nssa_core = {{ git = "https://github.com/logos-blockchain/logos-execution-zone.git", {lez_ref}, package = "lee_core" }}
-spel = {{ git = "https://github.com/logos-co/spel.git", {spel_ref} }}
+spel = {{ git = "{spel_git}", {spel_ref} }}
 {snake_name}_core = {{ path = "../{snake_name}_core" }}
 serde_json = "1.0"
 tokio = {{ version = "1.28.2", features = ["net", "rt-multi-thread", "sync", "macros"] }}

--- a/spel-cli/src/lib.rs
+++ b/spel-cli/src/lib.rs
@@ -212,6 +212,9 @@ pub async fn run() {
                     println!("  --spel-rev <REV>    SPEL revision (default: refs/pull/122/head)");
                     println!("  --lez-rev <REV>     LEZ revision (alternative to --lez-tag)");
                     println!("  --spel-tag <TAG>    SPEL tag (alternative to --spel-rev)");
+                    println!(
+                        "  --spel-git <URL>    SPEL git URL (default: https://github.com/logos-co/spel.git)"
+                    );
                     println!();
                     println!("Examples:");
                     println!("  spel init my-project");
@@ -224,6 +227,7 @@ pub async fn run() {
                 let mut spel_tag: Option<String> = None;
                 let mut lez_rev: Option<String> = None;
                 let mut spel_rev: Option<String> = None;
+                let mut spel_git: Option<String> = None;
                 let mut name_arg_idx = 2;
 
                 while name_arg_idx < remaining_args.len() {
@@ -248,6 +252,11 @@ pub async fn run() {
                         if name_arg_idx < remaining_args.len() {
                             spel_rev = Some(remaining_args[name_arg_idx].clone());
                         }
+                    } else if arg == "--spel-git" {
+                        name_arg_idx += 1;
+                        if name_arg_idx < remaining_args.len() {
+                            spel_git = Some(remaining_args[name_arg_idx].clone());
+                        }
                     } else {
                         break;
                     }
@@ -255,7 +264,7 @@ pub async fn run() {
                 }
 
                 let name = remaining_args.get(name_arg_idx).unwrap_or_else(|| {
-                    eprintln!("Usage: {} init <project-name> [--lez-tag <tag>] [--spel-tag <tag>] [--lez-rev <rev>] [--spel-rev <rev>]", args[0]);
+                    eprintln!("Usage: {} init <project-name> [--lez-tag <tag>] [--spel-tag <tag>] [--lez-rev <rev>] [--spel-rev <rev>] [--spel-git <url>]", args[0]);
                     process::exit(1);
                 });
                 init_project(
@@ -264,6 +273,7 @@ pub async fn run() {
                     spel_tag.as_deref(),
                     lez_rev.as_deref(),
                     spel_rev.as_deref(),
+                    spel_git.as_deref(),
                 );
                 return;
             },

--- a/spel-cli/src/lib.rs
+++ b/spel-cli/src/lib.rs
@@ -203,7 +203,7 @@ pub async fn run() {
                 if remaining_args.get(2) == Some(&"-h".to_string())
                     || remaining_args.get(2) == Some(&"--help".to_string())
                 {
-                    println!("Usage: spel init <project-name> [OPTIONS]");
+                    println!("Usage: spel init [OPTIONS] <project-name>");
                     println!();
                     println!("Create a new SPEL project");
                     println!();
@@ -219,7 +219,7 @@ pub async fn run() {
                     println!("Examples:");
                     println!("  spel init my-project");
                     println!(
-                        "  spel init my-project --lez-tag v0.1.2 --spel-rev refs/pull/122/head"
+                        "  spel init --lez-tag v0.1.2 --spel-rev refs/pull/122/head my-project"
                     );
                     return;
                 }
@@ -264,7 +264,7 @@ pub async fn run() {
                 }
 
                 let name = remaining_args.get(name_arg_idx).unwrap_or_else(|| {
-                    eprintln!("Usage: {} init <project-name> [--lez-tag <tag>] [--spel-tag <tag>] [--lez-rev <rev>] [--spel-rev <rev>] [--spel-git <url>]", args[0]);
+                    eprintln!("Usage: {} init [--lez-tag <tag>] [--spel-tag <tag>] [--lez-rev <rev>] [--spel-rev <rev>] [--spel-git <url>] <project-name>", args[0]);
                     process::exit(1);
                 });
                 init_project(


### PR DESCRIPTION
## Description

The three scaffold-based CI jobs (FFI Call Test, Init E2E, Privacy Smoke) fail on any fork: the scaffolded project hardcodes `https://github.com/logos-co/spel.git` while the workflow asks it to build `refs/pull/N/head`, a ref that only exists in the repo the run lives in. Failure: `revspec 'refs/pull/N/head' not found`.

This makes the scaffold's framework URL follow the repository running CI. On logos-co/spel the new expression resolves to exactly the current URL, so upstream CI behavior is unchanged.

## Changes

- `spel-cli/src/init.rs`: `init_project` takes an optional spel git URL, defaulting to the current hardcoded one; the three generated dependency sites interpolate it
- `spel-cli/src/lib.rs`: new `--spel-git <URL>` flag on `spel init`, help text updated
- `scripts/init-e2e-test.sh`, `scripts/ffi-call-test.sh`, `scripts/smoke-test-privacy.sh`: pass `--spel-git "$SPEL_GIT"` when the env var is set
- `.github/workflows/ci.yml`: the three jobs export `SPEL_GIT: ${{ github.server_url }}/${{ github.repository }}.git`

Green run of all five jobs on a fork: https://github.com/mmlado/spel/actions/runs/30816986387

## Checklist
- [x] Builds cleanly (`cargo build`; note `cargo clippy --all-targets` fails on current main independent of this PR, fix in #254)
- [x] Tests pass (`cargo test --workspace`, 264 passed, 0 failed)
- [x] README updated if new features, CLI commands, or behaviour changed (init help text documents the new flag; no behavior change with the flag unset)
- [x] New public methods have doc comments (none added, one parameter extended)
- [x] Branch is off `main` (not another feature branch)